### PR TITLE
fix: add KillMode=process to speed up systemctl restart

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -243,6 +243,7 @@ ExecStart=${nodePath} ${projectRoot}/dist/index.js
 WorkingDirectory=${projectRoot}
 Restart=always
 RestartSec=5
+KillMode=process
 Environment=HOME=${homeDir}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
 StandardOutput=append:${projectRoot}/logs/nanoclaw.log

--- a/systemd/nanoclaw.service
+++ b/systemd/nanoclaw.service
@@ -9,6 +9,7 @@ WorkingDirectory={{PROJECT_ROOT}}
 ExecStart={{NODE_PATH}} {{PROJECT_ROOT}}/dist/index.js
 Restart=always
 RestartSec=5
+KillMode=process
 
 Environment=HOME={{HOME}}
 Environment=PATH={{HOME}}/.local/bin:/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
## Summary

- Systemd restart was taking 90s+ due to docker child processes remaining in the cgroup after the main Node.js process exited
- Adding `KillMode=process` tells systemd to only kill the main process, reducing restart time to ~1.5s

## Test plan

- [x] Manual test on devbox: restart time reduced from 90s+ to 1.5s
- [x] Service still functions correctly after restart