### PR TITLE
docs: update MCP tool refs to ncf CLI, add CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Discord Server
   #worker-beta     <-->       |         <-->  Container B (Claude or Neuralwatt)
 ```
 
-One Discord bot. The host process routes messages by channel ID. Workers are isolated containers with their own filesystems and Claude sessions. The master calls MCP tools (create, destroy, list, switch) with the right arguments. Workers handle all the real work.
+One Discord bot. The host process routes messages by channel ID. Workers are isolated containers with their own filesystems and Claude sessions. The master uses `ncf` CLI commands to create, destroy, and switch workers. Workers handle all the real work.
 
 ### Configuration Model
 
@@ -187,7 +187,7 @@ See [docs/architecture/container-lifecycle.md](docs/architecture/container-lifec
 | ---------------------------------------- | -------------------------------------------------------------- |
 | [docs/architecture/](docs/architecture/) | How the system works (overview, routing, lifecycle, streaming) |
 | [docs/guides/](docs/guides/)             | Setup, personal config, testing, troubleshooting               |
-| [docs/reference/](docs/reference/)       | SDK internals                                                  |
+| [docs/reference/](docs/reference/)       | CLI reference, SDK internals                                   |
 | [design/](design/)                       | Design history and archived proposals                          |
 
 Full index: [docs/README.md](docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ How to do X (step-by-step):
 
 Lookup-oriented:
 
+- [CLI reference](reference/cli.md) — ncf commands for worker management
 - [SDK internals](reference/sdk-internals.md) — Claude Agent SDK deep dive
 
 ## Upstream Docs

--- a/docs/architecture/container-lifecycle.md
+++ b/docs/architecture/container-lifecycle.md
@@ -83,12 +83,12 @@ Workers have no idle timeout (disabled via `disableIdleTimeout`). They stay up i
 
 ## Destroy
 
-When the master calls `destroy_worker`:
+When the master runs `ncf destroy`:
 
 1. **Container killed** if running.
 2. **Discord channel deleted.**
 3. **Registration removed** from `registered_groups` in SQLite.
-4. **Session ID preserved** in the `sessions` table so a future `create_worker` with `reuse: "resume"` can pass it to the SDK for continuation.
+4. **Session ID preserved** in the `sessions` table so a future `ncf create` with `reuse: "resume"` can pass it to the SDK for continuation.
 5. **Session dir preserved** (`data/sessions/{folder}/.claude/`) with conversation history.
 6. **Agent-runner cache deleted** (`data/sessions/{folder}/agent-runner-src/`).
 7. **Workspace preserved** (`groups/{folder}/`). Repos, code changes, and CLAUDE.md stay on disk.
@@ -109,7 +109,7 @@ All worker lifecycle events are recorded in `logs/worker-events.jsonl`, an appen
 
 **Fields:** `timestamp` (ISO 8601), `event`, `worker` (display name), `folder` (e.g. `discord_baba`), `details` (optional, event-specific metadata like backend/model info).
 
-The master agent can query this log via the `worker_history` MCP tool, which supports filtering by worker name (partial match), event type, time range (`since`), and result limit. Source: `src/worker-events.ts`.
+The master agent can query this log via `ncf history`, which supports filtering by worker name (partial match), event type, time range (`since`), and result limit. Source: `src/worker-events.ts`.
 
 Events are written by `logWorkerEvent()` during create, destroy, backend switch, and resume operations in `src/ipc.ts`.
 
@@ -129,10 +129,10 @@ Session IDs are preserved in SQLite, so conversation context survives across res
 
 The `groups/` directory is gitignored and holds per-agent workspaces:
 
-| Directory                | What it is                                                | Created by      |
-| ------------------------ | --------------------------------------------------------- | --------------- |
-| `groups/discord_main/`   | Master agent workspace (assembled CLAUDE.md, repos, logs) | Startup sync    |
-| `groups/discord_{name}/` | Worker workspaces (repos, code, assembled CLAUDE.md)      | `create_worker` |
+| Directory                | What it is                                                | Created by   |
+| ------------------------ | --------------------------------------------------------- | ------------ |
+| `groups/discord_main/`   | Master agent workspace (assembled CLAUDE.md, repos, logs) | Startup sync |
+| `groups/discord_{name}/` | Worker workspaces (repos, code, assembled CLAUDE.md)      | `ncf create` |
 
 All `groups/` directories are ephemeral workspaces (gitignored). Agent instructions are assembled from layered fragments at startup (master) or worker creation time:
 

--- a/docs/architecture/model-discovery.md
+++ b/docs/architecture/model-discovery.md
@@ -43,6 +43,7 @@ curl -s http://localhost:3003/models/resolve/Qwen/Qwen3-Coder
 **Note:** Space-separated queries like "kimi fast" don't split correctly (spaces aren't in the delimiter set). This is a known limitation. Use hyphens instead: "kimi-fast".
 
 On no match, returns 404 with the full list of available models:
+
 ```json
 { "error": "no match for \"nonexistent\"", "available": ["moonshotai/Kimi-K2.5", ...] }
 ```
@@ -52,7 +53,7 @@ On no match, returns 404 with the full list of available models:
 When a user says "create agent foo using neuralwatt kimi-fast," the master agent:
 
 1. Calls `/models/resolve/kimi-fast` to get the model ID
-2. Passes the resolved model to the `create_worker` MCP tool
+2. Runs `ncf create foo --backend neuralwatt --model <resolved-model>`
 3. The host writes the model to `data/worker-backends.json`
 4. The shim reads this config on each request and routes to the correct model
 
@@ -60,6 +61,6 @@ The master doesn't need to know the full model catalog. It delegates resolution 
 
 ## Runtime Model Switching
 
-The `switch_backend` MCP tool (master-only) can change a Neuralwatt worker's model without destroying it. The master resolves the new model name via `/models/resolve`, then updates `data/worker-backends.json`. The shim re-reads this file on each request, so the change takes effect immediately.
+The `ncf switch` command can change a Neuralwatt worker's model without destroying it. The master resolves the new model name via `/models/resolve`, then `ncf switch` updates `data/worker-backends.json`. The shim re-reads this file on each request, so the change takes effect immediately.
 
 Switching between Anthropic and Neuralwatt backends requires destroying and recreating the worker, since the backend determines which proxy the container talks to (port 3001 vs 3003), and that's set at container startup.

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -30,8 +30,8 @@ Whether you use `/setup` or follow the manual steps below, you'll configure:
 1. **Claude auth**: OAuth token or Anthropic API key
 2. **Discord bot token**: from the Developer Portal
 3. **Discord Guild ID + Channel ID**: copied from Discord
-4. **GitHub PAT** *(optional)*: for workers that clone private repos
-5. **OpenAI-compatible API key** *(optional)*: for open-weight models
+4. **GitHub PAT** _(optional)_: for workers that clone private repos
+5. **OpenAI-compatible API key** _(optional)_: for open-weight models
 
 Each step explains how to create these if you don't have them yet.
 
@@ -41,35 +41,35 @@ NanoClaw separates generic code from per-installation configuration. The repo co
 
 **What goes in the repo** (`nanoclaw/`):
 
-| Directory | Purpose |
-|-|-|
-| `src/` | Host process (message routing, container lifecycle, IPC) |
-| `container/` | Dockerfile, agent runner, MCP tools, skills |
-| `instructions/` | Agent instructions — global, master, and worker (assembled at startup) |
-| `worker-profiles/` | Example worker profiles — templates you copy and customize |
-| `tools/` | Utility scripts (status dashboard, shims, injection helpers) |
-| `docs/` | Architecture docs, setup guides, testing procedures |
-| `.env.example` | Template for required environment variables |
+| Directory          | Purpose                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `src/`             | Host process (message routing, container lifecycle, IPC)               |
+| `container/`       | Dockerfile, agent runner, MCP tools, skills                            |
+| `instructions/`    | Agent instructions — global, master, and worker (assembled at startup) |
+| `worker-profiles/` | Example worker profiles — templates you copy and customize             |
+| `tools/`           | Utility scripts (status dashboard, shims, injection helpers)           |
+| `docs/`            | Architecture docs, setup guides, testing procedures                    |
+| `.env.example`     | Template for required environment variables                            |
 
 **What goes in user config** (`~/.config/nanoclaw/`):
 
-| Path | Purpose |
-|-|-|
-| `Dockerfile` | Personal container image layer — databases, test tools, CLI tools (optional) |
-| `worker-profiles/default.json` | Your worker profile — repos to clone, credential mounts, tools to install |
-| `worker-profiles/init.sh` | Your init script — runs inside each container at boot |
-| `instructions/global.md` | Personal instructions for all agents (beads, code conventions, etc.) |
-| `instructions/master.md` | Personal master-only instructions (mounts, GPU workflow, etc.) |
-| `instructions/worker.md` | Personal worker-only instructions (mount map, repos, network) |
+| Path                           | Purpose                                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| `Dockerfile`                   | Personal container image layer — databases, test tools, CLI tools (optional) |
+| `worker-profiles/default.json` | Your worker profile — repos to clone, credential mounts, tools to install    |
+| `worker-profiles/init.sh`      | Your init script — runs inside each container at boot                        |
+| `instructions/global.md`       | Personal instructions for all agents (beads, code conventions, etc.)         |
+| `instructions/master.md`       | Personal master-only instructions (mounts, GPU workflow, etc.)               |
+| `instructions/worker.md`       | Personal worker-only instructions (mount map, repos, network)                |
 
 **Other per-installation state** (also outside the repo):
 
-| Path | Purpose |
-|-|-|
-| `.env` | Secrets and tunables (bot tokens, guild IDs, backend config, container limits) |
-| `data/` | Runtime state — SQLite database, session data, usage metrics (gitignored) |
+| Path      | Purpose                                                                                |
+| --------- | -------------------------------------------------------------------------------------- |
+| `.env`    | Secrets and tunables (bot tokens, guild IDs, backend config, container limits)         |
+| `data/`   | Runtime state — SQLite database, session data, usage metrics (gitignored)              |
 | `groups/` | Agent workspaces — assembled CLAUDE.md, cloned repos, uncommitted changes (gitignored) |
-| `logs/` | Application logs (gitignored) |
+| `logs/`   | Application logs (gitignored)                                                          |
 
 The setup steps below walk through creating your user config from the repo's examples. When you later update NanoClaw (pull new code), your `~/.config/nanoclaw/` files are untouched — only the repo-side defaults change, and you can merge those into your config as needed. See the [personal config guide](personal-config.md) for a detailed walkthrough of each config file, and [`examples/personal-config/`](../../examples/personal-config/) for a complete reference example.
 
@@ -156,6 +156,7 @@ mkdir -p ~/.config/nanoclaw/instructions
 ```
 
 The final CLAUDE.md for each agent is assembled at startup:
+
 1. `instructions/global.md` (repo — shared base for all agents)
 2. `instructions/master.md` or `instructions/worker.md` (repo — role-specific)
 3. `~/.config/nanoclaw/instructions/global.md` (personal — all agents)
@@ -196,6 +197,7 @@ create a worker called test-worker
 ```
 
 You should see:
+
 1. The master agent acknowledges the request
 2. A new `#test-worker` channel appears in the server
 3. Sending a message in `#test-worker` spawns a container and the worker responds
@@ -204,41 +206,47 @@ You should see:
 
 When NanoClaw restarts (systemd restart, host reboot, crash):
 
-| What | Survives restart? | Survives destroy? | Why |
-|-|-|-|-|
-| Discord channels | ✅ | ❌ (deleted) | Server-side |
-| Registered groups (SQLite) | ✅ | ❌ (deleted) | On-disk database |
-| Worker repos + code changes | ✅ | ✅ (kept for resume) | Bind-mounted at `groups/{worker}/` |
-| SDK session state (`.claude/`) | ✅ | ❌ (deleted) | Bind-mounted at `data/sessions/{worker}/.claude/` |
-| Running containers | ❌ | ❌ | `--rm` flag — auto-removed on exit |
-| Installed packages | ❌ | ❌ | Rebuilt by `init.sh` on next spawn |
+| What                           | Survives restart? | Survives destroy?    | Why                                               |
+| ------------------------------ | ----------------- | -------------------- | ------------------------------------------------- |
+| Discord channels               | ✅                | ❌ (deleted)         | Server-side                                       |
+| Registered groups (SQLite)     | ✅                | ❌ (deleted)         | On-disk database                                  |
+| Worker repos + code changes    | ✅                | ✅ (kept for resume) | Bind-mounted at `groups/{worker}/`                |
+| SDK session state (`.claude/`) | ✅                | ❌ (deleted)         | Bind-mounted at `data/sessions/{worker}/.claude/` |
+| Running containers             | ❌                | ❌                   | `--rm` flag — auto-removed on exit                |
+| Installed packages             | ❌                | ❌                   | Rebuilt by `init.sh` on next spawn                |
 
 **Recovery flow (restart):** NanoClaw loads groups from SQLite on startup. Next message to any worker spawns a fresh container. `init.sh` runs but skips already-cloned repos.
 
-**Recovery flow (destroy + recreate):** Workspace is preserved on disk. When `create_worker` is called with the same name, it detects the leftover workspace and asks whether to "resume" (keep repos/code, fresh SDK session) or "fresh" (wipe everything). SDK session state is always cleared on create to prevent stale state from crashing the new worker.
+**Recovery flow (destroy + recreate):** Workspace is preserved on disk. When `ncf create` is called with the same name, it detects the leftover workspace and asks whether to "resume" (keep repos/code, fresh SDK session) or "fresh" (wipe everything). SDK session state is always cleared on create to prevent stale state from crashing the new worker.
 
 ## Troubleshooting
 
 **Worker channel created but no response to messages:**
+
 - Check `requires_trigger` — workers should have `requires_trigger = 0`
 - Check logs: `tail -f logs/nanoclaw.log`
 
-**"create_worker: missing required fields":**
+**"ncf create: missing required fields":**
+
 - `DISCORD_GUILD_ID` isn't reaching the container. Verify it's in `.env` and that `container-runner.ts` forwards it.
 
-**Agent doesn't know about create_worker tool:**
+**Agent doesn't know about ncf commands:**
+
 - Stale cached source. Kill the worker container (agent-runner auto-syncs by mtime on next spawn).
 
 **Container builds don't pick up source changes:**
+
 - Docker caches COPY layers. Use `./container/build.sh` (or `docker build --no-cache`) when `container/` changes.
 - Agent-runner source auto-syncs by mtime — kill the container and message the worker again.
 
 **Repos fail to clone (403 or 404):**
+
 - Check that `NANOCLAW_GITHUB_TOKEN_PATH` is set in the systemd service and points to a valid token file.
 - The token needs `repo` scope for private repos. Classic PATs with `repo` scope work across all orgs.
 - Fine-grained PATs need per-org approval — use classic PATs for simplicity.
 - Verify: `docker exec <container> bash -c 'echo $GITHUB_TOKEN | head -c 10'`
 
 **Bot can't create channels:**
+
 - Verify the bot has `Manage Channels` permission in the Discord server.
 - Check the bot's role in Server Settings → Roles.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -355,11 +355,11 @@ docker logs $(docker ps -q --filter name=test-e2e) 2>&1 | tail -50
 
 ## Common Failures
 
-| Symptom                                  | Likely cause                                                | Fix                                                        |
-| ---------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
-| Worker channel created, no response      | `requires_trigger` is 1                                     | Check SQLite, should be 0 for workers                      |
-| "create_worker: missing required fields" | `DISCORD_GUILD_ID` not in container env                     | Check `.env` and container-runner.ts                       |
-| Agent doesn't know about MCP tools       | Agent-runner auto-sync failed or container hasn't restarted | Kill container, message worker again (auto-syncs by mtime) |
-| Container builds don't pick up changes   | Docker layer caching                                        | `./container/build.sh` (uses `--no-cache`)                 |
-| Worker stuck in crash loop               | Stale session state                                         | Delete `.claude/` for that worker, restart                 |
-| Shim returns 500                         | Neuralwatt API key invalid or model not found               | Check your Neuralwatt API key file, test with curl         |
+| Symptom                                | Likely cause                                                | Fix                                                        |
+| -------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| Worker channel created, no response    | `requires_trigger` is 1                                     | Check SQLite, should be 0 for workers                      |
+| "ncf create: missing required fields"  | `DISCORD_GUILD_ID` not in container env                     | Check `.env` and container-runner.ts                       |
+| Agent doesn't know about MCP tools     | Agent-runner auto-sync failed or container hasn't restarted | Kill container, message worker again (auto-syncs by mtime) |
+| Container builds don't pick up changes | Docker layer caching                                        | `./container/build.sh` (uses `--no-cache`)                 |
+| Worker stuck in crash loop             | Stale session state                                         | Delete `.claude/` for that worker, restart                 |
+| Shim returns 500                       | Neuralwatt API key invalid or model not found               | Check your Neuralwatt API key file, test with curl         |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,216 @@
+# ncf CLI Reference
+
+The `ncf` (NanoClaw Fleet) CLI is the unified tool for managing workers, containers, and debugging. Works from both the host machine and inside containers.
+
+## Installation
+
+```bash
+# From project root
+npx tsx src/cli.ts <command>
+
+# Or add alias
+alias ncf='npx tsx /path/to/nanoclaw-fleet/src/cli.ts'
+```
+
+## Commands
+
+### Status
+
+```bash
+ncf status [--json]
+```
+
+Show all workers, containers, backends, and usage stats.
+
+**Output fields:**
+
+- `folder` — Group folder name (e.g., `discord_main`)
+- `name` — Display name
+- `jid` — Discord channel ID
+- `backend` — `anthropic` or `neuralwatt`
+- `model` — Model ID
+- `container` — Running container name or `null`
+- `requests` — Total requests
+- `tokens` — Total tokens
+- `energyWh` — Energy usage (Neuralwatt only)
+
+### Create
+
+```bash
+ncf create <name> [--backend <b>] [--model <m>] [--trigger <t>]
+```
+
+Create a new worker (Discord channel + workspace). Container spawns on first message.
+
+**Options:**
+
+- `--backend` — `anthropic` (default) or `neuralwatt`
+- `--model` — Model ID for neuralwatt (e.g., `moonshotai/Kimi-K2.5`)
+- `--trigger` — Trigger pattern (default: `@Andy`)
+
+### Destroy
+
+```bash
+ncf destroy <worker>
+```
+
+Tear down a worker: delete Discord channel, remove registration, clear session state. Workspace preserved.
+
+### Switch
+
+```bash
+ncf switch <worker> <backend> [model]
+```
+
+Switch a worker's backend or model. Neuralwatt-to-Neuralwatt switches are instant; cross-backend switches restart the container.
+
+**Examples:**
+
+```bash
+ncf switch test-worker neuralwatt moonshotai/Kimi-K2.5
+ncf switch test-worker anthropic
+```
+
+### Restart
+
+```bash
+ncf restart <worker> [--fresh]
+```
+
+Restart a worker's container. Use `--fresh` to clear session history first.
+
+**Use cases:**
+
+- `ncf restart main` — Restart master container (picks up code changes)
+- `ncf restart main --fresh` — Fresh start, clears `.claude/` session state
+- `ncf restart worker-name` — Restart a worker container
+
+### Rebuild
+
+```bash
+ncf rebuild [worker]
+```
+
+Rebuild the container image. Required after `Dockerfile` or `init.sh` changes.
+
+**Note:** Agent-runner source auto-syncs by mtime on each container spawn — no rebuild needed for `container/agent-runner/src/` changes.
+
+### Logs
+
+```bash
+ncf logs <worker> [n] [--cache|--slow|--follow|--json]
+```
+
+Show per-worker audit logs (turns).
+
+**Options:**
+
+- `n` — Number of entries (default: 20)
+- `--cache` — Show only cache hits
+- `--slow` — Show only slow requests (>5s)
+- `--follow` — Follow container logs in real-time
+- `--json` — JSON output
+
+### Session
+
+```bash
+ncf session <worker> [lines] [--json]
+```
+
+Show session transcript from the SDK's JSONL file.
+
+**Options:**
+
+- `lines` — Number of lines (default: 80)
+- `--json` — JSON output
+
+### History
+
+```bash
+ncf history [--json] [--since <date>] [--limit <n>]
+```
+
+Query worker lifecycle events from `logs/worker-events.jsonl`.
+
+**Options:**
+
+- `--since` — ISO timestamp (e.g., `2026-04-06T00:00:00Z`)
+- `--limit` — Max events (default: 50)
+- `--json` — JSON output
+
+### Inject
+
+```bash
+ncf inject <channel> <message> [--wait]
+```
+
+Inject a message to any registered channel. Useful for testing and debugging.
+
+**Options:**
+
+- `--wait` — Poll logs until agent responds, then print output
+
+**Examples:**
+
+```bash
+ncf inject main "create a worker called test"
+ncf inject --wait test "what model are you?"
+ncf inject dc:1234567890 "hello"
+```
+
+### Debug
+
+```bash
+ncf debug
+```
+
+Show system state: paths, database location, running containers, proxy status, config files.
+
+## When to Use What
+
+| Task                                   | Command                                   |
+| -------------------------------------- | ----------------------------------------- |
+| Check system health                    | `ncf status`                              |
+| Create a worker                        | `ncf create <name>`                       |
+| Tear down a worker                     | `ncf destroy <name>`                      |
+| Switch a worker's model                | `ncf switch <name> neuralwatt <model>`    |
+| Restart master after code changes      | `ncf restart main`                        |
+| Fresh start for master (clear session) | `ncf restart main --fresh`                |
+| Rebuild after Dockerfile changes       | `ncf rebuild`                             |
+| Debug a worker's conversation          | `ncf session <name>`                      |
+| Check cache performance                | `ncf logs <name> --cache`                 |
+| Test via CLI                           | `ncf inject --wait <name> "test message"` |
+| System diagnostics                     | `ncf debug`                               |
+
+## Common Patterns
+
+### Testing a Worker
+
+```bash
+ncf create test-e2e --backend neuralwatt --model moonshotai/Kimi-K2.5
+ncf inject --wait test-e2e "what model are you?"
+ncf logs test-e2e --cache  # Check cache hits
+ncf destroy test-e2e
+```
+
+### Debugging Master Issues
+
+```bash
+ncf restart main --fresh   # Clear stale session
+ncf inject main "list workers"
+ncf logs main 50             # Last 50 log entries
+```
+
+### After Code Changes
+
+```bash
+# Host-side changes (src/)
+npm run build && systemctl --user restart nanoclaw
+
+# Container-side changes (container/Dockerfile)
+ncf rebuild
+
+# Agent-runner changes (container/agent-runner/src/)
+# Auto-syncs on next spawn — just restart the container
+ncf restart main
+```


### PR DESCRIPTION
## Summary

- Replace stale MCP tool references (`create_worker`, `destroy_worker`, `switch_backend`, `worker_history`) with `ncf` CLI commands across all docs
- Add `docs/reference/cli.md` with full command reference including `ncf restart main --fresh`
- Update docs index to include CLI reference link
- Fix incorrect `--tail` option in example (use positional arg `n`)

## Files Changed

- `README.md` — Update architecture description, add CLI reference to docs table
- `docs/README.md` — Add CLI reference link
- `docs/guides/setup.md` — Update troubleshooting section
- `docs/guides/testing.md` — Update error table
- `docs/architecture/container-lifecycle.md` — Update all MCP tool refs to ncf
- `docs/architecture/model-discovery.md` — Update workflow description
- `docs/reference/cli.md` — New comprehensive CLI reference

Context: PR #45 removed MCP tools in favor of `ncf` CLI. This updates the docs to match.