### PR TITLE
feat: show non-cached tokens in ncf status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,7 +190,7 @@ function cmdStatus(json: boolean, noColor: boolean) {
       model: b.model || 'unknown',
       container,
       requests: u.requests || 0,
-      tokens: u.total_tokens || 0,
+      tokens: (u.input_tokens || 0) + (u.output_tokens || 0) - (u.cached_input_tokens || 0),
       energyWh: (u.energy_kwh || 0) * 1000,
     };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,7 +190,10 @@ function cmdStatus(json: boolean, noColor: boolean) {
       model: b.model || 'unknown',
       container,
       requests: u.requests || 0,
-      tokens: (u.input_tokens || 0) + (u.output_tokens || 0) - (u.cached_input_tokens || 0),
+      tokens:
+        (u.input_tokens || 0) +
+        (u.output_tokens || 0) -
+        (u.cached_input_tokens || 0),
       energyWh: (u.energy_kwh || 0) * 1000,
     };
 

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -79,6 +79,7 @@ interface WorkerUsage {
   requests: number;
   input_tokens: number;
   output_tokens: number;
+  cached_input_tokens: number;
   last_input_tokens?: number;
   total_tokens: number;
   energy_joules: number;
@@ -157,6 +158,7 @@ function recordUsage(
     requests: 0,
     input_tokens: 0,
     output_tokens: 0,
+    cached_input_tokens: 0,
     total_tokens: 0,
     energy_joules: 0,
     energy_kwh: 0,
@@ -164,8 +166,10 @@ function recordUsage(
   };
   w.requests++;
   const promptTokens = usage?.prompt_tokens || 0;
+  const cachedTokens = usage?.prompt_tokens_details?.cached_tokens || 0;
   w.input_tokens += promptTokens;
   w.output_tokens += usage?.completion_tokens || 0;
+  w.cached_input_tokens = (w.cached_input_tokens || 0) + cachedTokens;
   // Track last input for max_tokens capping — persisted in workerUsage
   // so it survives shim restarts.
   if (promptTokens > 0) {


### PR DESCRIPTION
## Summary

`ncf status` was showing total tokens (including prompt cache hits), inflating the displayed cost. Now shows non-cached tokens only: `input + output - cached`.

The shim now accumulates `cached_input_tokens` in `worker-usage.json` from the NW API's `prompt_tokens_details.cached_tokens` field.

Example: 3 requests with 98.6k total input but 93.4k cached → displays **5.2k tok** (the real compute cost).

## Test plan

- [x] Created test worker, sent 3 messages, verified `ncf status` shows 5.2k (non-cached) vs 98.6k (total)
- [x] Verified `cached_input_tokens` accumulates correctly in `worker-usage.json`
- [x] 352/352 unit tests pass