### PR TITLE
fix: e2e test timeouts and proxy health check

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -817,11 +817,14 @@ function cmdDebug() {
     { ignoreError: true },
   );
 
+  // Any HTTP response means the server is running (404, 401, etc. are fine).
+  // Only 000 (connection refused) or empty means down.
+  const isUp = (code: string) => code && code !== '000' && code !== '';
   console.log(
-    `  Credential proxy :${proxyPort}: ${proxyUp === '200' ? GREEN + 'up' : YELLOW + proxyUp}${NC}`,
+    `  Credential proxy :${proxyPort}: ${isUp(proxyUp) ? GREEN + 'up' : RED + (proxyUp || 'down')}${NC}`,
   );
   console.log(
-    `  Neuralwatt proxy :${nwPort}: ${nwUp === '200' ? GREEN + 'up' : YELLOW + nwUp}${NC}`,
+    `  Neuralwatt proxy :${nwPort}: ${isUp(nwUp) ? GREEN + 'up' : RED + (nwUp || 'down')}${NC}`,
   );
 
   console.log();

--- a/tools/e2e-test.ts
+++ b/tools/e2e-test.ts
@@ -322,9 +322,10 @@ async function testFirstBoot(workerName: string) {
   }
   if (!containerUp) fail('Container did not spawn within 60s');
 
-  // Wait for agent response
+  // Wait for agent response — cold boot includes tsc compile, repo clone,
+  // and first API call (which may have high TTFT for large contexts).
   let responded = false;
-  for (let elapsed = 0; elapsed < 60_000; elapsed += 2000) {
+  for (let elapsed = 0; elapsed < 120_000; elapsed += 2000) {
     const entries = scanJsonl(
       (e) => e.group === workerName && e.msg === 'Container first output',
       { afterMs: t0 },
@@ -337,7 +338,12 @@ async function testFirstBoot(workerName: string) {
     }
     await sleep(2000);
   }
-  if (!responded) fail('Agent did not respond within 60s');
+  if (!responded) {
+    // Diagnose: is the container still running or did it crash?
+    const ps = sh(`docker ps --format '{{.Names}}'`, { ignoreError: true });
+    const running = ps.includes(`nanoclaw-${safeName}`);
+    fail(`Agent did not respond within 120s (container ${running ? 'still running' : 'not running'})`);
+  }
 
   // Check for errors
   const errors = scanJsonl((e) => e.group === workerName && e.level >= 50, {
@@ -423,9 +429,9 @@ async function testSessionResume(workerName: string) {
   const t2 = Date.now();
   inject(workerName, 'What was the secret code I told you?');
 
-  // Wait for respawn
+  // Wait for respawn (session resume still needs tsc + first API call)
   let respawned = false;
-  for (let elapsed = 0; elapsed < 60_000; elapsed += 2000) {
+  for (let elapsed = 0; elapsed < 120_000; elapsed += 2000) {
     const entries = scanJsonl(
       (e) => e.group === workerName && e.msg === 'Container first output',
       { afterMs: t2 },
@@ -437,7 +443,7 @@ async function testSessionResume(workerName: string) {
     }
     await sleep(2000);
   }
-  if (!respawned) fail('Container did not respawn within 60s');
+  if (!respawned) fail('Container did not respawn within 120s');
 
   // Check secret code recall (best-effort)
   await sleep(5000);


### PR DESCRIPTION
## Summary

- **E2E test timeouts** (nanoclaw-t30): Agent response timeout increased from 60s to 120s. Cold boot includes tsc compile, repo clone, and first API call. Added diagnostic on timeout showing whether container is still running or crashed.
- **Proxy health check** (nanoclaw-etl): `ncf debug` now treats any HTTP response (including 404, 401) as "up". Only connection refused (000) means down.

## Test plan

- [x] `ncf debug` shows both proxies as green "up"
- [x] `npm run build` passes
- [x] 352/352 unit tests pass