### PR TITLE
fix: log warnings for implicit fallbacks

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -8,6 +8,7 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
 // Mock config
 vi.mock('./config.js', () => ({
+  BACKEND_NEURALWATT: 'neuralwatt',
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min
@@ -16,7 +17,10 @@ vi.mock('./config.js', () => ({
   GITHUB_TOKEN_PATH: null,
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  NEURALWATT_PROXY_PORT: 3003,
   TIMEZONE: 'America/Los_Angeles',
+  WORKER_API_KEY_PREFIX: 'sk-ant-worker-',
+  WORKER_BACKENDS_FILENAME: 'worker-backends.json',
 }));
 
 // Mock logger

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -470,8 +470,11 @@ function buildContainerArgs(
       if (token) {
         args.push('-e', `GITHUB_TOKEN=${token}`);
       }
-    } catch {
-      // Token file missing or unreadable — git push will just fail without auth
+    } catch (err) {
+      logger.warn(
+        { err, path: GITHUB_TOKEN_PATH },
+        'GitHub token file unreadable — container git operations will lack auth',
+      );
     }
   }
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -227,7 +227,10 @@ async function fetchWorkerUsage(
     if ((data as any).error) return null;
     return data as Record<string, number>;
   } catch (err) {
-    logger.debug({ err, folder }, 'Shim usage fetch error (shim may not be running)');
+    logger.debug(
+      { err, folder },
+      'Shim usage fetch error (shim may not be running)',
+    );
     return null;
   }
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -49,8 +49,11 @@ function sanitizeThinkingBlocks(folder: string): number {
       recursive: true,
       withFileTypes: true,
     });
-  } catch {
-    return 0; // Directory doesn't exist or isn't readable
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      logger.warn({ err, folder }, 'Failed to read sessions directory');
+    }
+    return 0;
   }
   const jsonlFiles = entries
     .filter((e) => e.isFile() && e.name.endsWith('.jsonl'))
@@ -216,11 +219,15 @@ async function fetchWorkerUsage(
     const resp = await fetch(
       `http://localhost:${NEURALWATT_PROXY_PORT}/usage/${folder}`,
     );
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      logger.debug({ folder, status: resp.status }, 'Shim usage fetch failed');
+      return null;
+    }
     const data = await resp.json();
     if ((data as any).error) return null;
     return data as Record<string, number>;
-  } catch {
+  } catch (err) {
+    logger.debug({ err, folder }, 'Shim usage fetch error (shim may not be running)');
     return null;
   }
 }

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -317,7 +317,13 @@ function resolveNeuralwattModel(
   configModel?: string,
 ): string {
   if (configModel) return configModel;
-  return NEURALWATT_MODEL_MAP[anthropicModel] || DEFAULT_NEURALWATT_MODEL;
+  const mapped = NEURALWATT_MODEL_MAP[anthropicModel];
+  if (!mapped) {
+    console.warn(
+      `[proxy] Unknown model "${anthropicModel}" — falling back to ${DEFAULT_NEURALWATT_MODEL}`,
+    );
+  }
+  return mapped || DEFAULT_NEURALWATT_MODEL;
 }
 
 // ── Anthropic → OpenAI translation ─────────────────────────────


### PR DESCRIPTION
## Summary

Audit of silent error-swallowing patterns per CLAUDE.md's "no implicit fallbacks" principle. Four catch blocks that returned defaults without logging now surface warnings.

- GitHub token file read failure → `logger.warn` with path
- Sessions directory read failure (non-ENOENT) → `logger.warn`  
- Shim usage fetch errors → `logger.debug` (expected when shim is down)
- Unknown model in shim resolution → `console.warn` about fallback

Closes nanoclaw-7yu.

## Test plan

- [x] `npm run build` passes
- [x] `vitest run src/ipc.test.ts` passes
- Logging changes are observational — verified by reading the code