### PR TITLE
Fix Anthropic workers showing 'unknown' model name

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1041,9 +1041,15 @@ const cmd = args[0];
           process.exit(1);
         }
         const opts = {
-          backend: args[args.indexOf('--backend') + 1],
-          model: args[args.indexOf('--model') + 1],
-          trigger: args[args.indexOf('--trigger') + 1],
+          backend: args.includes('--backend')
+            ? args[args.indexOf('--backend') + 1]
+            : undefined,
+          model: args.includes('--model')
+            ? args[args.indexOf('--model') + 1]
+            : undefined,
+          trigger: args.includes('--trigger')
+            ? args[args.indexOf('--trigger') + 1]
+            : undefined,
         };
         cmdCreate(name, opts);
         break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -13,6 +13,8 @@ import {
   TIMEZONE,
   WORKER_BACKENDS_FILENAME,
 } from './config.js';
+
+const DEFAULT_ANTHROPIC_MODEL = 'claude-opus-4-6';
 import { AvailableGroup } from './container-runner.js';
 import { sanitizeFolderName } from './container-runtime.js';
 import { readEnvFile } from './env.js';
@@ -152,7 +154,12 @@ function updateWorkerBackends(
       backend: BACKEND_NEURALWATT,
       model: model || DEFAULT_NEURALWATT_MODEL,
     };
-  } else {
+  } else if (backend === BACKEND_ANTHROPIC) {
+    backends[folder] = {
+      backend: BACKEND_ANTHROPIC,
+      model: model || DEFAULT_ANTHROPIC_MODEL,
+    };
+  } else if (backend === null) {
     delete backends[folder];
   }
 
@@ -916,6 +923,12 @@ export async function processTaskIpc(
             workerEnv.NANOCLAW_BACKEND = BACKEND_NEURALWATT;
             workerEnv.NANOCLAW_MODEL = model;
             updateWorkerBackends(data.folder, BACKEND_NEURALWATT, model);
+          } else {
+            // Anthropic backend - also track in worker-backends.json for status pins
+            const model = data.model || DEFAULT_ANTHROPIC_MODEL;
+            workerEnv.NANOCLAW_BACKEND = BACKEND_ANTHROPIC;
+            workerEnv.NANOCLAW_MODEL = model;
+            updateWorkerBackends(data.folder, BACKEND_ANTHROPIC, model);
           }
           const envDir = path.join(DATA_DIR, 'sessions', data.folder);
           fs.mkdirSync(envDir, { recursive: true });
@@ -1298,7 +1311,7 @@ export async function processTaskIpc(
 
       updateWorkerBackends(
         workerGroup.folder,
-        data.backend === BACKEND_NEURALWATT ? BACKEND_NEURALWATT : null,
+        data.backend === BACKEND_NEURALWATT ? BACKEND_NEURALWATT : BACKEND_ANTHROPIC,
         data.model as string | undefined,
       );
 


### PR DESCRIPTION
## Problem

Anthropic workers showed "unknown" in their status pin model field because:
1. `worker-backends.json` only tracked Neuralwatt backends
2. `updateWorkerBackends()` deleted entries for non-Neuralwatt backends
3. Status pins defaulted to "unknown" when no model was found

## Solution

- Track Anthropic backends in `worker-backends.json` with model name
- Add `DEFAULT_ANTHROPIC_MODEL = 'claude-opus-4-6'` constant
- Update `updateWorkerBackends()` to handle Anthropic backend
- Fix backend switch logic to pass `BACKEND_ANTHROPIC` instead of `null`

## Testing

- All 352 tests pass
- Build succeeds

## E2E Verification Needed

After deploy, create a new Anthropic worker and verify its status pin shows:
- `claude-opus-4-6` (or the specified model) instead of `unknown`

Fixes claude-inbox-2yn