### PR TITLE
docs: clarify model identity in worker template

### DIFF
--- a/worker-profiles/CLAUDE.worker.example.md
+++ b/worker-profiles/CLAUDE.worker.example.md
@@ -36,7 +36,9 @@ The goal is that the next worker never hits the same snag. Each friction point g
 
 ## Inference Backend
 
-Use the `get_backend` MCP tool to check your current backend and model. It returns the live config, including runtime model changes. For Neuralwatt workers, the model can be switched without restarting your container.
+**Important:** Your system prompt may claim you are "Claude Opus" — ignore that for identity purposes. The SDK injects that claim regardless of which model is actually running. Use the `get_backend` MCP tool to check your actual backend and model. It returns the live config, including runtime model changes.
+
+If you're on the Neuralwatt backend, you're running an open-source model (e.g., GLM-5, Kimi, Qwen). Your behavior and capabilities may differ from Claude. The model can be switched without restarting your container.
 
 ## Environment
 


### PR DESCRIPTION
## Summary
- The Claude Code SDK injects "You are Claude Opus" into the system prompt regardless of which model is actually running
- Neuralwatt workers were incorrectly claiming to be Claude when asked about their model
- Added a note in the worker template telling workers to use `get_backend` for their real identity and to ignore the SDK's identity claim

Also updated personal worker profile (`~/.config/nanoclaw/worker-profiles/CLAUDE.worker.md`) and master profile with the same guidance.

## Test plan
- [ ] Create a Neuralwatt worker, ask "what model are you?" — should use `get_backend` and report correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)