### PR TITLE
feat: add port mappings to worker profiles

### DIFF
--- a/docs/architecture/container-lifecycle.md
+++ b/docs/architecture/container-lifecycle.md
@@ -46,6 +46,7 @@ When the first message arrives in a worker channel:
    - Bind mount: `data/sessions/{folder}/` → session state dirs
    - Env vars: `ANTHROPIC_BASE_URL` pointing to the correct proxy (`:3001` for Anthropic, `:3003/w/{folder}/` for Neuralwatt)
    - `NANOCLAW_MODEL`, `NANOCLAW_IS_MAIN=0`, `DISCORD_GUILD_ID`, etc.
+   - Port mappings from worker profile (`-p` flags), if configured
 3. **init.sh runs** from the worker profile. This clones repos (skipping already-cloned), installs tools, symlinks skills. Runs every time a container spawns.
 4. **Agent runner starts** with the Claude Agent SDK. If a session ID exists in SQLite, it resumes that session.
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -299,6 +299,7 @@ function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   groupFolder?: string,
+  ports?: string[],
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
@@ -307,6 +308,17 @@ function buildContainerArgs(
   // Without the fallback, pypi.org/github.com/etc. fail.
   if (fs.existsSync('/var/run/tailscale/tailscaled.sock')) {
     args.push('--dns', '100.100.100.100', '--dns', '1.1.1.1');
+  }
+
+  // Port mappings from worker profile (e.g., ["8080:8080", "8090:8090/tcp"])
+  if (ports?.length) {
+    for (const port of ports) {
+      if (/^\d+:\d+(\/\w+)?$/.test(port)) {
+        args.push('-p', port);
+      } else {
+        logger.warn({ port }, 'Ignoring invalid port mapping');
+      }
+    }
   }
 
   // Pass host timezone so container's local time matches the user's
@@ -455,7 +467,12 @@ export async function runContainerAgent(
   const mounts = buildVolumeMounts(group, input.isMain);
   const safeName = sanitizeFolderName(group.folder);
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
-  const containerArgs = buildContainerArgs(mounts, containerName, group.folder);
+  const containerArgs = buildContainerArgs(
+    mounts,
+    containerName,
+    group.folder,
+    group.containerConfig?.ports,
+  );
 
   logger.debug(
     {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -810,6 +810,7 @@ export async function processTaskIpc(
             added_at: new Date().toISOString(),
             containerConfig: {
               additionalMounts: profile.mounts || [],
+              ports: profile.ports || [],
               disableIdleTimeout: true, // Workers stay alive until explicitly destroyed
             },
             requiresTrigger: false, // Workers have dedicated channels — no trigger needed

--- a/src/profile-sync.ts
+++ b/src/profile-sync.ts
@@ -21,6 +21,7 @@ export interface WorkerProfile {
     containerPath: string;
     readonly: boolean;
   }[];
+  ports?: string[]; // Docker port mappings (e.g., ["8080:8080", "8090:8090/tcp"])
   claude_md?: string;
   skills_repo?: string;
 }
@@ -70,10 +71,11 @@ export function syncWorkerProfiles(): number {
   for (const [jid, group] of Object.entries(groups)) {
     if (group.isMain) continue;
 
-    // Update container_config with current profile mounts
+    // Update container_config with current profile mounts and ports
     const newConfig = {
       ...group.containerConfig,
       additionalMounts: profile.mounts || [],
+      ports: profile.ports || [],
       disableIdleTimeout: true,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface AllowedRoot {
 
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
+  ports?: string[]; // Docker port mappings (e.g., ["8080:8080", "8090:8090/tcp"])
   timeout?: number; // Default: 300000 (5 minutes)
   disableIdleTimeout?: boolean; // If true, worker stays alive until explicitly destroyed
 }


### PR DESCRIPTION
## Summary
- Workers can now expose ports to the host via an optional `ports` array in the worker profile JSON
- Format matches Docker's `-p` syntax: `["8080:8080", "8090:8090/tcp"]`
- Ports are validated (must match `hostPort:containerPort[/protocol]`) and invalid entries are logged and skipped
- Profile sync propagates port changes to existing workers (take effect on next container spawn)

**Motivation:** Workers running dev servers (e.g., a portal on :8090) need those services reachable from the host's Tailscale network.

## Files changed
- `src/types.ts` — Added `ports?: string[]` to `ContainerConfig`
- `src/profile-sync.ts` — Added `ports` to `WorkerProfile` interface + sync logic
- `src/container-runner.ts` — `buildContainerArgs()` reads ports and adds `-p` flags
- `src/ipc.ts` — `create_worker` passes ports from profile to containerConfig
- `docs/architecture/container-lifecycle.md` — Documented port mappings in container startup

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npm test` — all 304 tests pass
- [ ] Add `"ports": ["8090:8090"]` to worker profile, create a worker, run `python3 -m http.server 8090` inside, verify reachable from host at `localhost:8090`

🤖 Generated with [Claude Code](https://claude.com/claude-code)