### PR TITLE
Unified shim routing for live backend switching

### DIFF
--- a/docs/architecture/inference-routing.md
+++ b/docs/architecture/inference-routing.md
@@ -11,58 +11,77 @@ How API traffic flows from worker containers to inference backends.
                                            │
                                 ┌──────────┴───────────┐
                                 │  Credential Proxy     │
-                                │  :3001 (OAuth inject) │
+                                │  :3001 (auth inject)  │
                                 └──────────┬───────────┘
                                            │
-         ┌─────────────────────────────────┼─────────────────────────────────┐
-         │                                 │                                 │
-┌────────┴─────────┐  ┌───────────────────┴──────────┐  ┌────────────────────┴───────┐
-│  Anthropic Worker │  │  Anthropic Worker            │  │  Neuralwatt Worker         │
-│  ANTHROPIC_BASE_  │  │  ANTHROPIC_BASE_URL=         │  │  ANTHROPIC_BASE_URL=       │
-│  URL=:3001        │  │  :3001                       │  │  :3003/w/discord_foo       │
-│  (OAuth)          │  │  (OAuth)                     │  │  (API key placeholder)     │
-└──────────────────┘  └──────────────────────────────┘  └────────────┬───────────────┘
-                                                                     │
-                                                          ┌──────────┴───────────┐
-                                                          │  Translation Shim    │
-                                                          │  :3003               │
-                                                          │  Anthropic → OpenAI  │
-                                                          │  reads config/req    │
-                                                          └──────────┬───────────┘
-                                                                     │
-                                                          ┌──────────┴───────────┐
-                                                          │  api.neuralwatt.com  │
-                                                          │  (OpenAI format)     │
-                                                          └──────────────────────┘
+                          ┌────────────────┴────────────────┐
+                          │                                 │
+               ┌──────────┴───────────┐          ┌─────────┴──────────┐
+               │  Universal Shim      │          │  api.neuralwatt.com │
+               │  :3003               │──────────│  (OpenAI format)    │
+               │  per-request routing  │          └────────────────────┘
+               └──────────┬───────────┘
+                          │
+         ┌────────────────┼────────────────┐
+         │                │                │
+┌────────┴─────────┐ ┌───┴──────────┐ ┌───┴──────────────┐
+│  Worker A        │ │  Worker B    │ │  Worker C        │
+│  (Anthropic)     │ │  (Anthropic) │ │  (Neuralwatt)    │
+│  BASE_URL=:3003  │ │  BASE_URL=   │ │  BASE_URL=:3003  │
+│  /w/discord_a    │ │  :3003/w/b   │ │  /w/discord_c    │
+└──────────────────┘ └──────────────┘ └──────────────────┘
 ```
+
+**All workers route through the shim (:3003).** The shim reads `worker-backends.json`
+per-request to decide whether to forward to Anthropic (via credential proxy) or
+Neuralwatt (with Anthropic→OpenAI translation). This enables live backend switching
+without restarting containers.
 
 ## Request Flow: Anthropic Worker
 
 ```
-1. Agent SDK sends POST /v1/messages
-   Headers: Authorization: Bearer <temp-api-key>
+1. Agent SDK sends POST /w/discord_foo/v1/messages
+   Headers: x-api-key: sk-ant-worker-discord_foo000...
    Body: { model: "claude-opus-4-6", messages: [...] }
 
-2. Credential proxy (:3001)
-   - First request: SDK sends OAuth exchange to /api/oauth/claude_cli/create_api_key
-     Proxy replaces "Bearer placeholder" with real OAuth token
-     Anthropic returns a temporary API key
-   - Subsequent requests: SDK sends x-api-key: <temp-key>
-     Proxy passes through (temp key is already valid)
+2. Shim (:3003)
+   - Extracts worker folder from URL path: "discord_foo"
+   - Reads worker-backends.json → no entry (default: anthropic)
+   - Forwards request to credential proxy (:3001)
 
-3. api.anthropic.com responds with Anthropic Messages format
+3. Credential proxy (:3001)
+   - Replaces placeholder API key / OAuth token with real credentials
+   - Forwards to api.anthropic.com
+
+4. api.anthropic.com responds with Anthropic Messages format
+   (passed through shim and credential proxy unchanged)
+```
+
+## Request Flow: Anthropic Worker (SDK Init)
+
+```
+1. SDK sends GET /v1/organizations or POST /api/oauth/claude_cli/create_api_key
+   Headers: x-api-key: sk-ant-worker-discord_foo000...
+   (These go to CLAUDE_CODE_API_BASE_URL, which also points to the shim)
+
+2. Shim (:3003)
+   - Extracts worker folder from API key: "discord_foo"
+   - Reads worker-backends.json → anthropic
+   - Forwards to credential proxy (which injects real auth)
+
+3. Credential proxy → api.anthropic.com → real response back to SDK
 ```
 
 ## Request Flow: Neuralwatt Worker
 
 ```
-1. Agent SDK sends POST /w/discord_foo/v1/messages
-   Headers: x-api-key: placeholder
+1. Agent SDK sends POST /w/discord_bar/v1/messages
+   Headers: x-api-key: sk-ant-worker-discord_bar000...
    Body: { model: "claude-opus-4-6", messages: [...], tools: [...] }
 
 2. Shim (:3003)
-   - Extracts worker folder from URL path: "discord_foo"
-   - Reads data/worker-backends.json → { backend: "neuralwatt", model: "moonshotai/Kimi-K2.5" }
+   - Extracts worker folder from URL path: "discord_bar"
+   - Reads worker-backends.json → { backend: "neuralwatt", model: "moonshotai/Kimi-K2.5" }
    - Translates request:
      * system blocks → system message
      * tool_use/tool_result blocks → OpenAI function call format
@@ -79,36 +98,73 @@ How API traffic flows from worker containers to inference backends.
    * Returns Anthropic Messages format to the SDK
 ```
 
+## Request Flow: Neuralwatt Worker (SDK Init)
+
+```
+1. SDK sends GET /v1/organizations or POST /api/check_model_access
+   Headers: x-api-key: sk-ant-worker-discord_bar000...
+
+2. Shim (:3003)
+   - Extracts worker folder from API key: "discord_bar"
+   - Reads worker-backends.json → neuralwatt
+   - Returns stubbed empty response (fake credentials can't auth with Anthropic)
+```
+
+## Live Backend Switching
+
+Backends can be switched at runtime via `switch_backend` (IPC command from master).
+This updates `data/worker-backends.json`, which the shim re-reads on every request
+(mtime-cached). The change takes effect on the worker's next API call — no container
+restart needed.
+
+```
+# Before: worker is on Neuralwatt
+data/worker-backends.json:
+  { "discord_foo": { "backend": "neuralwatt", "model": "moonshotai/Kimi-K2.5" } }
+
+# Master runs switch_backend → updates file
+data/worker-backends.json:
+  {}  (no entry = default anthropic)
+
+# Next request from worker goes through Anthropic automatically
+```
+
+## Worker Identification
+
+Workers are identified by two mechanisms:
+
+1. **URL path prefix**: `/w/{folder}/v1/messages` — used for API requests
+2. **API key encoding**: `sk-ant-worker-{folder}000...` — used for init requests
+   that don't include the `/w/` prefix (e.g., OAuth exchange, model access checks)
+
+The per-worker API key is generated by `container-runner.ts` using the
+`WORKER_API_KEY_PREFIX` constant. The shim extracts the folder by stripping
+the prefix and trailing zero-padding.
+
 ## Configuration
 
-**Per-worker backend** is set at container creation time in `worker.env`:
-```
-NANOCLAW_BACKEND=neuralwatt   # or absent for anthropic
-```
-
-`container-runner.ts` reads this and sets `ANTHROPIC_BASE_URL` accordingly. The backend cannot be changed without restarting the container.
-
-**Per-worker model** (Neuralwatt only) can be changed at runtime via `data/worker-backends.json`:
+**Per-worker backend and model** are managed in `data/worker-backends.json`:
 ```json
 {
   "discord_foo": { "backend": "neuralwatt", "model": "moonshotai/Kimi-K2.5" }
 }
 ```
 
-The shim re-reads this file on each request (cached with mtime check). Model changes take effect immediately.
+Workers not listed default to Anthropic. The shim re-reads this file on each
+request (cached with mtime check). Both backend and model changes take effect
+immediately.
 
 ## Key Files
 
 | File | Role |
 |-|-|
+| `tools/anthropic-shim.ts` | Universal proxy — routing, translation, init stubs |
 | `src/credential-proxy.ts` | OAuth/API key injection for Anthropic |
-| `tools/anthropic-shim.ts` | Anthropic→OpenAI translation + routing |
-| `src/container-runner.ts` | Sets ANTHROPIC_BASE_URL per container |
-| `data/worker-backends.json` | Runtime model config (shim reads per-request) |
+| `src/container-runner.ts` | Sets ANTHROPIC_BASE_URL to shim for all containers |
+| `data/worker-backends.json` | Runtime backend+model config (shim reads per-request) |
 
 ## Limitations
 
-- Backend (Anthropic vs Neuralwatt) is fixed per container lifetime
 - Streaming is supported but tool call streaming can be complex (partial JSON accumulation)
 - Tool call translation covers common cases but complex schemas may hit edge cases
 - Open-source models vary in tool calling quality

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -11,12 +11,13 @@ vi.mock('./config.js', () => ({
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min
-  CREDENTIAL_PROXY_PORT: 3001,
   DATA_DIR: '/tmp/nanoclaw-test-data',
   GITHUB_TOKEN_PATH: null,
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  NEURALWATT_PROXY_PORT: 3003,
   TIMEZONE: 'America/Los_Angeles',
+  WORKER_API_KEY_PREFIX: 'sk-ant-worker-',
 }));
 
 // Mock logger

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -10,8 +10,6 @@ import {
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
-  BACKEND_NEURALWATT,
-  CREDENTIAL_PROXY_PORT,
   DATA_DIR,
   GITHUB_TOKEN_PATH,
   GROUPS_DIR,
@@ -30,7 +28,6 @@ import {
   sanitizeFolderName,
   stopContainer,
 } from './container-runtime.js';
-import { detectAuthMode } from './credential-proxy.js';
 import { readEnvFile } from './env.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
@@ -355,8 +352,8 @@ function buildContainerArgs(
     args.push('-e', `DISCORD_GUILD_ID=${DISCORD_GUILD_ID}`);
   }
 
-  // Pass worker profile env vars and detect backend setting (single read).
-  let useNeuralwatt = false;
+  // Pass worker profile env vars (backend detection is no longer needed here —
+  // all workers route through the shim which reads worker-backends.json per-request).
   if (groupFolder) {
     const workerEnvPath = path.join(
       DATA_DIR,
@@ -369,51 +366,46 @@ function buildContainerArgs(
       for (const line of envContent.split('\n')) {
         if (line.trim() && !line.startsWith('#')) {
           args.push('-e', line);
-          if (
-            line.startsWith('NANOCLAW_BACKEND=') &&
-            line.includes(BACKEND_NEURALWATT)
-          ) {
-            useNeuralwatt = true;
-          }
         }
       }
     }
   }
 
-  // Route based on backend: Anthropic workers go directly to credential proxy,
-  // Neuralwatt workers go through the translation shim.
-  if (useNeuralwatt) {
-    const workerPath = groupFolder ? `/w/${groupFolder}` : '';
-    args.push(
-      '-e',
-      `ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${NEURALWATT_PROXY_PORT}${workerPath}`,
-    );
-    // Fake API key with valid format — the SDK validates key format locally.
-    // "placeholder" gets rejected; this passes format checks.
-    // The shim handles real auth for Neuralwatt.
-    args.push(
-      '-e',
-      'ANTHROPIC_API_KEY=sk-ant-api03-neuralwatt-shim-placeholder-000000000000000000000000000000000000000000000000-000000000000',
-    );
-    // Redirect SDK init checks (oauth/profile, usage, etc.) to the shim
-    // instead of api.anthropic.com. Without this, the SDK tries to validate
-    // the fake API key against Anthropic's real API and crashes with 401.
-    args.push(
-      '-e',
-      `CLAUDE_CODE_API_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${NEURALWATT_PROXY_PORT}`,
-    );
-  } else {
-    args.push(
-      '-e',
-      `ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}`,
-    );
-    const authMode = detectAuthMode();
-    if (authMode === 'api-key') {
-      args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
-    } else {
-      args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
-    }
-  }
+  // Unified routing: ALL workers go through the shim (port 3003).
+  //
+  // Previously, Anthropic workers went directly to the credential proxy (:3001)
+  // and Neuralwatt workers went to the shim (:3003). This meant switching
+  // backends required a container restart because ANTHROPIC_BASE_URL was baked
+  // into the container's env at spawn time.
+  //
+  // Now the shim handles both backends and reads worker-backends.json per-request
+  // (mtime-cached). switch_backend updates that file, so changes take effect
+  // immediately on the next API call — no container restart needed.
+  //
+  // For Anthropic workers, the shim forwards to the credential proxy which
+  // injects real credentials. For Neuralwatt workers, the shim translates
+  // Anthropic→OpenAI format and forwards to the Neuralwatt API.
+  const workerPath = groupFolder ? `/w/${groupFolder}` : '';
+  args.push(
+    '-e',
+    `ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${NEURALWATT_PROXY_PORT}${workerPath}`,
+  );
+  // Per-worker API key encodes the worker folder so the shim can identify
+  // the worker on init requests (which don't use the /w/ URL prefix).
+  // The SDK validates key format locally — this passes format checks.
+  // Real auth is handled downstream (credential proxy for Anthropic,
+  // Neuralwatt API key for open-source models).
+  const workerKey = groupFolder
+    ? `${WORKER_API_KEY_PREFIX}${groupFolder}`.padEnd(60, '0')
+    : 'sk-ant-api03-placeholder-000000000000000000000000000000';
+  args.push('-e', `ANTHROPIC_API_KEY=${workerKey}`);
+  // Redirect SDK init checks (oauth/profile, usage, model access) to the shim.
+  // The shim stubs these for Neuralwatt workers and forwards to the credential
+  // proxy for Anthropic workers.
+  args.push(
+    '-e',
+    `CLAUDE_CODE_API_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${NEURALWATT_PROXY_PORT}`,
+  );
 
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -201,6 +201,24 @@ function getWorkerConfig(workerFolder: string): WorkerBackendConfig {
   return config[workerFolder] || { backend: 'anthropic' };
 }
 
+// ── Worker identification ────────────────────────────────────────
+// Extract worker folder from the API key or Authorization header.
+// Container-runner gives each worker a key like "sk-ant-worker-discord_foo000...".
+// This lets the shim identify the worker on init requests (which don't use
+// the /w/{folder} URL prefix).
+
+function extractWorkerFolder(request: Request): string {
+  const apiKey =
+    request.headers.get('x-api-key') ||
+    request.headers.get('authorization')?.replace('Bearer ', '') ||
+    '';
+  if (apiKey.startsWith(WORKER_API_KEY_PREFIX)) {
+    // Strip prefix and trailing zero-padding
+    return apiKey.slice(WORKER_API_KEY_PREFIX.length).replace(/0+$/, '');
+  }
+  return '';
+}
+
 // ── Model mapping (Neuralwatt) ─────────────────────────────────
 
 const NEURALWATT_MODEL_MAP: Record<string, string> = {
@@ -408,26 +426,9 @@ const server = Bun.serve({
     // Log ALL requests for debugging
     console.log(`[proxy:req] ${request.method} ${url.pathname}`);
 
-    // Claude Code SDK v2.1+ checks model access before starting a session.
-    // Return has_access: true so NW workers don't get rejected.
-    if (url.pathname === '/api/check_model_access') {
-      return Response.json({ has_access: true });
-    }
-
-    // Stub out SDK init endpoints that try to reach CLAUDE_CODE_API_BASE_URL.
-    // For NW workers, this points to the shim. Return empty 200s so the SDK's
-    // oauth/profile, fast-mode, usage checks don't crash with 401/404.
-    // Only /v1/messages (via /w/<folder>/) needs real handling.
-    if (
-      url.pathname.startsWith('/api/') ||
-      url.pathname.startsWith('/v1/organizations') ||
-      url.pathname.startsWith('/v1/sessions') ||
-      (request.method === 'GET' && !url.pathname.startsWith('/w/') && !url.pathname.startsWith('/usage') && !url.pathname.startsWith('/health') && !url.pathname.startsWith('/models'))
-    ) {
-      return Response.json({});
-    }
-
-    // Health + usage + config endpoints
+    // ── Fast paths (health, usage, config) ──────────────────────
+    // Handle these before the init endpoint check to avoid unnecessary
+    // header parsing and config lookups on frequent monitoring requests.
     if (url.pathname === '/health') {
       return Response.json({ status: 'ok' });
     }
@@ -440,6 +441,49 @@ const server = Bun.serve({
     if (url.pathname.startsWith('/usage/')) {
       const folder = url.pathname.slice('/usage/'.length);
       return Response.json(workerUsage[folder] || { error: 'no data' });
+    }
+
+    // ── SDK init endpoints ──────────────────────────────────────
+    // CLAUDE_CODE_API_BASE_URL points here for ALL workers (both Anthropic
+    // and Neuralwatt). The SDK hits these endpoints during startup for
+    // OAuth exchange, model access checks, profile/usage queries, etc.
+    //
+    // - Neuralwatt workers use fake credentials → stub with empty 200s
+    // - Anthropic workers need real API responses → forward to credential
+    //   proxy which injects real auth and proxies to api.anthropic.com
+    //
+    // Worker identification: the API key encodes the worker folder as
+    // "sk-ant-worker-{folder}000...". Extract it from the x-api-key or
+    // Authorization header to look up the worker's backend config.
+    const isInitEndpoint =
+      url.pathname.startsWith('/api/') ||
+      url.pathname.startsWith('/v1/organizations') ||
+      url.pathname.startsWith('/v1/sessions') ||
+      (request.method === 'GET' &&
+        !url.pathname.startsWith('/w/') &&
+        !url.pathname.startsWith('/models'));
+
+    if (isInitEndpoint) {
+      const workerFolder = extractWorkerFolder(request);
+      const config = workerFolder
+        ? getWorkerConfig(workerFolder)
+        : { backend: 'anthropic' as const };
+
+      if (config.backend === BACKEND_NEURALWATT) {
+        // Neuralwatt: stub init endpoints. Fake credentials can't authenticate
+        // against Anthropic's API, so return minimal valid responses.
+        if (url.pathname === '/api/check_model_access') {
+          return Response.json({ has_access: true });
+        }
+        return Response.json({});
+      } else {
+        // Anthropic: forward to credential proxy for real API responses.
+        // The proxy injects real OAuth/API-key credentials before forwarding
+        // to api.anthropic.com. This enables OAuth token exchange, model
+        // access checks, and other init flows that require real auth.
+        const bodyBuffer = Buffer.from(await request.arrayBuffer());
+        return forwardToAnthropic(request, bodyBuffer);
+      }
     }
     // Resolve a fuzzy model name to the best matching model ID
     if (url.pathname.startsWith('/models/resolve/')) {


### PR DESCRIPTION
## Summary

- Route ALL workers through the shim (:3003) instead of splitting Anthropic→credential proxy and Neuralwatt→shim
- Shim reads `worker-backends.json` per-request to decide routing (Anthropic via credential proxy, or Neuralwatt with format translation)
- Per-worker API keys (`sk-ant-worker-{folder}`) let the shim identify workers on init requests that don't use the `/w/` URL prefix
- `switch_backend` changes now take effect on the **next API call** — no container restart needed

## Motivation

Previously, `ANTHROPIC_BASE_URL` was baked into each container's env at spawn time (`:3001` for Anthropic, `:3003` for Neuralwatt). Switching backends via `switch_backend` only updated the host-side config file, but the container still pointed at the old endpoint. This caused 401 errors when switching from Neuralwatt to Anthropic because the container was still hitting the shim without going through the credential proxy.

## Test plan

- [x] All 304 tests pass (`npm test`)
- [ ] Create a worker on Anthropic, verify it works
- [ ] Switch it to Neuralwatt via `switch_backend`, verify next request uses NW
- [ ] Switch back to Anthropic, verify it works without container restart
- [ ] Create a worker directly on Neuralwatt, verify init stubs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)