### PR TITLE
docs: add Using Workers section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ The master resolves fuzzy model names automatically — "kimi fast", "qwen coder
 
 ### Switching Models
 
-For Neuralwatt workers, you can switch models live without losing your workspace or conversation:
+**Within Neuralwatt** — model switches are instant, no restart needed. The translation shim re-reads the model config on every request:
 
 ```
 switch my-task to qwen 3.5
 ```
 
-Switching between Anthropic and Neuralwatt requires recreating the worker. The master handles this with `transfer_worker` — your workspace and chat history are preserved:
+**Between Anthropic and Neuralwatt** — requires a container restart because `ANTHROPIC_BASE_URL` is set at container start (Anthropic workers talk to the credential proxy on :3001, Neuralwatt workers talk to the translation shim on :3003). Use `transfer_worker`, which destroys the old container and creates a new one — workspace and chat history are preserved:
 
 ```
 transfer my-task to neuralwatt kimi k2.5


### PR DESCRIPTION
## Summary

- Adds a new **Using Workers** section to the README with practical examples for:
  - Creating workers (default Anthropic vs Neuralwatt with fuzzy model names)
  - Switching models live and transferring between backends
  - Viewing energy & usage data via `/status`, on destruction, and direct curl
  - Listing and destroying workers
- Condenses the existing Inference Backends and Energy Tracking sections to focus on technical details (the user-facing guidance is now in Using Workers)

## Context

Feedback from Scott (scottcha) trying the setup — he got workers running but wasn't clear on how to use Neuralwatt backends or see energy data. This addresses those friction points with concrete examples.

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Confirm example `/status` output matches actual format from `nc-status.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)