### PR TITLE
perf: faster first boot + document tsc recompilation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ curl http://localhost:3003/logs/<folder>   # last 20 turns for a worker
 
 ## Gotchas
 
-- **Agent-runner source auto-syncs by mtime.** Changes to MCP tools or agent-runner code take effect on next container spawn. No manual cache clearing needed.
+- **Agent-runner source auto-syncs by mtime.** Changes to MCP tools or agent-runner code take effect on next container spawn. No manual cache clearing needed. However, if the image is stale, the entrypoint recompiles TypeScript on every spawn (~2-3s). Rebuild the image (`container/build.sh`) after agent-runner changes to avoid this.
 - **Docker build cache is aggressive.** `--no-cache` alone doesn't invalidate COPY steps. Prune the builder for a truly clean rebuild.
 - **WhatsApp is a separate channel fork.** Run `/add-whatsapp` to install it after upgrading.
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -20,8 +20,10 @@ if [ -x /workspace/init.sh ]; then
 fi
 
 # Use pre-built dist from Docker image if source hasn't changed.
-# The host mounts agent-runner source to /app/src at runtime, so mtime
-# comparisons are unreliable. Instead, compare content hashes.
+# The host mounts agent-runner source to /app/src at runtime (synced from
+# container/agent-runner/src/ on the host). If the host source differs from
+# what the image was built with, tsc recompiles. Rebuild the container image
+# after agent-runner changes to avoid this 2-3s penalty on every spawn.
 DIST_DIR="/app/dist"
 needs_compile=false
 if [ ! -f "$DIST_DIR/index.js" ]; then

--- a/instructions/worker.md
+++ b/instructions/worker.md
@@ -21,7 +21,7 @@ To check your session's usage stats (Neuralwatt only): `curl -s http://host.dock
 
 ## First Boot
 
-On your first message, briefly announce what's available — list the cloned repos and confirm key tools are working. Keep it short.
+On your first message, acknowledge you're ready and respond to the user's request. Don't run setup commands or list repos unless asked.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

- Simplify worker first-boot instructions: just acknowledge and respond, don't list repos/tools. Cuts first turn from 4 model turns (~13s) to 1 turn (~3.5s).
- Document why tsc recompiles on spawn when the image is stale (entrypoint.sh comment + CLAUDE.md gotcha).

Expected first-message time improvement: ~30s → ~17s (saving ~13s of model thinking).

## Test plan

- [x] Builds clean
- [ ] Create fresh worker, verify faster first response