### PR TITLE
fix: resolve model aliases for correct SDK context window

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -66,6 +66,26 @@ const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
 
+// SDK model alias map — the SDK uses these to determine context window,
+// max output tokens, and other model-specific behavior. Short aliases like
+// "opus" don't carry enough info (e.g., the [1m] suffix for 1M context).
+const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
+  opus: 'claude-opus-4-6[1m]',
+  sonnet: 'claude-sonnet-4-6',
+  haiku: 'claude-haiku-4-5-20251001',
+};
+
+/** Resolve the model string for the SDK query.
+ * - NW workers: pass the NW model name (e.g., "kimi-k2.5-fast") for shim routing.
+ * - Anthropic workers: resolve short aliases to full model IDs so the SDK
+ *   correctly identifies context window and capabilities. */
+function resolveModelForSdk(): string | undefined {
+  const raw = process.env.NANOCLAW_MODEL;
+  if (!raw) return undefined;
+  if (process.env.NANOCLAW_BACKEND === 'neuralwatt') return raw;
+  return ANTHROPIC_MODEL_ALIASES[raw.toLowerCase()] || raw;
+}
+
 /**
  * Push-based async iterable for streaming user messages to the SDK.
  * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
@@ -518,9 +538,7 @@ async function runQuery(
   for await (const message of query({
     prompt: stream,
     options: {
-      model:
-        (process.env.NANOCLAW_MODEL as 'sonnet' | 'opus' | 'haiku') ||
-        undefined,
+      model: resolveModelForSdk(),
       cwd: '/workspace/group',
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,


### PR DESCRIPTION
## Summary

The SDK determines context window from the model string. Short aliases like `opus` (from .env `NANOCLAW_MODEL=opus`) don't match the SDK's checks (which look for `opus-4-6` or `[1m]`), causing Anthropic workers to use 200k context instead of 1M. Auto-compact threshold was 167k instead of 967k.

Now the agent-runner resolves aliases before passing to the SDK:
- `opus` → `claude-opus-4-6[1m]` (1M context)
- `sonnet` → `claude-sonnet-4-6`
- `haiku` → `claude-haiku-4-5-20251001`

NW workers pass the model name through unchanged (for shim routing).

## Test plan

- [x] Before: `effectiveWindow=180000` (200k context, threshold=167k)
- [x] After: `effectiveWindow=980000` (1M context, threshold=967k)
- [x] Verified via SDK debug log `autocompact:` line
- [x] 352/352 unit tests pass