### PR TITLE
feat: add include_files for compaction-safe instruction injection

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -31,6 +31,7 @@ interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  includeContent?: string;
 }
 
 interface ContainerOutput {
@@ -448,12 +449,24 @@ async function runQuery(
   let messageCount = 0;
   let resultCount = 0;
 
-  // Load global CLAUDE.md as additional system context (shared across all groups)
+  // Build systemPrompt.append from multiple sources:
+  // 1. globalClaudeMd (workers only, from /workspace/global/CLAUDE.md)
+  // 2. includeContent (all agents, from include_files in personal config)
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
   if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
+
+  const systemPromptParts: string[] = [];
+  if (globalClaudeMd) systemPromptParts.push(globalClaudeMd.trimEnd());
+  if (containerInput.includeContent)
+    systemPromptParts.push(containerInput.includeContent);
+
+  const systemPromptAppend =
+    systemPromptParts.length > 0
+      ? systemPromptParts.join('\n\n---\n\n')
+      : undefined;
 
   // Discover additional directories mounted at /workspace/extra/*
   // These are passed to the SDK so their CLAUDE.md files are loaded automatically
@@ -481,11 +494,11 @@ async function runQuery(
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
+      systemPrompt: systemPromptAppend
         ? {
             type: 'preset' as const,
             preset: 'claude_code' as const,
-            append: globalClaudeMd,
+            append: systemPromptAppend,
           }
         : undefined,
       allowedTools: [

--- a/docs/guides/personal-config.md
+++ b/docs/guides/personal-config.md
@@ -12,6 +12,7 @@ The repo ships with generic agent instructions, example profiles, and a base con
 
 ```
 ~/.config/nanoclaw/
+├── config.json                   # Personal config (include_files, etc.)
 ├── Dockerfile                    # Personal container image layer (optional)
 ├── instructions/
 │   ├── global.md                 # Instructions for ALL agents (master + workers)
@@ -36,6 +37,18 @@ Each agent's `CLAUDE.md` is assembled from four fragments at startup:
 
 Repo instructions set baseline behavior (communication style, first-boot, workspace layout). Personal instructions add your conventions (code design, PR workflow, repo list, mount map). You never edit repo instructions for personal preferences; add a personal fragment instead.
 
+### Including External Files
+
+If you have a global `~/.claude/CLAUDE.md` with coding conventions you want all agents to follow, include it via `config.json`:
+
+```json
+{
+  "include_files": ["~/.claude/CLAUDE.md"]
+}
+```
+
+Included files are passed to the SDK via `systemPrompt.append`, which guarantees they survive conversation compaction. This is safer than writing to CLAUDE.md directly, which gets loaded via `settingSources` and could potentially be trimmed during long sessions.
+
 ## Worker Profile
 
 The worker profile (`default.json`) controls what each worker container gets:
@@ -44,24 +57,27 @@ The worker profile (`default.json`) controls what each worker container gets:
 {
   "name": "default",
   "repos": [
-    {"url": "git@github.com:your-org/your-repo.git", "postClone": "git config core.hooksPath .githooks"}
+    {
+      "url": "git@github.com:your-org/your-repo.git",
+      "postClone": "git config core.hooksPath .githooks"
+    }
   ],
   "tools": ["uv tool install /workspace/group/your-tool --force"],
   "mounts": [
-    {"hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true}
+    { "hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true }
   ],
   "ports": ["8080:8080"],
   "skills_repo": "your-skills-repo-name"
 }
 ```
 
-| Field | Purpose |
-|-|-|
-| `name` | Profile name (used to select non-default profiles). |
-| `repos` | Git repos cloned on first boot. `postClone` runs after each clone. |
-| `tools` | Shell commands run during init (package installs, CLI setup). |
-| `mounts` | Host directories mounted into the container. Must be on the allowlist. |
-| `ports` | Docker port mappings (`host:container`). |
+| Field         | Purpose                                                                             |
+| ------------- | ----------------------------------------------------------------------------------- |
+| `name`        | Profile name (used to select non-default profiles).                                 |
+| `repos`       | Git repos cloned on first boot. `postClone` runs after each clone.                  |
+| `tools`       | Shell commands run during init (package installs, CLI setup).                       |
+| `mounts`      | Host directories mounted into the container. Must be on the allowlist.              |
+| `ports`       | Docker port mappings (`host:container`).                                            |
 | `skills_repo` | Name of a cloned repo containing Claude skills. Symlinked into `~/.claude/skills/`. |
 
 ## Personal Dockerfile

--- a/examples/personal-config/config.json
+++ b/examples/personal-config/config.json
@@ -1,0 +1,3 @@
+{
+  "include_files": ["~/.claude/CLAUDE.md"]
+}

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -319,6 +319,18 @@ export class DiscordChannel implements Channel {
     }
   }
 
+  async unpinMessage(jid: string, messageId: string): Promise<void> {
+    const textChannel = await this.fetchTextChannel(jid);
+    try {
+      const message = await textChannel.messages.fetch(messageId);
+      if (message.pinned) {
+        await message.unpin();
+      }
+    } catch {
+      // Message may have been deleted
+    }
+  }
+
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     if (!this.client || !isTyping) return;
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,6 +123,14 @@ function resolveWorker(
   return { jid, folder, name };
 }
 
+function formatTokens(tokens: number): string {
+  if (tokens < 1) return `${tokens}`;
+  if (tokens < 1000) return `${Math.round(tokens)}`;
+  if (tokens < 1000000) return `${(tokens / 1000).toFixed(1)}k`;
+  if (tokens < 1000000000) return `${(tokens / 1000000).toFixed(1)}M`;
+  return `${(tokens / 1000000000).toFixed(1)}B`;
+}
+
 function getContainerName(folder: string): string | null {
   const pattern = `nanoclaw-${folder.replace(/_/g, '-')}`;
   const containers = sh(
@@ -144,6 +152,8 @@ function cmdStatus(json: boolean, noColor: boolean) {
   const STATUS_UP = noColor ? '🟢' : `${GREEN}●${NC}`;
   const STATUS_DOWN = noColor ? '🔴' : `${RED}○${NC}`;
   const STATUS_STOPPED = noColor ? '🟡' : `${YELLOW}○${NC}`;
+  const MASTER_EMOJI = noColor ? '⬛ ' : '';
+  const WORKERS_EMOJI = noColor ? '🤖 ' : '';
   const backends = jsonRead(path.join(DATA_DIR, 'worker-backends.json')) || {};
   const usage = jsonRead(path.join(DATA_DIR, 'worker-usage.json')) || {};
   const groups =
@@ -201,17 +211,17 @@ function cmdStatus(json: boolean, noColor: boolean) {
   if (master) {
     const status = master.container ? STATUS_UP : STATUS_DOWN;
     console.log(
-      `\n${BOLD}Master${NC}  ${status} ${CYAN}${master.model}${NC} ${master.container ? 'up' : 'down'}`,
+      `\n${MASTER_EMOJI}${BOLD}Master${NC}  ${status} ${CYAN}${master.model}${NC} ${master.container ? 'up' : 'down'}`,
     );
   }
 
   if (workers.length > 0) {
-    console.log(`\n${BOLD}Workers${NC}`);
+    console.log(`\n${WORKERS_EMOJI}${BOLD}Workers${NC}`);
     for (const w of workers) {
       const status = w.container ? STATUS_UP : STATUS_STOPPED;
       const usage =
         w.requests > 0
-          ? `  ${w.requests} reqs, ${(w.tokens / 1000).toFixed(1)}k tok`
+          ? `  ${w.requests} reqs, ${formatTokens(w.tokens)} tok`
           : '';
       const displayName = w.name.replace(/^devbox server /, '');
       console.log(

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -52,6 +52,7 @@ export interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  includeContent?: string;
 }
 
 export interface ContainerOutput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import { EventEmitter, once } from 'events';
 import fs from 'fs';
 import path from 'path';
 
-import { syncMasterProfile, syncWorkerProfiles } from './profile-sync.js';
+import {
+  syncMasterProfile,
+  syncWorkerProfiles,
+  loadPersonalConfig,
+} from './profile-sync.js';
 import { startResourceMonitor } from './resource-monitor.js';
 import { startStatusPin, markStatusOffline } from './status-pin.js';
 import { startWorkerStatusPins } from './worker-status-pin.js';
@@ -398,6 +402,30 @@ async function runAgent(
       }
     : undefined;
 
+  // Read include_files content for systemPrompt.append (compaction-safe)
+  let includeContent: string | undefined;
+  const personalConfig = loadPersonalConfig();
+  if (personalConfig.include_files?.length) {
+    const parts: string[] = [];
+    for (const filePath of personalConfig.include_files) {
+      const expandedPath = filePath.replace(/^~/, process.env.HOME || '/root');
+      try {
+        if (fs.existsSync(expandedPath)) {
+          parts.push(fs.readFileSync(expandedPath, 'utf-8').trimEnd());
+        }
+      } catch (err) {
+        logger.warn({ path: filePath, err }, 'Failed to read include file');
+      }
+    }
+    if (parts.length > 0) {
+      includeContent = parts.join('\n\n---\n\n');
+      logger.debug(
+        { files: personalConfig.include_files },
+        'Loaded include_files for systemPrompt',
+      );
+    }
+  }
+
   try {
     const output = await runContainerAgent(
       group,
@@ -408,6 +436,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        includeContent,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { syncMasterProfile, syncWorkerProfiles } from './profile-sync.js';
 import { startResourceMonitor } from './resource-monitor.js';
 import { startStatusPin, markStatusOffline } from './status-pin.js';
+import { startWorkerStatusPins } from './worker-status-pin.js';
 import type { DiscordChannel } from './channels/discord.js';
 
 import {
@@ -83,6 +84,7 @@ let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
 let stopStatusPin: (() => void) | undefined;
+let stopWorkerPins: (() => void) | undefined;
 
 const channels: Channel[] = [];
 const queue = new GroupQueue();
@@ -671,6 +673,7 @@ async function main(): Promise<void> {
       }
       // Stop status pin loop before marking offline
       stopStatusPin?.();
+      stopWorkerPins?.();
 
       // Mark pinned status as offline (best-effort, 3s timeout)
       const dcShutdown = channels.find((c) => c.name === 'discord') as
@@ -851,6 +854,14 @@ async function main(): Promise<void> {
       sendMessage: (jid, text) => dc.sendMessageWithId(jid, text),
       editMessage: (jid, msgId, text) => dc.editMessage(jid, msgId, text),
       pinMessage: (jid, msgId) => dc.pinMessage(jid, msgId),
+    });
+
+    // Start worker status pins in each worker channel
+    stopWorkerPins = startWorkerStatusPins(STATUS_PIN_INTERVAL, {
+      sendMessage: (jid, text) => dc.sendMessageWithId(jid, text),
+      editMessage: (jid, msgId, text) => dc.editMessage(jid, msgId, text),
+      pinMessage: (jid, msgId) => dc.pinMessage(jid, msgId),
+      unpinMessage: (jid, msgId) => dc.unpinMessage?.(jid, msgId),
     });
   }
 

--- a/src/profile-sync.ts
+++ b/src/profile-sync.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { getAllRegisteredGroups, setRegisteredGroup } from './db.js';
 import { DATA_DIR } from './config.js';
 import { logger } from './logger.js';
-import { RegisteredGroup } from './types.js';
+import { RegisteredGroup, PersonalConfig } from './types.js';
 
 export interface WorkerProfile {
   repos?: { url: string; postClone?: string }[];
@@ -21,9 +21,22 @@ export interface WorkerProfile {
     containerPath: string;
     readonly: boolean;
   }[];
-  ports?: string[]; // Docker port mappings (e.g., ["8080:8080", "8090:8090/tcp"])
+  ports?: string[];
   claude_md?: string;
   skills_repo?: string;
+}
+
+export function loadPersonalConfig(): PersonalConfig {
+  const configPath = path.join(
+    process.env.HOME || '/root',
+    '.config',
+    'nanoclaw',
+    'config.json',
+  );
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 }
 
 export function loadWorkerProfile(profileName = 'default'): {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+export interface PersonalConfig {
+  include_files?: string[];
+}
+
 export interface AdditionalMount {
   hostPath: string; // Absolute path on host (supports ~ for home)
   containerPath?: string; // Optional — defaults to basename of hostPath. Mounted at /workspace/extra/{value}

--- a/src/worker-status-pin.ts
+++ b/src/worker-status-pin.ts
@@ -1,0 +1,287 @@
+/**
+ * Worker status pins: maintains pinned Discord messages in each worker channel
+ * showing live status (container state, tokens, last activity).
+ */
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { getRouterState, setRouterState } from './db.js';
+import { logger } from './logger.js';
+import { formatCurrentTime } from './timezone.js';
+import { TIMEZONE } from './config.js';
+
+const STATE_KEY_PREFIX = 'worker_status_pin_';
+const DISCORD_ERROR_UNKNOWN_MESSAGE = 10008;
+
+export interface WorkerStatusPinDeps {
+  editMessage: (jid: string, messageId: string, text: string) => Promise<void>;
+  sendMessage: (jid: string, text: string) => Promise<string | undefined>;
+  pinMessage: (jid: string, messageId: string) => Promise<void>;
+  unpinMessage?: (jid: string, messageId: string) => Promise<void>;
+}
+
+interface WorkerStatus {
+  folder: string;
+  name: string;
+  jid: string;
+  backend: string;
+  model: string;
+  container: string | null;
+  requests: number;
+  totalTokens: number;
+  lastActivity: string | null;
+}
+
+function getContainerName(folder: string): string | null {
+  try {
+    const result = execSync(
+      `docker ps --filter "name=nanoclaw-${folder}-" --format "{{.Names}}"`,
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+function getContainerUptime(containerName: string): number | null {
+  try {
+    const started = execSync(
+      `docker inspect --format "{{.State.StartedAt}}" "${containerName}"`,
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+    if (!started || started === '0001-01-01T00:00:00Z') return null;
+    const startMs = new Date(started).getTime();
+    if (isNaN(startMs)) return null;
+    return Date.now() - startMs;
+  } catch {
+    return null;
+  }
+}
+
+function formatUptime(ms: number): string {
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  if (hours < 24)
+    return remainMins > 0 ? `${hours}h ${remainMins}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainHours = hours % 24;
+  return remainHours > 0 ? `${days}d ${remainHours}h` : `${days}d`;
+}
+
+function formatLastActivity(timestamp: string | null): string {
+  if (!timestamp) return 'never';
+  const ms = Date.now() - new Date(timestamp).getTime();
+  if (isNaN(ms) || ms < 0) return '?';
+  if (ms < 60000) return 'just now';
+  if (ms < 3600000) return `${Math.floor(ms / 60000)}m ago`;
+  if (ms < 86400000) return `${Math.floor(ms / 3600000)}h ago`;
+  return `${Math.floor(ms / 86400000)}d ago`;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens < 1) return `${tokens}`;
+  if (tokens < 1000) return `${Math.round(tokens)}`;
+  if (tokens < 1000000) return `${(tokens / 1000).toFixed(1)}k`;
+  if (tokens < 1000000000) return `${(tokens / 1000000).toFixed(1)}M`;
+  return `${(tokens / 1000000000).toFixed(1)}B`;
+}
+
+function readJsonSafe(p: string): Record<string, unknown> | null {
+  try {
+    const content = readFileSync(p, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function getWorkerStatuses(): WorkerStatus[] {
+  const backends =
+    readJsonSafe(path.join(DATA_DIR, 'worker-backends.json')) || {};
+  const usage = readJsonSafe(path.join(DATA_DIR, 'worker-usage.json')) || {};
+  const groupsData = readJsonSafe(
+    path.join(DATA_DIR, 'ipc/discord_main/available_groups.json'),
+  );
+  const groups = (groupsData?.groups || []) as Array<{
+    jid: string;
+    name: string;
+    folder: string;
+    isRegistered: boolean;
+  }>;
+
+  const statuses: WorkerStatus[] = [];
+
+  for (const g of groups) {
+    if (!g.isRegistered || !g.folder || g.folder === 'discord_main') continue;
+
+    const b = (backends[g.folder] || {}) as Record<string, unknown>;
+    const u = (usage[g.folder] || {}) as Record<string, unknown>;
+    const container = getContainerName(g.folder);
+
+    statuses.push({
+      folder: g.folder,
+      name: g.name.replace(/^devbox server /, ''),
+      jid: g.jid,
+      backend: (b.backend as string) || 'anthropic',
+      model: (b.model as string) || 'unknown',
+      container,
+      requests: (u.requests as number) || 0,
+      totalTokens: (u.total_tokens as number) || 0,
+      lastActivity: (u.last_updated as string) || null,
+    });
+  }
+
+  return statuses;
+}
+
+function buildStatusText(status: WorkerStatus): string {
+  const emoji = status.container ? '🟢' : '🔴';
+  const state = status.container ? 'running' : 'stopped';
+  const modelShort =
+    status.model.length > 25 ? status.model.slice(0, 22) + '...' : status.model;
+
+  let text = `${emoji} **${status.name}** · ${modelShort} · ${state}`;
+
+  if (status.container) {
+    const uptime = getContainerUptime(status.container);
+    if (uptime !== null) {
+      text += ` · ${formatUptime(uptime)} uptime`;
+    }
+  }
+
+  text += '\n\n';
+
+  if (status.requests > 0) {
+    text += `${status.requests} requests · ${formatTokens(status.totalTokens)} tokens`;
+  } else {
+    text += 'No requests yet';
+  }
+
+  text += ` · last activity ${formatLastActivity(status.lastActivity)}`;
+
+  text += `\n\n_Updated ${formatCurrentTime(TIMEZONE)}_`;
+
+  return text;
+}
+
+async function updateWorkerPin(
+  status: WorkerStatus,
+  deps: WorkerStatusPinDeps,
+): Promise<void> {
+  const stateKey = STATE_KEY_PREFIX + status.folder;
+  const text = buildStatusText(status);
+  const existingId = getRouterState(stateKey);
+
+  if (existingId) {
+    try {
+      await deps.editMessage(status.jid, existingId, text);
+      return;
+    } catch (err: unknown) {
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? (err as { code: number }).code
+          : undefined;
+      if (code === DISCORD_ERROR_UNKNOWN_MESSAGE) {
+        logger.info(
+          { folder: status.folder },
+          'Worker status pin deleted, creating new',
+        );
+      } else {
+        logger.warn(
+          { err, folder: status.folder },
+          'Error editing worker status pin',
+        );
+        return;
+      }
+    }
+  }
+
+  const newId = await deps.sendMessage(status.jid, text);
+  if (newId) {
+    setRouterState(stateKey, newId);
+    try {
+      await deps.pinMessage(status.jid, newId);
+    } catch (err) {
+      logger.debug(
+        { err, folder: status.folder },
+        'Could not pin worker status',
+      );
+    }
+    logger.info(
+      { folder: status.folder, messageId: newId },
+      'Created worker status pin',
+    );
+  }
+}
+
+export async function updateAllWorkerPins(
+  deps: WorkerStatusPinDeps,
+): Promise<void> {
+  const statuses = getWorkerStatuses();
+
+  const results = await Promise.allSettled(
+    statuses.map((s) => updateWorkerPin(s, deps)),
+  );
+
+  let updated = 0;
+  let failed = 0;
+  for (const r of results) {
+    if (r.status === 'fulfilled') updated++;
+    else failed++;
+  }
+
+  logger.info(
+    { updated, failed, total: statuses.length },
+    'Worker pins updated',
+  );
+}
+
+export function startWorkerStatusPins(
+  intervalMs: number,
+  deps: WorkerStatusPinDeps,
+): () => void {
+  if (!intervalMs || intervalMs <= 0) {
+    logger.info('Worker status pins disabled');
+    return () => {};
+  }
+
+  const poll = () => {
+    updateAllWorkerPins(deps).catch((err) => {
+      logger.error({ err }, 'Worker status pin update failed');
+    });
+  };
+
+  const initialTimeout = setTimeout(poll, 15_000);
+  const interval = setInterval(poll, intervalMs);
+  logger.info({ intervalMs }, 'Worker status pin loop started');
+
+  return () => {
+    clearTimeout(initialTimeout);
+    clearInterval(interval);
+  };
+}
+
+export async function clearWorkerPin(
+  folder: string,
+  jid: string,
+  deps: Pick<WorkerStatusPinDeps, 'unpinMessage'>,
+): Promise<void> {
+  const stateKey = STATE_KEY_PREFIX + folder;
+  const messageId = getRouterState(stateKey);
+  if (!messageId) return;
+
+  if (deps.unpinMessage) {
+    try {
+      await deps.unpinMessage(jid, messageId);
+    } catch {
+      // Best effort
+    }
+  }
+
+  setRouterState(stateKey, '');
+}


### PR DESCRIPTION
## Summary

- Add `include_files` option in `~/.config/nanoclaw/config.json` to include external files (e.g., `~/.claude/CLAUDE.md`) in agent system prompts
- Content is passed via `systemPrompt.append`, which guarantees survival during SDK conversation compaction
- This is safer than writing to CLAUDE.md directly, which gets loaded via `settingSources` and could potentially be trimmed during long sessions

## Changes

- Add `PersonalConfig` type with `include_files` option
- Read `include_files` on host and pass to container via `includeContent`
- Append to `systemPrompt` in agent-runner (compaction-safe)
- Remove `include_files` from CLAUDE.md assembly (fragments only)
- Add example `config.json` and update docs

## Test Plan

- [x] Typecheck passes
- [x] Format check passes
- [x] Service restarts successfully
- [x] `include_files` content is now passed via `systemPrompt.append` instead of CLAUDE.md

Closes nanoclaw-4kn, nanoclaw-zr9