### PR TITLE
docs: add personal config guide and reference examples

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -128,7 +128,7 @@ AskUserQuestion: "Do your workers need to clone private GitHub repos?"
 
 ## 7. Worker Profiles
 
-Worker profiles define what repos, tools, and credentials each worker container gets. They live at `~/.config/nanoclaw/worker-profiles/`.
+Worker profiles define what repos, tools, and credentials each worker container gets. They live at `~/.config/nanoclaw/worker-profiles/`. See `docs/guides/personal-config.md` for the full config reference and `examples/personal-config/` for a complete example.
 
 ```bash
 mkdir -p ~/.config/nanoclaw/worker-profiles
@@ -154,7 +154,7 @@ If yes:
 mkdir -p ~/.config/nanoclaw/instructions
 ```
 
-Create `global.md` (applies to all agents), `master.md` (master only), or `worker.md` (workers only) as needed. Help them add their conventions.
+Create `global.md` (applies to all agents), `master.md` (master only), or `worker.md` (workers only) as needed. Help them add their conventions. Reference examples are in `examples/personal-config/instructions/`.
 
 ### Personal Dockerfile (Optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Before working on a subsystem, read the relevant doc:
 - **Streaming SSE translation:** [docs/architecture/streaming-shim.md](docs/architecture/streaming-shim.md)
 - **E2E testing procedures:** [docs/guides/testing.md](docs/guides/testing.md)
 - **Setup from scratch:** [docs/guides/setup.md](docs/guides/setup.md)
+- **Personal config (instructions, profiles, Dockerfile):** [docs/guides/personal-config.md](docs/guides/personal-config.md)
 - **Full doc index:** [docs/README.md](docs/README.md)
 
 ## Communication (Discord)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This applies to instructions, the container image, init scripts, and tools:
 
 At startup, NanoClaw assembles each agent's CLAUDE.md from four fragments: repo global, repo role, personal global, personal role. The container image works similarly — the repo Dockerfile is the base, and your personal Dockerfile layers on top. The repo provides generic NanoClaw behavior; your personal config adds your workflow, repos, tools, and conventions.
 
-See [docs/guides/setup.md](docs/guides/setup.md) for the full config layout and [docs/architecture/container-lifecycle.md](docs/architecture/container-lifecycle.md) for how each layer propagates.
+See [docs/guides/personal-config.md](docs/guides/personal-config.md) for the full config reference with examples, [docs/guides/setup.md](docs/guides/setup.md) for installation, and [docs/architecture/container-lifecycle.md](docs/architecture/container-lifecycle.md) for how each layer propagates.
 
 For goals, design principles, and detailed architecture, see [docs/architecture/overview.md](docs/architecture/overview.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ How the system works (current state of the code):
 How to do X (step-by-step):
 
 - [Setup](guides/setup.md) — Getting started with dynamic workers on Discord
+- [Personal config](guides/personal-config.md) — Customizing instructions, profiles, and container image
 - [Testing](guides/testing.md) — Exercising every behavior end-to-end
 - [Troubleshooting](guides/troubleshooting.md) — Common issues and fixes
 

--- a/docs/guides/personal-config.md
+++ b/docs/guides/personal-config.md
@@ -1,0 +1,111 @@
+# Personal Configuration Guide
+
+NanoClaw separates reusable code (the repo) from per-installation config (`~/.config/nanoclaw/`). This guide explains the config system, what goes where, and how to set up your own.
+
+A complete reference example lives at [`examples/personal-config/`](../../examples/personal-config/).
+
+## Why Personal Config?
+
+The repo ships with generic agent instructions, example profiles, and a base container image. Your personal config layers on top: which repos your workers clone, which tools are pre-installed, what coding conventions your agents follow, and what credentials are mounted. Because personal config lives outside the repo, pulling upstream updates never overwrites your setup.
+
+## Directory Structure
+
+```
+~/.config/nanoclaw/
+├── Dockerfile                    # Personal container image layer (optional)
+├── instructions/
+│   ├── global.md                 # Instructions for ALL agents (master + workers)
+│   ├── master.md                 # Master-only instructions
+│   └── worker.md                 # Worker-only instructions
+├── worker-profiles/
+│   ├── default.json              # Worker profile (repos, tools, mounts, ports)
+│   └── init.sh                   # Boot script (runs every container start)
+└── mount-allowlist.json          # Allowed host paths for container mounts
+```
+
+## How Instructions Are Assembled
+
+Each agent's `CLAUDE.md` is assembled from four fragments at startup:
+
+```
+1. instructions/global.md          (repo, shared, all agents)
+2. instructions/{master,worker}.md (repo, shared, role-specific)
+3. ~/.config/nanoclaw/instructions/global.md   (personal, all agents)
+4. ~/.config/nanoclaw/instructions/{master,worker}.md (personal, role-specific)
+```
+
+Repo instructions set baseline behavior (communication style, first-boot, workspace layout). Personal instructions add your conventions (code design, PR workflow, repo list, mount map). You never edit repo instructions for personal preferences; add a personal fragment instead.
+
+## Worker Profile
+
+The worker profile (`default.json`) controls what each worker container gets:
+
+```json
+{
+  "name": "default",
+  "repos": [
+    {"url": "git@github.com:your-org/your-repo.git", "postClone": "git config core.hooksPath .githooks"}
+  ],
+  "tools": ["uv tool install /workspace/group/your-tool --force"],
+  "mounts": [
+    {"hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true}
+  ],
+  "ports": ["8080:8080"],
+  "skills_repo": "your-skills-repo-name"
+}
+```
+
+| Field | Purpose |
+|-|-|
+| `name` | Profile name (used to select non-default profiles). |
+| `repos` | Git repos cloned on first boot. `postClone` runs after each clone. |
+| `tools` | Shell commands run during init (package installs, CLI setup). |
+| `mounts` | Host directories mounted into the container. Must be on the allowlist. |
+| `ports` | Docker port mappings (`host:container`). |
+| `skills_repo` | Name of a cloned repo containing Claude skills. Symlinked into `~/.claude/skills/`. |
+
+## Personal Dockerfile
+
+If your workers need system packages (databases, compilers, language runtimes), add a personal Dockerfile:
+
+```dockerfile
+FROM nanoclaw-agent:base
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql redis-server \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system --break-system-packages pytest httpx
+
+USER node
+```
+
+`container/build.sh` automatically layers this on top of the base image if it exists at `~/.config/nanoclaw/Dockerfile`.
+
+## What Goes Where
+
+The rule of thumb: if removing it would break NanoClaw for any user, it belongs in the repo. If it only matters for your setup, it's personal config. The [setup guide](setup.md#repo-vs-user-config) has the full breakdown.
+
+## Getting Started
+
+The examples at `examples/personal-config/` show a realistic config. To use them as a starting point:
+
+```bash
+cp -r examples/personal-config/ ~/.config/nanoclaw/
+```
+
+Then customize each file for your setup. At minimum, edit `worker-profiles/default.json` to point at your repos, and `instructions/global.md` to set your GitHub username. The [setup guide](setup.md) walks through each file in detail.
+
+After changes, rebuild the container image (if you added a Dockerfile) and restart NanoClaw:
+
+```bash
+cd container && ./build.sh          # only if Dockerfile changed
+systemctl --user restart nanoclaw   # picks up instruction changes
+```
+
+## See Also
+
+- [Setup guide](setup.md): full installation walkthrough
+- [Architecture overview](../architecture/overview.md): system design and config model
+- [Container lifecycle](../architecture/container-lifecycle.md): how workers boot and use profiles

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -71,7 +71,7 @@ NanoClaw separates generic code from per-installation configuration. The repo co
 | `groups/` | Agent workspaces — assembled CLAUDE.md, cloned repos, uncommitted changes (gitignored) |
 | `logs/` | Application logs (gitignored) |
 
-The setup steps below walk through creating your user config from the repo's examples. When you later update NanoClaw (pull new code), your `~/.config/nanoclaw/` files are untouched — only the repo-side defaults change, and you can merge those into your config as needed.
+The setup steps below walk through creating your user config from the repo's examples. When you later update NanoClaw (pull new code), your `~/.config/nanoclaw/` files are untouched — only the repo-side defaults change, and you can merge those into your config as needed. See the [personal config guide](personal-config.md) for a detailed walkthrough of each config file, and [`examples/personal-config/`](../../examples/personal-config/) for a complete reference example.
 
 ## 1. Create a Discord Server
 

--- a/examples/personal-config/Dockerfile
+++ b/examples/personal-config/Dockerfile
@@ -1,0 +1,25 @@
+# Personal NanoClaw agent layer
+# Adds tools and packages specific to this installation.
+# Built on top of the public base image by container/build.sh.
+
+FROM nanoclaw-agent:base
+
+USER root
+
+# PostgreSQL + pgvector + Redis (for integration tests)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql \
+    postgresql-client \
+    postgresql-server-dev-15 \
+    redis-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && cd /tmp \
+    && git clone --branch v0.8.0 --depth 1 https://github.com/pgvector/pgvector.git \
+    && cd pgvector && make -j$(nproc) && make install \
+    && rm -rf /tmp/pgvector
+
+# Python test/dev packages
+RUN uv pip install --system --break-system-packages \
+    pytest httpx pytest-repeat pytest-xdist pipenv
+
+USER node

--- a/examples/personal-config/instructions/global.md
+++ b/examples/personal-config/instructions/global.md
@@ -1,0 +1,33 @@
+# Personal Instructions (All Agents)
+
+## Code Design Principles
+
+- **No implicit fallbacks.** If an operation can't produce its expected result, fail loudly with a descriptive error. Don't silently degrade to a secondary code path.
+- **No band-aid fixes.** Don't fix symptoms. Fix root causes. If something crashes, investigate why, don't just add a try-catch that swallows the error.
+- **Repro before fix.** When investigating a bug, find a reliable reproduction first. Then fix it. Then re-run the repro to confirm.
+- **E2E before handoff.** Any feature or fix must be exercised end-to-end before reporting it as done. Don't claim it works based on unit tests alone.
+- **Fix the system, not the state.** When the system gets into a bad state, investigate how it got there and fix the system. One-off manual interventions mean the system is broken.
+
+## Git & GitHub
+
+- The user's GitHub username is **your-username**
+- Create feature branches for all changes
+- Push branches and open PRs
+- Never push directly to `main`
+
+## PR Quality Workflow
+
+Before creating or submitting a PR:
+
+1. **`/code-review`**: review the diff for bugs, edge cases, and architectural issues
+2. **`/simplify`**: check changed files for reuse opportunities, code quality, and efficiency
+3. **Apply all material improvements**: fix anything that would genuinely improve quality
+4. Amend or add a commit with the fixes, then push and create the PR
+
+## Repos
+
+Available repos:
+- `backend` — API server
+- `frontend` — Web application
+- `shared-tools` — Shared CLI tools and utilities
+- `nanoclaw-fleet` — NanoClaw Fleet, the system running these agents

--- a/examples/personal-config/instructions/master.md
+++ b/examples/personal-config/instructions/master.md
@@ -1,0 +1,29 @@
+# Personal Instructions (Master)
+
+When you or a worker hits repeated friction (missing tool, unclear instructions, environment gap), file a bead or GitHub issue. If a worker reports a problem, fix the template or profile before creating the next worker.
+
+## Working on NanoClaw Code
+
+The NanoClaw repo is at `/workspace/project/`. When modifying it:
+
+- Read `CLAUDE.md` in the repo root for workflow conventions
+- Read `docs/architecture/overview.md` for goals and design principles
+- **You must personally exercise your changes before declaring done.** Use `tools/nc-inject.sh` and `tools/nc-ipc.sh` to send real messages, create/destroy workers, and confirm behavior.
+- After container-side changes (`container/`, `worker-profiles/`), rebuild the image with `cd /workspace/project/container && ./build.sh`
+- After host-side changes (`src/`), restart the NanoClaw service
+
+## First-Run Setup
+
+On your first conversation in a new container (no `~/.ssh` directory exists):
+
+```bash
+mkdir -p ~/.ssh && cp /workspace/group/.ssh/* ~/.ssh/ && chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_ed25519
+```
+
+## Mounted Volumes
+
+| Container path | Contents | Writable |
+|-|-|-|
+| `/workspace/project` | NanoClaw repo | yes |
+| `/workspace/group` | Working directory (cloned repos, files) | yes |
+| `/workspace/group/.ssh/` | SSH keys | yes |

--- a/examples/personal-config/instructions/worker.md
+++ b/examples/personal-config/instructions/worker.md
@@ -1,0 +1,44 @@
+# Personal Instructions (Worker)
+
+## Skills
+
+Skills come from two sources, both symlinked into `~/.claude/skills/`:
+
+1. **Shared skills repo**: mounted from the host, writable. Edits are immediately visible to all workers and persist on the host.
+2. **Host personal skills**: mounted from the host's `~/.claude/skills/`, also writable. Changes persist to the host and are available everywhere.
+
+To create a new skill: write it to `/workspace/extra/host-skills/<skill-name>/SKILL.md`.
+
+## Filesystem Mount Map
+
+| Container path | Source | Writable | Persists |
+|-|-|-|-|
+| `/workspace/group/` | Host: `groups/<your-folder>/` | yes | yes |
+| `~/.claude/` | Host: `data/sessions/<your-folder>/.claude/` | yes | yes |
+| `~/.claude/skills/` | Symlinks from init.sh | varies | yes |
+| `/workspace/extra/host-skills/` | Host: `~/.claude/skills/` | yes | yes |
+| `/workspace/extra/shared-skills-repo/` | Host: `~/git/your-skills-repo/` | yes | yes |
+| `/workspace/extra/host-ssh/` | Host: `~/.ssh/` | no | n/a |
+| `/workspace/worker-profiles/` | Host: `~/.config/nanoclaw/worker-profiles/` | yes | yes |
+| `/workspace/ipc/` | Host: `data/ipc/<your-folder>/` | yes | yes |
+| `/app/src/` | Copied from `container/agent-runner/src/` | yes | yes |
+| Everything else (`/usr/`, `/tmp/`, etc.) | Container image | yes | no |
+
+**Key takeaways:**
+- **To persist anything:** put it in `/workspace/group/`
+- **To create a skill visible everywhere:** write to `/workspace/extra/host-skills/<name>/SKILL.md`
+- **To install tools permanently:** edit the worker profile or ask the user to update the Dockerfile
+- **Credentials** are mounted read-only. Never copy them into repos or committed files.
+
+## Available Repos
+
+- `backend` — API server
+- `frontend` — Web application
+- `shared-tools` — Shared CLI tools and utilities
+- `nanoclaw-fleet` — NanoClaw Fleet, the system running you
+
+## Network & Access
+
+- **Internet access.** You can reach the internet (git, pip, npm, etc.).
+- **Host machine.** Accessible at `host.docker.internal`.
+- **No access to other workers.** Each worker has its own container and filesystem.

--- a/examples/personal-config/worker-profiles/default.json
+++ b/examples/personal-config/worker-profiles/default.json
@@ -1,0 +1,23 @@
+{
+  "name": "default",
+  "description": "Standard development worker",
+
+  "repos": [
+    {"url": "git@github.com:your-org/backend.git", "postClone": "git config core.hooksPath .githooks"},
+    {"url": "git@github.com:your-org/frontend.git", "postClone": "git config core.hooksPath .githooks"},
+    {"url": "git@github.com:your-org/shared-tools.git"},
+    {"url": "git@github.com:your-org/nanoclaw-fleet.git", "postClone": "git config core.hooksPath .githooks"}
+  ],
+
+  "tools": [
+    "uv tool install /workspace/group/shared-tools --force"
+  ],
+
+  "mounts": [
+    {"hostPath": "~/.config/your-tool", "containerPath": "your-tool", "readonly": false},
+    {"hostPath": "~/.claude/skills", "containerPath": "host-skills", "readonly": false},
+    {"hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true}
+  ],
+
+  "skills_repo": "your-claude-skills"
+}

--- a/instructions/global.md
+++ b/instructions/global.md
@@ -53,7 +53,7 @@ When the user asks you to change instructions, tools, packages, or other config,
 
 Most of these require a NanoClaw restart to take effect (instructions are assembled at startup, Dockerfiles need an image rebuild). Worker profiles are the exception — workers can edit them directly at `/workspace/worker-profiles/` and changes apply to the next new worker.
 
-Host paths (`~/.config/nanoclaw/`) are not directly accessible from worker containers. If the master has host filesystem access, it may be able to edit them. Otherwise, tell the user what to add.
+Host paths (`~/.config/nanoclaw/`) are not directly accessible from worker containers. If the master has host filesystem access, it may be able to edit them. Otherwise, tell the user what to add. See `docs/guides/personal-config.md` in the repo for the full config reference.
 
 ## Your Workspace
 


### PR DESCRIPTION
## Summary

- Adds `examples/personal-config/` with realistic, sanitized reference configs (worker profile, Dockerfile, instructions for global/master/worker)
- Adds `docs/guides/personal-config.md` explaining the config system, instruction assembly, worker profiles, and Dockerfile layering
- Cross-references from CLAUDE.md, README, docs index, setup guide, setup skill, and global agent instructions

## Test plan

- [ ] Verify example files contain no secrets or company-specific references
- [ ] Verify `cp -r examples/personal-config/ ~/.config/nanoclaw/` produces a valid config structure
- [ ] Verify all cross-reference links resolve correctly