### PR TITLE
feat: postClone commands for worker profile repos

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -780,6 +780,12 @@ export async function processTaskIpc(
           const workerEnv: Record<string, string> = {};
           if (profile.repos?.length) {
             workerEnv.WORKER_REPOS = profile.repos.map((r) => r.url).join('|');
+            const postClones = profile.repos
+              .filter((r) => r.postClone)
+              .map((r) => `${path.basename(r.url, '.git')}:${r.postClone}`);
+            if (postClones.length > 0) {
+              workerEnv.WORKER_REPO_POST_CLONE = postClones.join('|');
+            }
           }
           if (profile.tools?.length) {
             workerEnv.WORKER_TOOLS = profile.tools.join('|');

--- a/src/profile-sync.ts
+++ b/src/profile-sync.ts
@@ -14,7 +14,7 @@ import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
 export interface WorkerProfile {
-  repos?: { url: string }[];
+  repos?: { url: string; postClone?: string }[];
   tools?: string[];
   mounts?: {
     hostPath: string;
@@ -114,6 +114,12 @@ export function syncWorkerProfiles(): number {
     const workerEnv: Record<string, string> = {};
     if (profile.repos?.length) {
       workerEnv.WORKER_REPOS = profile.repos.map((r) => r.url).join('|');
+      const postClones = profile.repos
+        .filter((r) => r.postClone)
+        .map((r) => `${path.basename(r.url, '.git')}:${r.postClone}`);
+      if (postClones.length > 0) {
+        workerEnv.WORKER_REPO_POST_CLONE = postClones.join('|');
+      }
     }
     if (profile.tools?.length) {
       workerEnv.WORKER_TOOLS = profile.tools.join('|');

--- a/worker-profiles/example.json
+++ b/worker-profiles/example.json
@@ -3,7 +3,7 @@
   "description": "Example worker profile — copy to ~/.config/nanoclaw/worker-profiles/default.json and customize",
 
   "repos": [
-    {"url": "git@github.com:your-org/your-repo.git", "description": "Main project repo"}
+    {"url": "git@github.com:your-org/your-repo.git", "postClone": "git config core.hooksPath .githooks"}
   ],
 
   "tools": [


### PR DESCRIPTION
## Summary

- Repos in worker profiles can now specify a `postClone` command that runs after cloning. Common use: `git config core.hooksPath .githooks` to enable repo git hooks.
- Updates example profile to show the pattern.

## Test plan

- [x] Built and restarted nanoclaw
- [x] Created test worker, verified postClone ran for all 5 configured repos
- [x] Repos without postClone (neuralwatt-tools) were unaffected