### PR TITLE
fix: surface SSE errors, enable auto-compact for NW workers

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -732,7 +732,16 @@ async function main(): Promise<void> {
   // No real secrets exist in the container environment.
   const sdkEnv: Record<string, string | undefined> = {
     ...process.env,
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW: '165000',
+    // Auto-compact: the SDK calculates the threshold from the model's context
+    // window. For NW workers routed through the shim, the SDK sees a Claude
+    // model name with a much larger window than the actual NW model (1M vs
+    // ~200k). Override the compact percentage so it triggers at a reasonable
+    // fill level for the actual model. Anthropic workers use the real model
+    // and don't need an override.
+    ...(process.env.NANOCLAW_BACKEND === 'neuralwatt' &&
+    !process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+      ? { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '16' }
+      : {}),
   };
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -383,7 +383,10 @@ function buildContainerArgs(
         neuralwattModel = config.model || null;
       }
     } catch (err) {
-      logger.warn({ err, groupFolder }, 'Failed to read worker-backends.json — defaulting to Anthropic');
+      logger.warn(
+        { err, groupFolder },
+        'Failed to read worker-backends.json — defaulting to Anthropic',
+      );
     }
 
     // Pass worker profile env vars (repos, tools, skills — not backend).

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -370,10 +370,23 @@ function buildContainerArgs(
     args.push('-e', `DISCORD_GUILD_ID=${DISCORD_GUILD_ID}`);
   }
 
-  // Pass worker profile env vars and detect backend setting (single read).
+  // Determine backend from worker-backends.json (single source of truth).
   let useNeuralwatt = false;
   let neuralwattModel: string | null = null;
   if (groupFolder) {
+    const backendsPath = path.join(DATA_DIR, WORKER_BACKENDS_FILENAME);
+    try {
+      const backends = JSON.parse(fs.readFileSync(backendsPath, 'utf-8'));
+      const config = backends[groupFolder];
+      if (config?.backend === BACKEND_NEURALWATT) {
+        useNeuralwatt = true;
+        neuralwattModel = config.model || null;
+      }
+    } catch (err) {
+      logger.warn({ err, groupFolder }, 'Failed to read worker-backends.json — defaulting to Anthropic');
+    }
+
+    // Pass worker profile env vars (repos, tools, skills — not backend).
     const workerEnvPath = path.join(
       DATA_DIR,
       'sessions',
@@ -385,31 +398,19 @@ function buildContainerArgs(
       for (const line of envContent.split('\n')) {
         if (line.trim() && !line.startsWith('#')) {
           args.push('-e', line);
-          if (
-            line.startsWith('NANOCLAW_BACKEND=') &&
-            line.includes(BACKEND_NEURALWATT)
-          ) {
-            useNeuralwatt = true;
-          }
         }
       }
     }
 
-    // For Neuralwatt workers, read model from worker-backends.json (source of truth).
-    // Global .env may have Anthropic model like "opus" which causes mismatches.
-    if (useNeuralwatt) {
-      const backendsPath = path.join(DATA_DIR, WORKER_BACKENDS_FILENAME);
-      try {
-        const backends = JSON.parse(fs.readFileSync(backendsPath, 'utf-8'));
-        neuralwattModel = backends[groupFolder]?.model || null;
-      } catch {
-        // File missing or corrupt — will fall back to env var below
-      }
-    }
+    // Always inject NANOCLAW_BACKEND so the container knows its backend.
+    args.push(
+      '-e',
+      `NANOCLAW_BACKEND=${useNeuralwatt ? BACKEND_NEURALWATT : 'anthropic'}`,
+    );
   }
 
   // Pass model to container agent.
-  // For Neuralwatt: use model from worker-backends.json (resolved above).
+  // For Neuralwatt: use model from worker-backends.json.
   // For Anthropic: use model from global .env (opus, sonnet, etc.).
   if (neuralwattModel) {
     args.push('-e', `NANOCLAW_MODEL=${neuralwattModel}`);

--- a/src/ipc.test.ts
+++ b/src/ipc.test.ts
@@ -17,42 +17,30 @@ describe('updateWorkerEnvBackend', () => {
     fs.rmSync(envDir, { recursive: true, force: true });
   });
 
-  // Regression: switch_backend only updated worker-backends.json but not
-  // worker.env, so container-runner routed to the wrong proxy on next spawn.
-  it('adds NANOCLAW_BACKEND and NANOCLAW_MODEL when switching to neuralwatt', () => {
-    fs.writeFileSync(envPath, 'WORKER_REPOS=foo\nNANOCLAW_MODEL=opus');
-    updateWorkerEnvBackend(folder, 'neuralwatt', 'zai-org/GLM-5-FP8');
-    const content = fs.readFileSync(envPath, 'utf-8');
-    expect(content).toContain('NANOCLAW_BACKEND=neuralwatt');
-    expect(content).toContain('NANOCLAW_MODEL=zai-org/GLM-5-FP8');
-    expect(content).toContain('WORKER_REPOS=foo');
-  });
-
-  it('removes NANOCLAW_BACKEND and NANOCLAW_MODEL when switching to anthropic', () => {
+  // Backend routing now comes from worker-backends.json. updateWorkerEnvBackend
+  // only strips stale NANOCLAW_BACKEND/MODEL from worker.env (legacy cleanup).
+  it('strips stale NANOCLAW_BACKEND and NANOCLAW_MODEL from worker.env', () => {
     fs.writeFileSync(
       envPath,
       'WORKER_REPOS=foo\nNANOCLAW_BACKEND=neuralwatt\nNANOCLAW_MODEL=opus',
     );
-    updateWorkerEnvBackend(folder, 'anthropic');
+    updateWorkerEnvBackend(folder, 'neuralwatt', 'zai-org/GLM-5-FP8');
     const content = fs.readFileSync(envPath, 'utf-8');
     expect(content).not.toContain('NANOCLAW_BACKEND');
-    expect(content).not.toContain('NANOCLAW_MODEL=');
+    expect(content).not.toContain('NANOCLAW_MODEL');
     expect(content).toContain('WORKER_REPOS=foo');
   });
 
-  it('replaces existing NANOCLAW_BACKEND and NANOCLAW_MODEL (no duplicates)', () => {
+  it('preserves other env vars when stripping backend', () => {
     fs.writeFileSync(
       envPath,
       'NANOCLAW_BACKEND=anthropic\nNANOCLAW_MODEL=sonnet\nOTHER=val',
     );
-    updateWorkerEnvBackend(folder, 'neuralwatt', 'zai-org/GLM-5-FP8');
+    updateWorkerEnvBackend(folder, 'anthropic');
     const content = fs.readFileSync(envPath, 'utf-8');
-    const backendMatches = content.match(/NANOCLAW_BACKEND/g);
-    const modelMatches = content.match(/NANOCLAW_MODEL=/g);
-    expect(backendMatches).toHaveLength(1);
-    expect(modelMatches).toHaveLength(1);
-    expect(content).toContain('NANOCLAW_BACKEND=neuralwatt');
-    expect(content).toContain('NANOCLAW_MODEL=zai-org/GLM-5-FP8');
+    expect(content).not.toContain('NANOCLAW_BACKEND');
+    expect(content).not.toContain('NANOCLAW_MODEL');
+    expect(content).toContain('OTHER=val');
   });
 
   it('is a no-op when worker.env does not exist', () => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -159,17 +159,16 @@ function updateWorkerBackends(
   fs.renameSync(tmpPath, backendsPath);
 }
 
-/** Update NANOCLAW_BACKEND and NANOCLAW_MODEL in worker.env so container-runner routes correctly on next spawn. */
+/** Clean stale NANOCLAW_BACKEND/MODEL from worker.env (legacy cleanup).
+ * Backend routing now comes from worker-backends.json; the container-runner
+ * injects NANOCLAW_BACKEND directly. This just strips the dead env vars. */
 export function updateWorkerEnvBackend(
   folder: string,
-  backend: InferenceBackend | string,
-  model?: string,
+  _backend: InferenceBackend | string,
+  _model?: string,
 ): void {
   const envPath = path.join(DATA_DIR, 'sessions', folder, 'worker.env');
-  if (!fs.existsSync(envPath)) {
-    logger.warn({ folder }, 'updateWorkerEnvBackend: worker.env not found');
-    return;
-  }
+  if (!fs.existsSync(envPath)) return;
   const content = fs.readFileSync(envPath, 'utf-8');
   const lines = content
     .split('\n')
@@ -177,13 +176,6 @@ export function updateWorkerEnvBackend(
       (l) =>
         !l.startsWith('NANOCLAW_BACKEND=') && !l.startsWith('NANOCLAW_MODEL='),
     );
-  if (backend === BACKEND_NEURALWATT) {
-    lines.push(`NANOCLAW_BACKEND=${BACKEND_NEURALWATT}`);
-    if (model) {
-      lines.push(`NANOCLAW_MODEL=${model}`);
-    }
-  }
-  // Preserve trailing newline if the original file had one
   const result = lines.join('\n');
   fs.writeFileSync(envPath, content.endsWith('\n') ? result + '\n' : result);
 }
@@ -1306,9 +1298,8 @@ export async function processTaskIpc(
         data.model as string | undefined,
       );
 
-      // Also update worker.env so the next container spawn routes correctly.
-      // Without this, container-runner reads the stale worker.env and routes
-      // to the wrong proxy (e.g. still Anthropic after switching to NW).
+      // Clean stale NANOCLAW_BACKEND from worker.env (legacy — routing now
+      // comes from worker-backends.json, injected by container-runner).
       updateWorkerEnvBackend(
         workerGroup.folder,
         data.backend as string,

--- a/src/profile-sync.ts
+++ b/src/profile-sync.ts
@@ -140,9 +140,15 @@ export function syncWorkerProfiles(): number {
     if (profile.skills_repo) {
       workerEnv.WORKER_SKILLS_REPO = profile.skills_repo;
     }
-    // Preserve per-worker settings not managed by the profile
-    if (existingEnv.NANOCLAW_BACKEND) {
-      workerEnv.NANOCLAW_BACKEND = existingEnv.NANOCLAW_BACKEND;
+    // Preserve per-worker custom env vars that aren't managed by the profile.
+    // NANOCLAW_BACKEND/MODEL are injected by container-runner from
+    // worker-backends.json — don't persist them here.
+    const profileKeys = new Set(Object.keys(workerEnv));
+    const skipKeys = new Set(['NANOCLAW_BACKEND', 'NANOCLAW_MODEL']);
+    for (const [k, v] of Object.entries(existingEnv)) {
+      if (!profileKeys.has(k) && !skipKeys.has(k)) {
+        workerEnv[k] = v;
+      }
     }
     fs.writeFileSync(
       envPath,

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -147,8 +147,13 @@ function recordUsage(
     last_updated: '',
   };
   w.requests++;
-  w.input_tokens += usage?.prompt_tokens || 0;
+  const promptTokens = usage?.prompt_tokens || 0;
+  w.input_tokens += promptTokens;
   w.output_tokens += usage?.completion_tokens || 0;
+  // Track last input for max_tokens capping on next request
+  if (promptTokens > 0) {
+    lastInputTokens.set(workerFolder, promptTokens);
+  }
   w.total_tokens += usage?.total_tokens || 0;
   w.energy_joules += energy?.energy_joules || 0;
   w.energy_kwh += energy?.energy_kwh || 0;
@@ -172,6 +177,10 @@ function recordUsage(
     });
   }
 }
+
+// Track last input token count per worker for max_tokens capping.
+// Updated after each successful API call with real usage data.
+const lastInputTokens = new Map<string, number>();
 
 // Deduplicate SDK retries: track last request per worker to detect duplicates.
 // The SDK sends each request twice with different max_tokens.
@@ -252,6 +261,47 @@ function getWorkerConfig(workerFolder: string): WorkerBackendConfig {
 }
 
 // ── Model mapping (Neuralwatt) ─────────────────────────────────
+
+// ── Model context limits ──────────────────────────────────────
+// Fetched from the NW API at startup and cached. Used to cap max_tokens
+// so that input_tokens + max_tokens never exceeds the model's context window.
+// This prevents silent 400 errors from the upstream API.
+const modelContextLimits: Record<string, number> = {};
+// Headroom between estimated input + max_tokens and the model's hard limit.
+// Tokenizer differences between our byte-based estimate and the model's actual
+// tokenizer can vary by a few hundred tokens; 512 is conservative.
+const MODEL_CONTEXT_HEADROOM = 512;
+// Empirically derived from NW API payloads with tool definitions and
+// multi-turn conversation history. Used when no prior turn data is available.
+const CHARS_PER_TOKEN_ESTIMATE = 3.2;
+
+async function fetchModelLimits(): Promise<void> {
+  try {
+    const resp = await fetch(`${NEURALWATT_BASE}/models`, {
+      headers: { Authorization: `Bearer ${NEURALWATT_API_KEY}` },
+    });
+    if (!resp.ok) {
+      console.error(`[proxy] Failed to fetch model limits: ${resp.status}`);
+      return;
+    }
+    const data = await resp.json();
+    const models = data.data || data;
+    for (const m of models) {
+      if (m.id && m.max_model_len) {
+        modelContextLimits[m.id] = m.max_model_len;
+      }
+    }
+    console.log(
+      `[proxy] Cached context limits for ${Object.keys(modelContextLimits).length} models`,
+    );
+  } catch (err: any) {
+    console.error(`[proxy] Error fetching model limits: ${err.message}`);
+  }
+}
+
+// Fetch on startup. Requests arriving before this resolves will skip
+// max_tokens capping (the shim logs a warning in that case).
+const modelLimitsReady = fetchModelLimits();
 
 const NEURALWATT_MODEL_MAP: Record<string, string> = {
   'claude-opus-4-6': 'Qwen/Qwen3.5-397B-A17B-FP8',
@@ -645,6 +695,32 @@ const server = Bun.serve({
 
         const requestStart = Date.now();
         const reqBodySize = JSON.stringify(openaiReq).length;
+
+        // Cap max_tokens so input + output fits within the model's context.
+        // Use the last turn's actual input_tokens when available, otherwise
+        // estimate from serialized request size. ~3.2 chars per token is
+        // empirically derived from NW API payloads with tool definitions
+        // and multi-turn conversation history.
+        const contextLimit = modelContextLimits[nwModel];
+        if (contextLimit && openaiReq.max_tokens) {
+          const lastInput = lastInputTokens.get(workerFolder) || 0;
+          const estimatedInput =
+            lastInput > 0
+              ? lastInput
+              : Math.ceil(reqBodySize / CHARS_PER_TOKEN_ESTIMATE);
+          const available =
+            contextLimit - estimatedInput - MODEL_CONTEXT_HEADROOM;
+          if (available < openaiReq.max_tokens && available > 0) {
+            console.log(
+              `[proxy] Capping max_tokens: ${openaiReq.max_tokens} → ${available} (input≈${estimatedInput}, limit=${contextLimit})`,
+            );
+            openaiReq.max_tokens = available;
+          } else if (available <= 0) {
+            console.error(
+              `[proxy] Context exhausted: input≈${estimatedInput} >= limit=${contextLimit}. Request will likely fail.`,
+            );
+          }
+        }
         console.log(
           `[proxy] ${workerFolder}: ${anthropicBody.model} → ${nwModel} (${openaiReq.messages.length} msgs${openaiReq.tools ? `, ${openaiReq.tools.length} tools` : ''}, ${(reqBodySize / 1024).toFixed(1)}KB request)`,
         );
@@ -707,7 +783,10 @@ const server = Bun.serve({
                 }
               };
 
-              // Emit message_start
+              // Emit message_start — input_tokens starts at 0; we patch it
+              // in message_delta once the upstream usage chunk arrives.
+              // The SDK uses input_tokens for auto-compaction decisions, so
+              // accurate counts are critical.
               emit('message_start', {
                 type: 'message_start',
                 message: {
@@ -762,6 +841,45 @@ const server = Bun.serve({
                     try {
                       chunk = JSON.parse(line.slice(6));
                     } catch {
+                      continue;
+                    }
+
+                    // Detect error frames: NW API wraps some errors
+                    // (e.g. context length exceeded) as {"error": {...}} inside
+                    // an SSE data frame with HTTP 200. Surface them so the SDK
+                    // can react (e.g. trigger compaction or report to user).
+                    if (chunk.error) {
+                      const errMsg =
+                        chunk.error.message || JSON.stringify(chunk.error);
+                      console.error(
+                        `[proxy] Upstream SSE error: ${errMsg}`,
+                      );
+                      // Emit an error text block so the SDK sees it as a real
+                      // (non-empty) response rather than error_during_execution.
+                      if (!inText) {
+                        if (inThinking) {
+                          emit('content_block_stop', {
+                            type: 'content_block_stop',
+                            index: blockIndex,
+                          });
+                          blockIndex++;
+                          inThinking = false;
+                        }
+                        inText = true;
+                        emit('content_block_start', {
+                          type: 'content_block_start',
+                          index: blockIndex,
+                          content_block: { type: 'text', text: '' },
+                        });
+                      }
+                      emit('content_block_delta', {
+                        type: 'content_block_delta',
+                        index: blockIndex,
+                        delta: {
+                          type: 'text_delta',
+                          text: `[Inference error] ${errMsg}`,
+                        },
+                      });
                       continue;
                     }
 
@@ -896,11 +1014,20 @@ const server = Bun.serve({
                   });
                 }
 
-                // message_delta with stop_reason and usage
+                // message_delta with stop_reason and usage.
+                // Include input_tokens so the SDK can track context size
+                // for auto-compaction. The Anthropic spec puts input_tokens
+                // in message_start, but we don't know the count until the
+                // upstream usage chunk arrives at stream end. Sending it in
+                // message_delta is the best we can do — the SDK accumulates
+                // usage from both events.
                 emit('message_delta', {
                   type: 'message_delta',
                   delta: { stop_reason: stopReason, stop_sequence: null },
-                  usage: { output_tokens: usage.completion_tokens || 0 },
+                  usage: {
+                    input_tokens: usage.prompt_tokens || 0,
+                    output_tokens: usage.completion_tokens || 0,
+                  },
                 });
 
                 emit('message_stop', { type: 'message_stop' });


### PR DESCRIPTION
## Summary

NW workers became permanently unresponsive when context grew near the model's limit (~200k tokens). Three root causes:

- **SSE error frames silently dropped**: The NW API wraps 400 errors in SSE data frames with HTTP 200. The shim ignored them, causing the SDK to see empty responses forever.
- **Auto-compaction never triggered**: The shim sent `input_tokens: 0` to the SDK, so it never knew context was growing. Additionally, `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (set by the agent-runner) was a dead env var — the SDK doesn't read it.
- **Dual routing paths**: Workers could be NW-routed via `worker-backends.json` but the container wouldn't know (no `NANOCLAW_BACKEND` env var), missing all NW-specific handling.

Fixes:
- Detect and surface SSE error frames as visible text responses
- Send real `input_tokens` in `message_delta` (SDK accumulates from both events)
- Cap `max_tokens` to fit within model context limits (fetched at startup)
- Consolidate backend routing to `worker-backends.json` as single source of truth
- Always inject `NANOCLAW_BACKEND` into containers
- Set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=16` for NW workers (~157k token threshold)

## Test plan

- [x] SSE error surfacing: sent message to pareto (170k context, exceeds GLM-5 limit) — error now visible in Discord instead of silent failure
- [x] max_tokens capping: shim capped 32k→12984 for pareto, request succeeded (79 out, 179k in, 38s)
- [x] Backend routing: panama now has `NANOCLAW_BACKEND=neuralwatt` and routes to shim directly (port 3003)
- [x] Auto-compact e2e: set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=1` on panama, sent two messages — SDK triggered auto-compact (`compact_boundary` observed), context dropped from 32k to 3k
- [x] Anthropic workers unaffected: compact override only set when `NANOCLAW_BACKEND=neuralwatt`
- [x] Unit tests pass (`npm run build`, `vitest run src/ipc.test.ts`)