### PR TITLE
feat: cross-layer trace IDs, stderr archival, compaction-safe instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,22 @@ jq 'select(.msg == "Container first output" and .startupMs > 10000)' logs/nanocl
 jq 'select(.level >= 50)' logs/nanoclaw.jsonl
 ```
 
+**Trace IDs**: Every user message gets a trace ID (`t-<timestamp>-<hex>`) that propagates from host → container → agent-runner logs. Use it to follow a single request across all layers:
+
+```bash
+# Find all host events for a trace
+jq 'select(.traceId == "t-1775854357638-9475")' logs/nanoclaw.5.jsonl
+
+# Search across host logs AND container stderr
+grep "t-1775854357638-9475" logs/nanoclaw.*.jsonl logs/workers/*/stderr-*.log
+
+# Find the trace ID for a recent message (look for "Processing messages")
+jq 'select(.msg == "Processing messages") | {traceId, group, messageCount}' logs/nanoclaw.5.jsonl | tail -5
+```
+
 **Container startup timing**: `Container first output` log entries include `startupMs` (spawn to first SDK output). The entrypoint's detailed `_profile` steps (init.sh, tsc, etc.) are logged at DEBUG level on stderr. View with `docker logs <container-name>`.
+
+**Container stderr archives** at `logs/workers/<folder>/stderr-<ts>.log` preserve agent-runner output (`[msg #N]` entries, SDK debug output, MessageStream counters) after containers exit. Last 20 files per worker are retained. These are the same logs you'd see with `docker logs` but survive container removal.
 
 **Worker event log** at `logs/worker-events.jsonl` tracks lifecycle events (created, destroyed, backend_switched, resumed). The master can query this via the `worker_history` MCP tool, or you can grep/jq it directly.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,20 @@ jq 'select(.msg == "Processing messages") | {traceId, group, messageCount}' logs
 
 **Worker event log** at `logs/worker-events.jsonl` tracks lifecycle events (created, destroyed, backend_switched, resumed). The master can query this via the `worker_history` MCP tool, or you can grep/jq it directly.
 
+**Inspecting API payloads (NW workers)**: Set `SHIM_DUMP=1` on the shim to write full API requests to `/tmp/shim-dump-<folder>-<ts>.json`. Useful for verifying what system prompt, messages, and tools actually reach the provider.
+
+```bash
+systemctl --user set-environment SHIM_DUMP=1
+systemctl --user restart nanoclaw-shim
+# Send a message to a NW worker, then inspect:
+python3 -c "import json; print(json.dumps(json.load(open('/tmp/shim-dump-discord_worker-1234.json')), indent=2)[:2000])"
+# Clean up:
+systemctl --user unset-environment SHIM_DUMP
+systemctl --user restart nanoclaw-shim
+```
+
+**How instructions reach the model**: Worker instructions are assembled from repo + personal fragments by profile-sync into `groups/<folder>/CLAUDE.md`. The SDK auto-discovers this file (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block with `# claudeMd` inside the user message — not in the system prompt. The `systemPrompt.append` path (global CLAUDE.md, include_files) does go into the actual system prompt. The SDK session transcript JSONL (`data/sessions/<folder>/.claude/.../*.jsonl`) does **not** capture the system prompt — use `SHIM_DUMP` or the credential proxy logs to see the full API payload.
+
 **Per-worker audit logs** track every API call at `logs/workers/<folder>/turns.jsonl`. Each entry has: model, backend, tokens (in/out/cached), latency, energy, and stop reason. Use `ncf logs` to query:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ systemctl --user unset-environment SHIM_DUMP
 systemctl --user restart nanoclaw-shim
 ```
 
-**How instructions reach the model**: Worker instructions are assembled from repo + personal fragments by profile-sync into `groups/<folder>/CLAUDE.md`. The SDK auto-discovers this file (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block with `# claudeMd` inside the user message — not in the system prompt. The `systemPrompt.append` path (global CLAUDE.md, include_files) does go into the actual system prompt. The SDK session transcript JSONL (`data/sessions/<folder>/.claude/.../*.jsonl`) does **not** capture the system prompt — use `SHIM_DUMP` or the credential proxy logs to see the full API payload.
+**How instructions reach the model**: Worker instructions are assembled from repo + personal fragments by profile-sync into `groups/<folder>/CLAUDE.md`. The agent-runner reads this file at startup and injects it into `systemPrompt.append`, which puts it in the actual system prompt sent on every API call. This survives context compaction. Global CLAUDE.md and `include_files` content take the same path. The SDK session transcript JSONL (`data/sessions/<folder>/.claude/.../*.jsonl`) does **not** capture the system prompt — use `SHIM_DUMP` to see the full API payload.
 
 **Per-worker audit logs** track every API call at `logs/workers/<folder>/turns.jsonl`. Each entry has: model, backend, tokens (in/out/cached), latency, energy, and stop reason. Use `ncf logs` to query:
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,6 +34,7 @@ interface ContainerInput {
   assistantName?: string;
   includeContent?: string;
   script?: string;
+  traceId?: string;
 }
 
 interface ContainerOutput {
@@ -139,10 +140,12 @@ function writeOutput(output: ContainerOutput): void {
 }
 
 const _processStartMs = Date.now();
+let _traceId: string | undefined;
 
 function log(message: string): void {
   const elapsed = Date.now() - _processStartMs;
-  console.error(`[agent-runner +${elapsed}ms] ${message}`);
+  const trace = _traceId ? ` ${_traceId}` : '';
+  console.error(`[agent-runner +${elapsed}ms${trace}] ${message}`);
 }
 
 function getSessionSummary(
@@ -702,6 +705,7 @@ async function main(): Promise<void> {
     } catch {
       /* may not exist */
     }
+    _traceId = containerInput.traceId;
     log(`Received input for group: ${containerInput.groupFolder}`);
   } catch (err) {
     writeOutput({

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -468,17 +468,29 @@ async function runQuery(
   let messageCount = 0;
   let resultCount = 0;
 
-  // Build systemPrompt.append from multiple sources:
-  // 1. globalClaudeMd (workers only, from /workspace/global/CLAUDE.md)
-  // 2. includeContent (all agents, from include_files in personal config)
-  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
-  let globalClaudeMd: string | undefined;
-  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
-    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  // Build systemPrompt.append from multiple sources.
+  // Everything here goes into the system prompt (sent every API call),
+  // so it survives context compaction. CLAUDE.md loaded via settingSources
+  // only appears in the first user message and is lost after compaction.
+  const systemPromptParts: string[] = [];
+
+  // 1. Per-worker CLAUDE.md (assembled by profile-sync from repo + personal instructions)
+  const workerClaudeMdPath = '/workspace/group/CLAUDE.md';
+  if (fs.existsSync(workerClaudeMdPath)) {
+    systemPromptParts.push(
+      fs.readFileSync(workerClaudeMdPath, 'utf-8').trimEnd(),
+    );
   }
 
-  const systemPromptParts: string[] = [];
-  if (globalClaudeMd) systemPromptParts.push(globalClaudeMd.trimEnd());
+  // 2. Global CLAUDE.md (workers only, shared context across all workers)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    systemPromptParts.push(
+      fs.readFileSync(globalClaudeMdPath, 'utf-8').trimEnd(),
+    );
+  }
+
+  // 3. includeContent (all agents, from include_files in personal config)
   if (containerInput.includeContent)
     systemPromptParts.push(containerInput.includeContent);
 

--- a/design/observability.md
+++ b/design/observability.md
@@ -1,6 +1,6 @@
 # Unified Observability for NanoClaw Fleet
 
-Status: DRAFT
+Status: IN PROGRESS
 Author: thmtz | Created: 2026-04-10
 
 ## Problem
@@ -189,11 +189,11 @@ $ ncf trace t-1775852707-a3f --json   # same data as JSONL
 
 ## Implementation Order
 
-1. **Trace IDs.** Generate in host message handler, propagate through container input, agent-runner, shim. This unblocks everything else.
-2. **Host event log enrichment.** Add trace IDs and missing events (suppression, throbber, piping) to nanoclaw.jsonl.
-3. **Container stderr archival.** Write stderr to file on all container exits.
+1. ~~**Trace IDs.** Generate in host message handler, propagate through container input, agent-runner, shim.~~ **Done.** Format: `t-<ts>-<hex>`. Generated in host, passed via ContainerInput, included in agent-runner `[msg #N]` stderr lines.
+2. ~~**Host event log enrichment.** Add trace IDs and missing events (suppression, throbber, piping) to nanoclaw.jsonl.~~ **Done.** Added trace IDs to all message-path log entries. New events: `Agent output` (with `suppressed` flag), `Message sent to channel`, `Piped messages to active container`.
+3. ~~**Container stderr archival.** Write stderr to file on all container exits.~~ **Done.** Written to `logs/workers/<folder>/stderr-<ts>.log`. 20-file retention per worker.
 4. **Turn index enrichment.** Add `id`, `trace_id`, `tools_called`, `detail` pointer to turns.jsonl.
 5. **Detail files.** Add `turns/` directory with full API payloads behind `NANOCLAW_VERBOSE_LOGS`.
 6. **`ncf trace` command.** Cross-layer timeline assembly.
 
-Steps 1-3 are the foundation. Steps 4-6 build on it.
+Steps 1-3 (foundation) are complete. Steps 4-6 build on them.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -80,6 +80,10 @@ When you need a clean slate: destroy the worker, delete its session cache, and r
 
 There is no automatic "rolling update" mechanism. This is an open design area.
 
+### Observability
+
+A single user message crosses six layers (Discord → host → container → agent SDK → API → back). Every message gets a **trace ID** (`t-<ts>-<hex>`) at the host that propagates through container input and agent-runner stderr, so you can grep one ID to follow a request end-to-end. Container stderr is archived to `logs/workers/<folder>/stderr-<ts>.log` on exit. The host writes structured JSONL with trace IDs on all message-path events. See [design/observability.md](../../design/observability.md) for the full design.
+
 ## Upstream
 
 This fork tracks [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw). The upstream project provides the core channel system, container isolation, and skill architecture. This fork adds dynamic workers, dual-backend inference, model discovery, streaming, and energy tracking.

--- a/docs/guides/personal-config.md
+++ b/docs/guides/personal-config.md
@@ -37,7 +37,7 @@ Each agent's `CLAUDE.md` is assembled from four fragments at startup:
 
 Repo instructions set baseline behavior (communication style, first-boot, workspace layout). Personal instructions add your conventions (code design, PR workflow, repo list, mount map). You never edit repo instructions for personal preferences; add a personal fragment instead.
 
-**How they reach the model**: The assembled CLAUDE.md is written to `groups/<folder>/CLAUDE.md` and bind-mounted into the container at `/workspace/group/`. The SDK auto-discovers it (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block inside the user message on every API call. Files from `include_files` take a different path — they go into `systemPrompt.append`, which lands in the actual system prompt. Both survive conversation compaction.
+**How they reach the model**: The assembled CLAUDE.md is written to `groups/<folder>/CLAUDE.md` and bind-mounted into the container at `/workspace/group/`. The SDK auto-discovers it (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block inside the **first user message** of the session. On subsequent API calls, the model sees it via conversation history — but after compaction, it gets summarized and the original instructions are lost. Files from `include_files` take a different path — they go into `systemPrompt.append`, which lands in the actual system prompt and is sent on **every** API call, surviving compaction fully. Put your most critical instructions in `include_files` for durability.
 
 ### Including External Files
 

--- a/docs/guides/personal-config.md
+++ b/docs/guides/personal-config.md
@@ -37,7 +37,7 @@ Each agent's `CLAUDE.md` is assembled from four fragments at startup:
 
 Repo instructions set baseline behavior (communication style, first-boot, workspace layout). Personal instructions add your conventions (code design, PR workflow, repo list, mount map). You never edit repo instructions for personal preferences; add a personal fragment instead.
 
-**How they reach the model**: The assembled CLAUDE.md is written to `groups/<folder>/CLAUDE.md` and bind-mounted into the container at `/workspace/group/`. The SDK auto-discovers it (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block inside the **first user message** of the session. On subsequent API calls, the model sees it via conversation history — but after compaction, it gets summarized and the original instructions are lost. Files from `include_files` take a different path — they go into `systemPrompt.append`, which lands in the actual system prompt and is sent on **every** API call, surviving compaction fully. Put your most critical instructions in `include_files` for durability.
+**How they reach the model**: The assembled CLAUDE.md is read by the agent-runner at startup and injected into `systemPrompt.append`. This puts it in the actual system prompt, which is sent on **every** API call and survives context compaction. Files from `include_files` in personal config take the same path. Both are durable across compaction.
 
 ### Including External Files
 

--- a/docs/guides/personal-config.md
+++ b/docs/guides/personal-config.md
@@ -37,6 +37,8 @@ Each agent's `CLAUDE.md` is assembled from four fragments at startup:
 
 Repo instructions set baseline behavior (communication style, first-boot, workspace layout). Personal instructions add your conventions (code design, PR workflow, repo list, mount map). You never edit repo instructions for personal preferences; add a personal fragment instead.
 
+**How they reach the model**: The assembled CLAUDE.md is written to `groups/<folder>/CLAUDE.md` and bind-mounted into the container at `/workspace/group/`. The SDK auto-discovers it (via `cwd: '/workspace/group'`) and injects it as a `<system-reminder>` block inside the user message on every API call. Files from `include_files` take a different path — they go into `systemPrompt.append`, which lands in the actual system prompt. Both survive conversation compaction.
+
 ### Including External Files
 
 If you have a global `~/.claude/CLAUDE.md` with coding conventions you want all agents to follow, include it via `config.json`:

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -21,7 +21,7 @@ Host-side test tools live in `tools/`.
 | I changed...                              | Test by...                                                                          |
 | ----------------------------------------- | ----------------------------------------------------------------------------------- |
 | `src/ipc.ts` (worker lifecycle)           | Create, message, destroy, recreate with resume (scenarios 1-4, 10-11)               |
-| `src/container-runner.ts` (mounts, env)   | Create a worker, exec in, check mounts and env vars (scenarios 1, 12)               |
+| `src/container-runner.ts` (mounts, env)   | Create a worker, exec in, check mounts and env vars (scenarios 1, 12). Check trace IDs in JSONL. |
 | `container/` or `worker-profiles/`        | Rebuild image, restart, message a worker (see "After Container-Side Changes" below) |
 | `tools/anthropic-shim.ts`                 | Restart shim, curl test, message a NW worker (see "After Shim Changes" below)       |
 | `container/agent-runner/src/` (MCP tools) | Restart, message a worker, verify the tool works (auto-syncs by mtime)              |
@@ -377,6 +377,18 @@ docker logs $(docker ps -q --filter name=test-e2e) 2>&1 | tail -50
 # Enable shim debug logging (verbose request/response)
 # Set SHIM_DEBUG=1 in the shim's environment, then restart
 ```
+
+**Tracing a request end-to-end:** Every user message gets a trace ID (format: `t-<timestamp>-<hex>`) that appears in both host JSONL and container stderr. To trace a failed or slow request:
+
+```bash
+# 1. Find the trace ID from recent host logs
+jq 'select(.msg == "Processing messages")' logs/nanoclaw.5.jsonl | tail -3
+
+# 2. Follow it across all layers
+grep "t-1775854357638-9475" logs/nanoclaw.*.jsonl logs/workers/*/stderr-*.log
+```
+
+Container stderr is archived to `logs/workers/<folder>/stderr-<ts>.log` on every container exit (last 20 per worker), so trace IDs remain searchable after containers are removed.
 
 ## Common Failures
 

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -13,7 +13,7 @@ import path from 'path';
 import { logger } from './logger.js';
 import { DATA_DIR } from './config.js';
 
-const LOGS_DIR = path.join(process.cwd(), 'logs', 'workers');
+export const WORKER_LOGS_DIR = path.join(process.cwd(), 'logs', 'workers');
 
 interface TurnEntry {
   ts: string;
@@ -126,7 +126,7 @@ export function extractTurnsFromTranscript(
   }
 
   // Write to audit log
-  const dir = path.join(LOGS_DIR, groupFolder);
+  const dir = path.join(WORKER_LOGS_DIR, groupFolder);
   fs.mkdirSync(dir, { recursive: true });
   const auditFile = path.join(dir, 'turns.jsonl');
   const entries = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -54,6 +54,7 @@ export interface ContainerInput {
   assistantName?: string;
   includeContent?: string;
   script?: string;
+  traceId?: string;
 }
 
 export interface ContainerOutput {
@@ -548,6 +549,7 @@ export async function runContainerAgent(
       containerName,
       mountCount: mounts.length,
       isMain: input.isMain,
+      traceId: input.traceId,
     },
     'Spawning container agent',
   );
@@ -621,7 +623,7 @@ export async function runContainerAgent(
               firstOutputLogged = true;
               const startupMs = Date.now() - containerSpawnTime;
               logger.info(
-                { group: group.name, containerName, startupMs },
+                { group: group.name, containerName, startupMs, traceId: input.traceId },
                 'Container first output',
               );
             }
@@ -722,6 +724,20 @@ export async function runContainerAgent(
         );
       }
 
+      // Archive container stderr so [msg #N] entries and SDK debug output
+      // survive container removal. Always written (not just on error).
+      if (stderr.trim()) {
+        const stderrDir = path.join(process.cwd(), 'logs', 'workers', group.folder);
+        fs.mkdirSync(stderrDir, { recursive: true });
+        const stderrTs = new Date().toISOString().replace(/[:.]/g, '-');
+        const stderrFile = path.join(stderrDir, `stderr-${stderrTs}.log`);
+        try {
+          fs.writeFileSync(stderrFile, stderr);
+        } catch (err) {
+          logger.warn({ group: group.name, err }, 'Failed to archive container stderr');
+        }
+      }
+
       if (timedOut) {
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         const timeoutLog = path.join(logsDir, `container-${ts}.log`);
@@ -743,7 +759,7 @@ export async function runContainerAgent(
         // container being reaped after the idle period expired.
         if (hadStreamingOutput) {
           logger.info(
-            { group: group.name, containerName, duration, code },
+            { group: group.name, containerName, duration, code, traceId: input.traceId },
             'Container timed out after output (idle cleanup)',
           );
           outputChain.then(() => {
@@ -757,7 +773,7 @@ export async function runContainerAgent(
         }
 
         logger.error(
-          { group: group.name, containerName, duration, code },
+          { group: group.name, containerName, duration, code, traceId: input.traceId },
           'Container timed out with no output',
         );
 
@@ -846,6 +862,7 @@ export async function runContainerAgent(
             stderr,
             stdout,
             logFile,
+            traceId: input.traceId,
           },
           'Container exited with error',
         );
@@ -862,7 +879,7 @@ export async function runContainerAgent(
       if (onOutput) {
         outputChain.then(() => {
           logger.info(
-            { group: group.name, duration, newSessionId },
+            { group: group.name, duration, newSessionId, traceId: input.traceId },
             'Container completed (streaming mode)',
           );
           resolve({
@@ -899,6 +916,7 @@ export async function runContainerAgent(
             duration,
             status: output.status,
             hasResult: !!output.result,
+            traceId: input.traceId,
           },
           'Container completed',
         );

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -596,7 +596,7 @@ export async function runContainerAgent(
           stdout += chunk.slice(0, remaining);
           stdoutTruncated = true;
           logger.warn(
-            { group: group.name, size: stdout.length },
+            { ...traceCtx, size: stdout.length },
             'Container stdout truncated due to size limit',
           );
         } else {
@@ -638,7 +638,7 @@ export async function runContainerAgent(
             outputChain = outputChain.then(() => onOutput(parsed));
           } catch (err) {
             logger.warn(
-              { group: group.name, error: err },
+              { ...traceCtx, error: err },
               'Failed to parse streamed output chunk',
             );
           }
@@ -650,7 +650,7 @@ export async function runContainerAgent(
       const chunk = data.toString();
       const lines = chunk.trim().split('\n');
       for (const line of lines) {
-        if (line) logger.debug({ container: group.folder }, line);
+        if (line) logger.debug({ ...traceCtx, container: group.folder }, line);
         // Fire heartbeat on SDK message events — used for Discord reaction
         // throbber so users can see the agent is alive and processing.
         if (onHeartbeat && line.includes('[msg #')) {
@@ -665,7 +665,7 @@ export async function runContainerAgent(
         stderr += chunk.slice(0, remaining);
         stderrTruncated = true;
         logger.warn(
-          { group: group.name, size: stderr.length },
+          { ...traceCtx, size: stderr.length },
           'Container stderr truncated due to size limit',
         );
       } else {
@@ -687,13 +687,13 @@ export async function runContainerAgent(
     const killOnTimeout = () => {
       timedOut = true;
       logger.error(
-        { group: group.name, containerName },
+        { ...traceCtx, containerName },
         'Container timeout, stopping gracefully',
       );
       exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
         if (err) {
           logger.warn(
-            { group: group.name, containerName, err },
+            { ...traceCtx, containerName, err },
             'Graceful stop failed, force killing',
           );
           container.kill('SIGKILL');
@@ -723,7 +723,7 @@ export async function runContainerAgent(
         );
       } catch (err) {
         logger.debug(
-          { group: group.name, error: err },
+          { ...traceCtx, error: err },
           'Audit extraction failed (non-fatal)',
         );
       }
@@ -939,7 +939,7 @@ export async function runContainerAgent(
       } catch (err) {
         logger.error(
           {
-            group: group.name,
+            ...traceCtx,
             stdout,
             stderr,
             error: err,
@@ -958,7 +958,7 @@ export async function runContainerAgent(
     container.on('error', (err) => {
       clearTimeout(timeout);
       logger.error(
-        { group: group.name, containerName, error: err },
+        { ...traceCtx, containerName, error: err },
         'Container spawn error',
       );
       resolve({

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -38,6 +38,7 @@ import { RegisteredGroup } from './types.js';
 import {
   extractTurnsFromTranscript,
   getTranscriptOffset,
+  WORKER_LOGS_DIR,
 } from './audit-log.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
@@ -530,9 +531,12 @@ export async function runContainerAgent(
     group.containerConfig?.ports,
   );
 
+  // Shared log context — avoids repeating traceId on every logger call
+  const traceCtx = { group: group.name, traceId: input.traceId };
+
   logger.debug(
     {
-      group: group.name,
+      ...traceCtx,
       containerName,
       mounts: mounts.map(
         (m) =>
@@ -545,11 +549,10 @@ export async function runContainerAgent(
 
   logger.info(
     {
-      group: group.name,
+      ...traceCtx,
       containerName,
       mountCount: mounts.length,
       isMain: input.isMain,
-      traceId: input.traceId,
     },
     'Spawning container agent',
   );
@@ -623,7 +626,7 @@ export async function runContainerAgent(
               firstOutputLogged = true;
               const startupMs = Date.now() - containerSpawnTime;
               logger.info(
-                { group: group.name, containerName, startupMs, traceId: input.traceId },
+                { ...traceCtx, containerName, startupMs },
                 'Container first output',
               );
             }
@@ -725,16 +728,28 @@ export async function runContainerAgent(
       }
 
       // Archive container stderr so [msg #N] entries and SDK debug output
-      // survive container removal. Always written (not just on error).
-      if (stderr.trim()) {
-        const stderrDir = path.join(process.cwd(), 'logs', 'workers', group.folder);
+      // survive container removal.
+      if (stderr.length > 0) {
+        const stderrDir = path.join(WORKER_LOGS_DIR, group.folder);
         fs.mkdirSync(stderrDir, { recursive: true });
         const stderrTs = new Date().toISOString().replace(/[:.]/g, '-');
         const stderrFile = path.join(stderrDir, `stderr-${stderrTs}.log`);
         try {
           fs.writeFileSync(stderrFile, stderr);
+          // Retain only the last 20 stderr files per worker
+          const stderrFiles = fs
+            .readdirSync(stderrDir)
+            .filter((f) => f.startsWith('stderr-') && f.endsWith('.log'))
+            .sort();
+          const excess = stderrFiles.slice(0, -20);
+          for (const f of excess) {
+            fs.unlinkSync(path.join(stderrDir, f));
+          }
         } catch (err) {
-          logger.warn({ group: group.name, err }, 'Failed to archive container stderr');
+          logger.warn(
+            { ...traceCtx, err },
+            'Failed to archive container stderr',
+          );
         }
       }
 
@@ -759,7 +774,7 @@ export async function runContainerAgent(
         // container being reaped after the idle period expired.
         if (hadStreamingOutput) {
           logger.info(
-            { group: group.name, containerName, duration, code, traceId: input.traceId },
+            { ...traceCtx, containerName, duration, code },
             'Container timed out after output (idle cleanup)',
           );
           outputChain.then(() => {
@@ -773,7 +788,7 @@ export async function runContainerAgent(
         }
 
         logger.error(
-          { group: group.name, containerName, duration, code, traceId: input.traceId },
+          { ...traceCtx, containerName, duration, code },
           'Container timed out with no output',
         );
 
@@ -856,13 +871,12 @@ export async function runContainerAgent(
       if (code !== 0) {
         logger.error(
           {
-            group: group.name,
+            ...traceCtx,
             code,
             duration,
             stderr,
             stdout,
             logFile,
-            traceId: input.traceId,
           },
           'Container exited with error',
         );
@@ -879,7 +893,7 @@ export async function runContainerAgent(
       if (onOutput) {
         outputChain.then(() => {
           logger.info(
-            { group: group.name, duration, newSessionId, traceId: input.traceId },
+            { ...traceCtx, duration, newSessionId },
             'Container completed (streaming mode)',
           );
           resolve({
@@ -912,11 +926,10 @@ export async function runContainerAgent(
 
         logger.info(
           {
-            group: group.name,
+            ...traceCtx,
             duration,
             status: output.status,
             hasResult: !!output.result,
-            traceId: input.traceId,
           },
           'Container completed',
         );

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -44,6 +44,7 @@ import {
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const MAX_STDERR_ARCHIVES = 20;
 
 export interface ContainerInput {
   prompt: string;
@@ -741,7 +742,7 @@ export async function runContainerAgent(
             .readdirSync(stderrDir)
             .filter((f) => f.startsWith('stderr-') && f.endsWith('.log'))
             .sort();
-          const excess = stderrFiles.slice(0, -20);
+          const excess = stderrFiles.slice(0, -MAX_STDERR_ARCHIVES);
           for (const f of excess) {
             fs.unlinkSync(path.join(stderrDir, f));
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
 import { startSessionCleanup } from './session-cleanup.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { generateTraceId } from './trace.js';
 import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
@@ -408,6 +409,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
 
   const prompt = formatMessages(missedMessages, TIMEZONE);
+  const traceId = generateTraceId();
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -417,7 +419,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   saveState();
 
   logger.info(
-    { group: group.name, messageCount: missedMessages.length },
+    { group: group.name, messageCount: missedMessages.length, traceId },
     'Processing messages',
   );
 
@@ -470,18 +472,23 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             : JSON.stringify(result.result);
         // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
         const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        const suppressed = !!(text && didGroupSendMessage(group.folder));
         logger.info(
-          { group: group.name },
-          `Agent output: ${raw.slice(0, 200)}`,
+          { group: group.name, traceId, suppressed, length: text.length },
+          'Agent output',
         );
         // Clear throbber when agent produces output (works for both
         // cold boot and warm piped messages)
         clearThrobber(group.folder, channel);
         // Suppress SDK output if the agent already sent messages via send_message
         // (prevents duplicate Discord messages)
-        if (text && !didGroupSendMessage(group.folder)) {
+        if (text && !suppressed) {
           await channel.sendMessage(chatJid, text);
           outputSentToUser = true;
+          logger.info(
+            { group: group.name, traceId, length: text.length },
+            'Message sent to channel',
+          );
         }
         // Only reset idle timer on actual results, not session-update markers (result: null)
         resetIdleTimer();
@@ -496,6 +503,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       }
     },
     () => cycleThrobber(group.folder, channel),
+    traceId,
   );
 
   clearThrobber(group.folder, channel);
@@ -508,7 +516,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     // the user got their response and re-processing would send duplicates.
     if (outputSentToUser) {
       logger.warn(
-        { group: group.name },
+        { group: group.name, traceId },
         'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
       );
       return true;
@@ -517,7 +525,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     lastAgentTimestamp[chatJid] = previousCursor;
     saveState();
     logger.warn(
-      { group: group.name },
+      { group: group.name, traceId },
       'Agent error, rolled back message cursor for retry',
     );
     return false;
@@ -532,6 +540,7 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onHeartbeat?: () => void,
+  traceId?: string,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
@@ -618,6 +627,7 @@ async function runAgent(
         isMain,
         assistantName: ASSISTANT_NAME,
         includeContent,
+        traceId,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
@@ -780,14 +790,16 @@ async function startMessageLoop(): Promise<void> {
             allPending.length > 0 ? allPending : groupMessages;
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
+          const pipeTraceId = generateTraceId();
+
           if (queue.sendMessage(chatJid, formatted)) {
             // Reset the send_message suppression flag for this group.
             // Without this, if the previous message used send_message,
             // the flag stays set and suppresses direct output for all
             // subsequent piped messages in the same container session.
             clearGroupSentMessage(group.folder);
-            logger.debug(
-              { chatJid, count: messagesToSend.length },
+            logger.info(
+              { chatJid, count: messagesToSend.length, traceId: pipeTraceId },
               'Piped messages to active container',
             );
             lastAgentTimestamp[chatJid] =

--- a/src/index.ts
+++ b/src/index.ts
@@ -790,9 +790,8 @@ async function startMessageLoop(): Promise<void> {
             allPending.length > 0 ? allPending : groupMessages;
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
-          const pipeTraceId = generateTraceId();
-
           if (queue.sendMessage(chatJid, formatted)) {
+            const pipeTraceId = generateTraceId();
             // Reset the send_message suppression flag for this group.
             // Without this, if the previous message used send_message,
             // the flag stays set and suppresses direct output for all

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,0 +1,17 @@
+/**
+ * Trace ID generation for cross-layer request tracing.
+ *
+ * Every user message gets a trace ID when it enters the host. The ID propagates
+ * through container input, agent-runner logs, and IPC events so a single request
+ * can be traced end-to-end.
+ *
+ * Format: t-<timestamp-ms>-<random-hex> (e.g. t-1775852707123-a3f)
+ * Short enough to grep, unique enough to avoid collisions.
+ */
+import crypto from 'crypto';
+
+export function generateTraceId(): string {
+  const ts = Date.now();
+  const rand = crypto.randomBytes(2).toString('hex'); // 4 hex chars
+  return `t-${ts}-${rand}`;
+}


### PR DESCRIPTION
## Summary

- **Trace IDs**: Every user message gets a `t-<ts>-<hex>` ID at the host that propagates through container input and agent-runner stderr logs. Grep one ID to follow a request across all layers.
- **Container stderr archival**: Agent-runner output (`[msg #N]` entries, SDK debug) is written to `logs/workers/<folder>/stderr-<ts>.log` on every container exit. 20-file retention per worker.
- **Compaction-safe instructions**: Worker CLAUDE.md is now injected into `systemPrompt.append` (system prompt, sent every API call) instead of relying solely on SDK `settingSources` which only injects in the first user message and is lost after compaction.
- **Host event enrichment**: All message-path log entries include trace IDs. New events for suppression and message delivery.
- **Docs**: CLAUDE.md debugging section, SHIM_DUMP usage, architecture overview, testing guide, personal-config guide all updated.

## Test plan

- [x] `npm run build` clean, 353 tests pass
- [x] Trace IDs verified in live JSONL: `Processing messages` → `Spawning container agent` → `Container first output` → `Agent output`
- [x] Agent-runner stderr includes trace ID: `[agent-runner +8848ms t-1775854357638-9475] [msg #6] type=result`
- [x] SHIM_DUMP verified CLAUDE.md now in system prompt (msg[0]) not just user message
- [x] Canary phrase test: both NW and Anthropic workers respond correctly to instructions-only question