### PR TITLE
Prep repo for public release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 
 # ── Assistant Identity ──────────────────────────────────────────
 # The name your bot responds to. Used as the trigger pattern (@Name).
-# ASSISTANT_NAME=Eugene
+# ASSISTANT_NAME=Andy
 
 # Set to "true" if the assistant has its own phone number (WhatsApp).
 # ASSISTANT_HAS_OWN_NUMBER=
@@ -49,3 +49,9 @@ DISCORD_GUILD_ID=
 # Debug bot token (stored at ~/.config/nanoclaw/debug_bot_token)
 # Used by ncf test for true end-to-end Discord testing
 # DISCORD_DEBUG_BOT_TOKEN_PATH=~/.config/nanoclaw/debug_bot_token
+
+# ── OpenAI-Compatible Backend (optional) ─────────────────────────
+# For open-weight models via OpenAI-compatible APIs (e.g., Neuralwatt, Together,
+# Fireworks, etc.) Set both URL and key to enable this backend.
+# OPENAI_COMPATIBLE_API_URL=https://api.example.com/v1
+# OPENAI_COMPATIBLE_API_KEY=sk-...

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By default, workers run on **Claude (Opus)** via the Anthropic API:
 create a worker named my-task
 ```
 
-To use an open-source model via [Neuralwatt](https://portal.neuralwatt.com), specify the backend and model. Neuralwatt's API reports energy consumption per request (joules, watt-hours), so you can track exactly how much power each worker uses.
+To use an open-source model via [Neuralwatt](https://portal.neuralwatt.com) or any OpenAI-compatible API, specify the backend and model. Backends that expose energy metrics (like Neuralwatt) report per-request power usage (joules, watt-hours) in addition to tokens.
 
 ```
 create a worker named my-task based on neuralwatt kimi k2.5

--- a/examples/worker-profile-foobar/CLAUDE.worker.md
+++ b/examples/worker-profile-foobar/CLAUDE.worker.md
@@ -1,0 +1,42 @@
+# Acme Corp Engineering Worker
+
+You are a software engineering assistant for **Acme Corp**, a company that builds logistics software for the shipping industry.
+
+## Your Organization
+
+**Acme Corp** maintains three main systems:
+- **RouteOptimizer** — Real-time route planning API (repo: `route-service`)
+- **FleetTracker** — GPS fleet monitoring dashboard (repo: `fleet-ui`)
+- **AcmeConnect** — Third-party integration platform (repo: `integrations`)
+
+## Repositories
+
+When cloned in your workspace:
+- `/workspace/group/route-service/` — Backend logistics API (Python, FastAPI, PostgreSQL)
+- `/workspace/group/fleet-ui/` — React dashboard (TypeScript, React Query, Mapbox)
+- `/workspace/group/shared-libs/` — Internal packages for authentication and logging
+
+## Conventions
+
+- **Testing**: Run `pytest` (backend) or `npm test` (frontend) before claiming a fix works
+- **Commits**: Use conventional commits format (`feat:`, `fix:`, `refactor:`)
+- **Branches**: Create feature branches (e.g., `feat/RO-123`), never push to main
+- **Code style**: Black + Ruff for Python, Prettier for TypeScript
+
+## Integrations
+
+- **Slack**: Read-only access to #engineering-alerts and #deployments
+- **AWS**: Credentials mounted at `/workspace/extra/aws-credentials/` (limited to dev account)
+- **Internal tooling**: Use `acme-cli` command for service discovery and deployments
+
+## Common Workflows
+
+1. **Deploy to staging**: `acme-cli deploy --service <name> --env staging`
+2. **Check service logs**: `acme-cli logs --service <name> --tail 100`
+3. **Database migrations**: Run from `route-service/` with `alembic upgrade head`
+
+## Protocol
+
+- When investigating a bug, always check the relevant repo's issue tracker first
+- If you discover a pattern that could affect multiple repos, file a shared improvement note
+- Never commit secrets—use the mounted credential files

--- a/examples/worker-profile-foobar/profile.json
+++ b/examples/worker-profile-foobar/profile.json
@@ -1,0 +1,44 @@
+{
+  "name": "acme-corp-default",
+  "description": "Example worker profile for Acme Corp — a logistics software company",
+
+  "_comment": "This is an illustrative example showing a complete worker profile.",
+
+  "repos": [
+    {
+      "url": "git@github.com:acme-corp/route-service.git",
+      "postClone": "pip install -e . && pip install -r requirements-dev.txt"
+    },
+    {
+      "url": "git@github.com:acme-corp/fleet-ui.git",
+      "postClone": "npm install"
+    },
+    {
+      "url": "git@github.com:acme-corp/shared-libs.git",
+      "postClone": "pip install -e ./packages/acme-auth && pip install -e ./packages/acme-logging"
+    }
+  ],
+
+  "tools": [
+    "uv tool install acme-cli --python 3.11",
+    "npm install -g @acme-corp/devtools"
+  ],
+
+  "mounts": [
+    {
+      "hostPath": "~/.config/acme-cli",
+      "containerPath": "acme-cli",
+      "readonly": true
+    },
+    {
+      "hostPath": "~/.aws",
+      "containerPath": "aws-credentials",
+      "readonly": true
+    }
+  ],
+
+  "skills_repo": "shared-libs",
+
+  "init_script": "init.sh",
+  "claude_md": "CLAUDE.worker.md"
+}

--- a/worker-profiles/example.json
+++ b/worker-profiles/example.json
@@ -2,19 +2,27 @@
   "name": "example",
   "description": "Example worker profile — copy to ~/.config/nanoclaw/worker-profiles/default.json and customize",
 
+  "_comment_repos": "Repos to clone when a worker starts. HTTPS URLs are rewritten to use GITHUB_TOKEN automatically.",
   "repos": [
-    {"url": "git@github.com:your-org/your-repo.git", "postClone": "git config core.hooksPath .githooks"}
+    {"url": "git@github.com:foobar-corp/api-service.git", "postClone": "npm install"},
+    {"url": "git@github.com:foobar-corp/web-dashboard.git", "postClone": "git config core.hooksPath .githooks"},
+    {"url": "git@github.com:foobar-corp/shared-libs.git"}
   ],
 
+  "_comment_tools": "Commands to install tools inside the worker container (runs after repos are cloned).",
   "tools": [
-    "uv tool install /workspace/group/your-repo --force"
+    "uv tool install /workspace/group/api-service/cli --force",
+    "npm install -g @foobar-corp/devtools"
   ],
 
+  "_comment_mounts": "Mount host directories into worker containers. Use readonly:true for credentials.",
   "mounts": [
-    {"hostPath": "~/.config/your-tool", "containerPath": "your-tool", "readonly": true}
+    {"hostPath": "~/.config/foobar-cli", "containerPath": "foobar-cli", "readonly": true},
+    {"hostPath": "~/.aws", "containerPath": "aws-credentials", "readonly": true}
   ],
 
-  "skills_repo": null,
+  "_comment_skills_repo": "Name of a cloned repo (from repos above) that contains .claude/skills/ to mount.",
+  "skills_repo": "shared-libs",
 
   "init_script": "init.sh",
   "claude_md": "CLAUDE.worker.md"


### PR DESCRIPTION
## Summary

Cleans up the repo for public release by addressing documentation gaps, inconsistent naming, and overly personal configuration examples.

## Changes

### .env.example
- Fix `ASSISTANT_NAME=Eugene` → `ASSISTANT_NAME=Andy` (consistent with upstream)
- Add `OPENAI_COMPATIBLE_API_URL` and `OPENAI_COMPATIBLE_API_KEY` for generic backend support

### README.md
- Reframe energy tracking as Neuralwatt-specific feature rather than universal
- Mention OpenAI-compatible APIs generally alongside Neuralwatt

### worker-profiles/example.json
- Expand with illustrative "Foobar Corp" example
- Add comments explaining each field (`_comment_*` keys)
- Show realistic repo setup, tools, and credential mounts

### examples/worker-profile-foobar/
- New complete example with `CLAUDE.worker.md` and `profile.json`
- Demonstrates a fake "Acme Corp" logistics company setup
- Shows best practices for repos, post-clone hooks, tools, mounts

## Checklist

- [x] No personal tool references (gpuctl, nebius) in repo instructions
- [x] Energy tracking framed appropriately
- [x] Consistent naming (Andy)
- [x] Better worker profile illustrations
- [x] LICENSE already present (MIT)

Closes release-readiness review.