### PR TITLE
fix: stub model access check in shim for SDK v2.1+

### DIFF
--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -408,6 +408,12 @@ const server = Bun.serve({
     // Log ALL requests for debugging
     console.log(`[proxy:req] ${request.method} ${url.pathname}`);
 
+    // Claude Code SDK v2.1+ checks model access before starting a session.
+    // Return has_access: true so NW workers don't get rejected.
+    if (url.pathname === '/api/check_model_access') {
+      return Response.json({ has_access: true });
+    }
+
     // Stub out SDK init endpoints that try to reach CLAUDE_CODE_API_BASE_URL.
     // For NW workers, this points to the shim. Return empty 200s so the SDK's
     // oauth/profile, fast-mode, usage checks don't crash with 401/404.


### PR DESCRIPTION
## Summary
- Claude Code SDK v2.1.91 added a `POST /api/check_model_access` call before starting sessions
- The shim's catch-all `/api/*` returned `{}`, which the SDK interpreted as "no access"
- This caused all Neuralwatt workers to fail with "There's an issue with the selected model (claude-opus-4-6)"
- Fix: return `{ has_access: true }` for this specific endpoint before the catch-all

## Test plan
- [x] Confirmed the error message in shim logs and SDK source
- [ ] Restart shim, message a Neuralwatt worker, verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)