### PR TITLE
feat: pinned status message in Discord

### DIFF
--- a/docs/architecture/container-lifecycle.md
+++ b/docs/architecture/container-lifecycle.md
@@ -13,6 +13,7 @@ The master agent has these lifecycle tools (master-only, enforced by `isMain` ch
 | `list_workers` | Returns all registered workers with their status |
 | `cleanup_workers` | Destroys stale or errored workers in bulk |
 | `switch_backend` | Changes a worker's inference backend or model. Cross-backend switches restart the container automatically. |
+| `worker_history` | Query the worker event log (`logs/worker-events.jsonl`). Filter by worker name, event type, or time range. |
 
 All agents (master and workers) also have:
 
@@ -93,6 +94,24 @@ When the master calls `destroy_worker`:
 7. **Workspace preserved** (`groups/{folder}/`). Repos, code changes, and CLAUDE.md stay on disk.
 
 If the worker was a Neuralwatt worker, the master reports its lifetime usage stats before cleanup.
+
+## Worker Event Log
+
+All worker lifecycle events are recorded in `logs/worker-events.jsonl`, an append-only JSONL file. Each line is a JSON object:
+
+```jsonl
+{"timestamp":"2026-04-06T23:49:36.997Z","event":"created","worker":"ci-fail","folder":"discord_ci-fail","details":{"backend":"anthropic"}}
+{"timestamp":"2026-04-07T03:34:58.449Z","event":"backend_switched","worker":"baba","folder":"discord_baba","details":{"from":"anthropic","to":"neuralwatt","model":"kimi-k2.5-fast"}}
+{"timestamp":"2026-04-06T23:58:35.362Z","event":"destroyed","worker":"baba","folder":"discord_baba"}
+```
+
+**Event types:** `created`, `destroyed`, `backend_switched`, `resumed`
+
+**Fields:** `timestamp` (ISO 8601), `event`, `worker` (display name), `folder` (e.g. `discord_baba`), `details` (optional, event-specific metadata like backend/model info).
+
+The master agent can query this log via the `worker_history` MCP tool, which supports filtering by worker name (partial match), event type, time range (`since`), and result limit. Source: `src/worker-events.ts`.
+
+Events are written by `logWorkerEvent()` during create, destroy, backend switch, and resume operations in `src/ipc.ts`.
 
 ## Restart Recovery
 

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -79,8 +79,9 @@ vi.mock('discord.js', () => {
 
     channels = {
       fetch: vi.fn().mockResolvedValue({
-        send: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ id: 'mock-msg-id' }),
         sendTyping: vi.fn().mockResolvedValue(undefined),
+        messages: { fetch: vi.fn(), edit: vi.fn() },
       }),
     };
 
@@ -687,8 +688,9 @@ describe('DiscordChannel', () => {
       await channel.connect();
 
       const mockChannel = {
-        send: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ id: 'mock-msg-id' }),
         sendTyping: vi.fn(),
+        messages: { fetch: vi.fn(), edit: vi.fn() },
       };
       currentClient().channels.fetch.mockResolvedValue(mockChannel);
 
@@ -736,6 +738,7 @@ describe('DiscordChannel', () => {
       const mockChannel = {
         send: vi.fn(),
         sendTyping: vi.fn().mockResolvedValue(undefined),
+        messages: { fetch: vi.fn(), edit: vi.fn() },
       };
       currentClient().channels.fetch.mockResolvedValue(mockChannel);
 

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -654,7 +654,10 @@ describe('DiscordChannel', () => {
 
       await channel.sendMessage('dc:9876543210', 'Test');
 
-      expect(currentClient().channels.fetch).toHaveBeenCalledWith('9876543210');
+      expect(currentClient().channels.fetch).toHaveBeenCalledWith(
+        '9876543210',
+        { force: false },
+      );
     });
 
     it('handles send failure gracefully', async () => {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -305,8 +305,7 @@ export class DiscordChannel implements Channel {
         'editMessage: content truncated',
       );
     }
-    const message = await textChannel.messages.fetch(messageId);
-    await message.edit(truncated);
+    await textChannel.messages.edit(messageId, truncated);
   }
 
   async pinMessage(jid: string, messageId: string): Promise<void> {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -51,7 +51,10 @@ export class DiscordChannel implements Channel {
   private async fetchTextChannel(jid: string): Promise<TextChannel> {
     if (!this.client) throw new Error('Discord client not initialized');
     const channelId = this.jidToChannelId(jid);
-    const channel = await this.client.channels.fetch(channelId);
+    // force: false lets discord.js use its internal cache (avoids API call per poll)
+    const channel = await this.client.channels.fetch(channelId, {
+      force: false,
+    });
     if (!channel || !('messages' in channel)) {
       throw new Error(`Discord channel not found or not text-based: ${jid}`);
     }

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -24,6 +24,9 @@ export interface DiscordChannelOpts {
   registeredGroups: () => Record<string, RegisteredGroup>;
 }
 
+// Discord enforces a 2000-character limit per message.
+const DISCORD_MAX_MESSAGE_LENGTH = 2000;
+
 export class DiscordChannel implements Channel {
   name = 'discord';
 
@@ -34,6 +37,25 @@ export class DiscordChannel implements Channel {
   constructor(botToken: string, opts: DiscordChannelOpts) {
     this.botToken = botToken;
     this.opts = opts;
+  }
+
+  /** Extract the Discord channel ID from a dc:-prefixed JID. */
+  private jidToChannelId(jid: string): string {
+    if (!jid.startsWith('dc:')) {
+      throw new Error(`Expected dc: JID, got: ${jid}`);
+    }
+    return jid.slice(3);
+  }
+
+  /** Fetch a text channel by JID. Throws if not found or not text-based. */
+  private async fetchTextChannel(jid: string): Promise<TextChannel> {
+    if (!this.client) throw new Error('Discord client not initialized');
+    const channelId = this.jidToChannelId(jid);
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !('messages' in channel)) {
+      throw new Error(`Discord channel not found or not text-based: ${jid}`);
+    }
+    return channel as TextChannel;
   }
 
   async connect(): Promise<void> {
@@ -192,34 +214,37 @@ export class DiscordChannel implements Channel {
   }
 
   async sendMessage(jid: string, text: string): Promise<void> {
-    if (!this.client) {
-      logger.warn('Discord client not initialized');
-      return;
-    }
+    await this.sendMessageWithId(jid, text);
+  }
 
+  /**
+   * Send a message and return its Discord message ID.
+   * Used by status-pin to track the pinned message.
+   */
+  async sendMessageWithId(
+    jid: string,
+    text: string,
+  ): Promise<string | undefined> {
     try {
-      const channelId = jid.replace(/^dc:/, '');
-      const channel = await this.client.channels.fetch(channelId);
+      const textChannel = await this.fetchTextChannel(jid);
 
-      if (!channel || !('send' in channel)) {
-        logger.warn({ jid }, 'Discord channel not found or not text-based');
-        return;
-      }
-
-      const textChannel = channel as TextChannel;
-
-      // Discord has a 2000 character limit per message — split if needed
-      const MAX_LENGTH = 2000;
-      if (text.length <= MAX_LENGTH) {
-        await textChannel.send(text);
+      let firstMessageId: string | undefined;
+      if (text.length <= DISCORD_MAX_MESSAGE_LENGTH) {
+        const sent = await textChannel.send(text);
+        firstMessageId = sent.id;
       } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          await textChannel.send(text.slice(i, i + MAX_LENGTH));
+        for (let i = 0; i < text.length; i += DISCORD_MAX_MESSAGE_LENGTH) {
+          const sent = await textChannel.send(
+            text.slice(i, i + DISCORD_MAX_MESSAGE_LENGTH),
+          );
+          if (!firstMessageId) firstMessageId = sent.id;
         }
       }
       logger.info({ jid, length: text.length }, 'Discord message sent');
+      return firstMessageId;
     } catch (err) {
       logger.error({ jid, err }, 'Failed to send Discord message');
+      return undefined;
     }
   }
 
@@ -267,14 +292,36 @@ export class DiscordChannel implements Channel {
     }
   }
 
+  async editMessage(
+    jid: string,
+    messageId: string,
+    text: string,
+  ): Promise<void> {
+    const textChannel = await this.fetchTextChannel(jid);
+    const truncated = text.slice(0, DISCORD_MAX_MESSAGE_LENGTH);
+    if (text.length > DISCORD_MAX_MESSAGE_LENGTH) {
+      logger.warn(
+        { jid, original: text.length, truncated: DISCORD_MAX_MESSAGE_LENGTH },
+        'editMessage: content truncated',
+      );
+    }
+    const message = await textChannel.messages.fetch(messageId);
+    await message.edit(truncated);
+  }
+
+  async pinMessage(jid: string, messageId: string): Promise<void> {
+    const textChannel = await this.fetchTextChannel(jid);
+    const message = await textChannel.messages.fetch(messageId);
+    if (!message.pinned) {
+      await message.pin();
+    }
+  }
+
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     if (!this.client || !isTyping) return;
     try {
-      const channelId = jid.replace(/^dc:/, '');
-      const channel = await this.client.channels.fetch(channelId);
-      if (channel && 'sendTyping' in channel) {
-        await (channel as TextChannel).sendTyping();
-      }
+      const textChannel = await this.fetchTextChannel(jid);
+      await textChannel.sendTyping();
     } catch (err) {
       logger.debug({ jid, err }, 'Failed to send Discord typing indicator');
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ const envConfig = readEnvFile([
   'MAX_CONCURRENT_CONTAINERS',
   'NANOCLAW_ENABLE_DOCKER',
   'NANOCLAW_GITHUB_TOKEN_PATH',
+  'STATUS_PIN_INTERVAL',
 ]);
 
 export const ASSISTANT_NAME =
@@ -110,6 +111,12 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// Interval (ms) for updating the pinned status message in Discord. 0 disables.
+export const STATUS_PIN_INTERVAL = parseInt(
+  process.env.STATUS_PIN_INTERVAL || envConfig.STATUS_PIN_INTERVAL || '30000',
+  10,
+);
 
 // When true, mounts /var/run/docker.sock into agent containers so they can run Docker commands.
 // Enable with NANOCLAW_ENABLE_DOCKER=true in the host environment.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { syncMasterProfile, syncWorkerProfiles } from './profile-sync.js';
 import { startResourceMonitor } from './resource-monitor.js';
 import { startStatusPin, markStatusOffline } from './status-pin.js';
+import type { DiscordChannel } from './channels/discord.js';
 
 import {
   ASSISTANT_NAME,
@@ -658,7 +659,7 @@ async function main(): Promise<void> {
       }
       // Mark pinned status as offline (best-effort, 3s timeout)
       const dcShutdown = channels.find((c) => c.name === 'discord') as
-        | import('./channels/discord.js').DiscordChannel
+        | DiscordChannel
         | undefined;
       if (dcShutdown) {
         await markStatusOffline(mainEntry[0], {
@@ -819,7 +820,7 @@ async function main(): Promise<void> {
 
   // Start pinned status message updater (Discord only)
   if (mainGroup && discordChannel) {
-    const dc = discordChannel as import('./channels/discord.js').DiscordChannel;
+    const dc = discordChannel as DiscordChannel;
     startStatusPin(mainGroup[0], STATUS_PIN_INTERVAL, {
       sendMessage: (jid, text) => dc.sendMessageWithId(jid, text),
       editMessage: (jid, msgId, text) => dc.editMessage(jid, msgId, text),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { syncMasterProfile, syncWorkerProfiles } from './profile-sync.js';
 import { startResourceMonitor } from './resource-monitor.js';
+import { startStatusPin, markStatusOffline } from './status-pin.js';
 
 import {
   ASSISTANT_NAME,
@@ -11,6 +12,7 @@ import {
   IDLE_TIMEOUT,
   MAX_CONCURRENT_CONTAINERS,
   POLL_INTERVAL,
+  STATUS_PIN_INTERVAL,
   TIMEZONE,
   TRIGGER_PATTERN,
 } from './config.js';
@@ -654,6 +656,17 @@ async function main(): Promise<void> {
           logger.debug({ err }, 'Shutdown notification failed');
         }
       }
+      // Mark pinned status as offline (best-effort, 3s timeout)
+      const dcShutdown = channels.find((c) => c.name === 'discord') as
+        | import('./channels/discord.js').DiscordChannel
+        | undefined;
+      if (dcShutdown) {
+        await markStatusOffline(mainEntry[0], {
+          editMessage: (jid, msgId, text) =>
+            dcShutdown.editMessage(jid, msgId, text),
+        });
+        sstep('status pin marked offline');
+      }
     }
 
     proxyServer.close();
@@ -802,6 +815,16 @@ async function main(): Promise<void> {
         () => queue.getActiveCount(),
       );
     }
+  }
+
+  // Start pinned status message updater (Discord only)
+  if (mainGroup && discordChannel) {
+    const dc = discordChannel as import('./channels/discord.js').DiscordChannel;
+    startStatusPin(mainGroup[0], STATUS_PIN_INTERVAL, {
+      sendMessage: (jid, text) => dc.sendMessageWithId(jid, text),
+      editMessage: (jid, msgId, text) => dc.editMessage(jid, msgId, text),
+      pinMessage: (jid, msgId) => dc.pinMessage(jid, msgId),
+    });
   }
 
   step('startup complete');

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
+let stopStatusPin: (() => void) | undefined;
 
 const channels: Channel[] = [];
 const queue = new GroupQueue();
@@ -822,7 +823,6 @@ async function main(): Promise<void> {
   }
 
   // Start pinned status message updater (Discord only)
-  let stopStatusPin: (() => void) | undefined;
   if (mainGroup && discordChannel) {
     const dc = discordChannel as DiscordChannel;
     stopStatusPin = startStatusPin(mainGroup[0], STATUS_PIN_INTERVAL, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -657,6 +657,9 @@ async function main(): Promise<void> {
           logger.debug({ err }, 'Shutdown notification failed');
         }
       }
+      // Stop status pin loop before marking offline
+      stopStatusPin?.();
+
       // Mark pinned status as offline (best-effort, 3s timeout)
       const dcShutdown = channels.find((c) => c.name === 'discord') as
         | DiscordChannel
@@ -819,9 +822,10 @@ async function main(): Promise<void> {
   }
 
   // Start pinned status message updater (Discord only)
+  let stopStatusPin: (() => void) | undefined;
   if (mainGroup && discordChannel) {
     const dc = discordChannel as DiscordChannel;
-    startStatusPin(mainGroup[0], STATUS_PIN_INTERVAL, {
+    stopStatusPin = startStatusPin(mainGroup[0], STATUS_PIN_INTERVAL, {
       sendMessage: (jid, text) => dc.sendMessageWithId(jid, text),
       editMessage: (jid, msgId, text) => dc.editMessage(jid, msgId, text),
       pinMessage: (jid, msgId) => dc.pinMessage(jid, msgId),

--- a/src/status-pin.ts
+++ b/src/status-pin.ts
@@ -1,0 +1,140 @@
+/**
+ * Status pin: maintains a pinned Discord message in the master channel
+ * that shows live worker status. Updates on a configurable interval by
+ * running the nc-status.sh script and editing the pinned message in place.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+
+import { getRouterState, setRouterState } from './db.js';
+import { logger } from './logger.js';
+import { TIMEZONE } from './config.js';
+
+const execFileAsync = promisify(execFile);
+
+const STATE_KEY = 'pinned_status_message_id';
+const NC_STATUS_SCRIPT = path.resolve(process.cwd(), 'tools/nc-status.sh');
+const STATUS_ENV = { ...process.env, NANOCLAW_ROOT: process.cwd() };
+
+export interface StatusPinDeps {
+  sendMessage: (jid: string, text: string) => Promise<string | undefined>;
+  editMessage: (jid: string, messageId: string, text: string) => Promise<void>;
+  pinMessage: (jid: string, messageId: string) => Promise<void>;
+}
+
+function formatTimestamp(): string {
+  return new Date().toLocaleString('en-US', {
+    timeZone: TIMEZONE,
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+  });
+}
+
+async function getStatusOutput(): Promise<string> {
+  const { stdout } = await execFileAsync('bash', [NC_STATUS_SCRIPT], {
+    timeout: 15_000,
+    env: STATUS_ENV,
+  });
+  return stdout.trim();
+}
+
+async function updateStatusPin(
+  mainJid: string,
+  deps: StatusPinDeps,
+): Promise<void> {
+  const statusText = await getStatusOutput();
+  if (!statusText) {
+    logger.warn('nc-status.sh returned empty output');
+    return;
+  }
+
+  const fullText = `${statusText}\n\n_Updated ${formatTimestamp()}_`;
+
+  const existingMessageId = getRouterState(STATE_KEY);
+
+  if (existingMessageId) {
+    try {
+      await deps.editMessage(mainJid, existingMessageId, fullText);
+      return;
+    } catch (err) {
+      // Message was deleted, permissions changed, or network error
+      logger.info(
+        { err },
+        'Pinned status message gone or inaccessible, creating new one',
+      );
+    }
+  }
+
+  // Create new message and pin it
+  const newMessageId = await deps.sendMessage(mainJid, fullText);
+  if (newMessageId) {
+    setRouterState(STATE_KEY, newMessageId);
+    try {
+      await deps.pinMessage(mainJid, newMessageId);
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Failed to pin status message (missing permissions?)',
+      );
+    }
+    logger.info(
+      { messageId: newMessageId },
+      'Created and pinned status message',
+    );
+  }
+}
+
+/**
+ * Start the status pin update loop. Returns a cleanup function to stop it.
+ */
+export function startStatusPin(
+  mainJid: string,
+  intervalMs: number,
+  deps: StatusPinDeps,
+): () => void {
+  if (intervalMs <= 0) {
+    logger.info('Status pin disabled (interval <= 0)');
+    return () => {};
+  }
+
+  const poll = () => {
+    updateStatusPin(mainJid, deps).catch((err) => {
+      logger.error({ err }, 'Status pin update failed');
+    });
+  };
+
+  // First update after 10s (let startup finish)
+  const initialTimeout = setTimeout(poll, 10_000);
+  const interval = setInterval(poll, intervalMs);
+  logger.info({ intervalMs }, 'Status pin loop started');
+
+  return () => {
+    clearTimeout(initialTimeout);
+    clearInterval(interval);
+  };
+}
+
+/**
+ * Best-effort update of the pinned message to show offline status.
+ * Call during shutdown — returns quickly if it fails.
+ */
+export async function markStatusOffline(
+  mainJid: string,
+  deps: Pick<StatusPinDeps, 'editMessage'>,
+): Promise<void> {
+  const messageId = getRouterState(STATE_KEY);
+  if (!messageId) return;
+
+  const offlineText = `**NanoClaw offline** — _${formatTimestamp()}_`;
+  await Promise.race([
+    deps.editMessage(mainJid, messageId, offlineText),
+    new Promise((r) => setTimeout(r, 3000)),
+  ]).catch(() => {
+    /* best effort */
+  });
+}

--- a/src/status-pin.ts
+++ b/src/status-pin.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import { getRouterState, setRouterState } from './db.js';
 import { logger } from './logger.js';
 import { TIMEZONE } from './config.js';
+import { formatCurrentTime } from './timezone.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -25,14 +26,7 @@ export interface StatusPinDeps {
 }
 
 function formatTimestamp(): string {
-  return new Date().toLocaleString('en-US', {
-    timeZone: TIMEZONE,
-    hour: 'numeric',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: true,
-    timeZoneName: 'short',
-  });
+  return formatCurrentTime(TIMEZONE);
 }
 
 async function getStatusOutput(): Promise<string> {

--- a/src/status-pin.ts
+++ b/src/status-pin.ts
@@ -18,6 +18,9 @@ const execFileAsync = promisify(execFile);
 const STATE_KEY = 'pinned_status_message_id';
 const NC_STATUS_SCRIPT = path.resolve(process.cwd(), 'tools/nc-status.sh');
 
+// Discord API error codes
+const DISCORD_ERROR_UNKNOWN_MESSAGE = 10008; // Message was deleted or not found
+
 /** Prevent overlapping updateStatusPin calls (e.g. if nc-status.sh is slow). */
 let updateInProgress = false;
 
@@ -76,8 +79,8 @@ async function doUpdateStatusPin(
         err && typeof err === 'object' && 'code' in err
           ? (err as { code: number }).code
           : undefined;
-      if (code === 10008) {
-        // Discord API 10008 = Unknown Message (deleted)
+      if (code === DISCORD_ERROR_UNKNOWN_MESSAGE) {
+        // Message was deleted or not found
         logger.info('Pinned status message was deleted, creating new one');
       } else {
         logger.warn(

--- a/src/status-pin.ts
+++ b/src/status-pin.ts
@@ -17,7 +17,6 @@ const execFileAsync = promisify(execFile);
 
 const STATE_KEY = 'pinned_status_message_id';
 const NC_STATUS_SCRIPT = path.resolve(process.cwd(), 'tools/nc-status.sh');
-const STATUS_ENV = { ...process.env, NANOCLAW_ROOT: process.cwd() };
 
 /** Prevent overlapping updateStatusPin calls (e.g. if nc-status.sh is slow). */
 let updateInProgress = false;
@@ -28,14 +27,10 @@ export interface StatusPinDeps {
   pinMessage: (jid: string, messageId: string) => Promise<void>;
 }
 
-function formatTimestamp(): string {
-  return formatCurrentTime(TIMEZONE);
-}
-
 async function getStatusOutput(): Promise<string> {
   const { stdout } = await execFileAsync('bash', [NC_STATUS_SCRIPT], {
     timeout: 15_000,
-    env: STATUS_ENV,
+    env: { ...process.env, NANOCLAW_ROOT: process.cwd() },
   });
   return stdout.trim();
 }
@@ -66,7 +61,7 @@ async function doUpdateStatusPin(
     return;
   }
 
-  const fullText = `${statusText}\n\n_Updated ${formatTimestamp()}_`;
+  const fullText = `${statusText}\n\n_Updated ${formatCurrentTime(TIMEZONE)}_`;
 
   const existingMessageId = getRouterState(STATE_KEY);
 
@@ -74,12 +69,23 @@ async function doUpdateStatusPin(
     try {
       await deps.editMessage(mainJid, existingMessageId, fullText);
       return;
-    } catch (err) {
-      // Message was deleted, permissions changed, or network error
-      logger.info(
-        { err },
-        'Pinned status message gone or inaccessible, creating new one',
-      );
+    } catch (err: unknown) {
+      // Only create a new message for permanent failures (message deleted/not found).
+      // Transient errors (rate limits, network, 500s) should skip this cycle.
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? (err as { code: number }).code
+          : undefined;
+      if (code === 10008) {
+        // Discord API 10008 = Unknown Message (deleted)
+        logger.info('Pinned status message was deleted, creating new one');
+      } else {
+        logger.warn(
+          { err },
+          'Transient error editing status pin, skipping this cycle',
+        );
+        return;
+      }
     }
   }
 
@@ -99,6 +105,8 @@ async function doUpdateStatusPin(
       { messageId: newMessageId },
       'Created and pinned status message',
     );
+  } else {
+    logger.warn('Failed to create status message (sendMessage returned empty)');
   }
 }
 
@@ -143,7 +151,7 @@ export async function markStatusOffline(
   const messageId = getRouterState(STATE_KEY);
   if (!messageId) return;
 
-  const offlineText = `**NanoClaw offline** — _${formatTimestamp()}_`;
+  const offlineText = `**NanoClaw offline** — _${formatCurrentTime(TIMEZONE)}_`;
   await Promise.race([
     deps.editMessage(mainJid, messageId, offlineText),
     new Promise((r) => setTimeout(r, 3000)),

--- a/src/status-pin.ts
+++ b/src/status-pin.ts
@@ -19,6 +19,9 @@ const STATE_KEY = 'pinned_status_message_id';
 const NC_STATUS_SCRIPT = path.resolve(process.cwd(), 'tools/nc-status.sh');
 const STATUS_ENV = { ...process.env, NANOCLAW_ROOT: process.cwd() };
 
+/** Prevent overlapping updateStatusPin calls (e.g. if nc-status.sh is slow). */
+let updateInProgress = false;
+
 export interface StatusPinDeps {
   sendMessage: (jid: string, text: string) => Promise<string | undefined>;
   editMessage: (jid: string, messageId: string, text: string) => Promise<void>;
@@ -38,6 +41,22 @@ async function getStatusOutput(): Promise<string> {
 }
 
 async function updateStatusPin(
+  mainJid: string,
+  deps: StatusPinDeps,
+): Promise<void> {
+  if (updateInProgress) {
+    logger.debug('Skipping status pin update — previous update still running');
+    return;
+  }
+  updateInProgress = true;
+  try {
+    await doUpdateStatusPin(mainJid, deps);
+  } finally {
+    updateInProgress = false;
+  }
+}
+
+async function doUpdateStatusPin(
   mainJid: string,
   deps: StatusPinDeps,
 ): Promise<void> {
@@ -91,8 +110,8 @@ export function startStatusPin(
   intervalMs: number,
   deps: StatusPinDeps,
 ): () => void {
-  if (intervalMs <= 0) {
-    logger.info('Status pin disabled (interval <= 0)');
+  if (!intervalMs || intervalMs <= 0 || !Number.isFinite(intervalMs)) {
+    logger.info('Status pin disabled (interval <= 0 or invalid)');
     return () => {};
   }
 

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -14,3 +14,18 @@ export function formatLocalTime(utcIso: string, timezone: string): string {
     hour12: true,
   });
 }
+
+/**
+ * Format the current time as a short local timestamp (e.g. "9:48:05 PM MDT").
+ * Used for status messages and lightweight timestamps.
+ */
+export function formatCurrentTime(timezone: string): string {
+  return new Date().toLocaleString('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a pinned Discord message in the master channel that auto-updates with worker status every 30s
- Runs `nc-status.sh` on a configurable interval (`STATUS_PIN_INTERVAL`), edits the pinned message in place
- Persists message ID in SQLite so it survives restarts; marks "offline" on shutdown
- New Discord methods: `sendMessageWithId()`, `editMessage()`, `pinMessage()` with shared `fetchTextChannel()` helper

## Key design decisions

- **Re-entrancy guard** prevents overlapping polls if `nc-status.sh` is slow
- **Transient vs permanent error handling**: only creates a new pinned message on Discord 10008 (Unknown Message); transient errors (rate limits, network) skip the cycle
- **`force: false` on `channels.fetch()`** uses discord.js cache, avoiding ~2,880 unnecessary API calls/day
- **Cleanup function pattern**: `startStatusPin()` returns a cleanup fn, called during shutdown before marking offline

## Test plan

- [ ] Verify pinned message appears in master channel after startup
- [ ] Verify message updates every 30s with current worker status
- [ ] Verify "NanoClaw offline" on shutdown
- [ ] Verify transient Discord errors don't create duplicate pins
- [ ] Delete the pinned message manually → verify it recreates on next cycle
- [ ] Set `STATUS_PIN_INTERVAL=0` → verify feature is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)