### PR TITLE
docs(setup): cover inference shim in skill, guide, and .env

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ Tell the user what setup will walk them through. If they already have some of th
 3. **Discord Guild (Server) ID**: right-click server name in Discord
 4. **Discord Channel ID** for `#master`: right-click the channel in Discord
 5. **GitHub PAT** *(optional)*: only needed if workers clone private repos
-6. **OpenAI-compatible API key** *(optional)*: only if using open-weight models
+6. **OpenAI-compatible API key** *(optional)*: to route workers through an alternative inference provider (e.g. Neuralwatt at https://portal.neuralwatt.com, or any other OpenAI-compatible endpoint) for open-weight models like Kimi / Qwen / GLM as an alternative to Claude
 
 ## 0. Git Remote Setup
 
@@ -185,19 +185,77 @@ EOF
 
 `container/build.sh` will automatically detect and apply this layer. Heavy packages that are the same every boot (databases, compilers, test frameworks) go in the Dockerfile. Setup that needs host context (repo cloning, credential symlinks) stays in init.sh. Per-profile tools that depend on workspace content stay in profile tools.
 
-## 9. Optional: Open-Weight Model Support
+## 9. Optional: Alternative Inference Provider (Translation Shim)
 
-AskUserQuestion: "Do you want to use open-weight models (e.g. Kimi K2.5, Qwen) in addition to Claude?"
+Workers can route through an OpenAI-compatible endpoint instead of Claude — useful for open-weight models (Kimi, Qwen, GLM, etc.). This requires a small translation shim service (`tools/anthropic-shim.ts`) that converts Anthropic Messages format → OpenAI Chat Completions format. The shim runs as a separate background service on `localhost:3003`. Worker containers created with `backend: neuralwatt` point `ANTHROPIC_BASE_URL` at the shim; Claude-backed workers bypass it entirely.
 
-**Yes:** Collect the OpenAI-compatible endpoint URL and API key. Add to `.env`:
-```
-NEURALWATT_API_URL=<endpoint-url>
-NEURALWATT_API_KEY=<api-key>
-```
+AskUserQuestion: "Do you want to set up the translation shim to use an OpenAI-compatible inference provider (e.g. Neuralwatt at https://portal.neuralwatt.com, or any other OpenAI-compatible endpoint)? You can skip this and all workers will use Claude."
 
-The translation shim converts between Anthropic and OpenAI API formats automatically. Workers can be created with `backend: neuralwatt` to use these models.
+**No:** Skip to step 10.
 
-**No:** Skip. All workers will use Claude.
+**Yes:**
+
+Full human-facing write-up is at `docs/guides/setup.md` § 9 — follow that as the source of truth. The skill-level steps below are the agent-driven version.
+
+1. **Ensure `bun` is installed.** The shim uses `Bun.serve()` and cannot run under plain Node or `tsx`. Check with `command -v bun`. If missing:
+   ```bash
+   curl -fsSL https://bun.sh/install | bash
+   ```
+   Record the absolute path (`command -v bun`, typically `~/.bun/bin/bun`) — systemd won't resolve it from PATH.
+
+2. **Collect credentials and write them to `.env`.** Tell the user:
+   > For Neuralwatt, sign in at https://portal.neuralwatt.com to create an API key. For another provider, use whatever endpoint they give you — the base URL should be the root that exposes `/v1/chat/completions`.
+
+   Append to `.env` (quote values that contain special chars):
+   ```
+   NEURALWATT_API_KEY=<their-api-key>
+   # Only if not using Neuralwatt's default:
+   # NEURALWATT_BASE_URL=https://api.example.com/v1
+   ```
+
+3. **Install the shim as a background service.** Before writing the unit, resolve `BUN_BIN=$(command -v bun)` and `REPO=$(pwd)` into shell vars — the heredoc below is unquoted so they expand at write-time.
+
+   **Linux (systemd user service):**
+   ```bash
+   mkdir -p ~/.config/systemd/user
+   cat > ~/.config/systemd/user/nanoclaw-shim.service << EOF
+   [Unit]
+   Description=NanoClaw Inference Shim (Anthropic↔OpenAI-compatible proxy)
+   After=network.target nanoclaw.service
+
+   [Service]
+   Type=simple
+   WorkingDirectory=${REPO}
+   ExecStart=${BUN_BIN} run ${REPO}/tools/anthropic-shim.ts
+   Restart=always
+   RestartSec=3
+   Environment=SHIM_PORT=3003
+   Environment=CREDENTIAL_PROXY_URL=http://172.17.0.1:3001
+   EnvironmentFile=${REPO}/.env
+   StandardOutput=append:${REPO}/logs/shim.log
+   StandardError=append:${REPO}/logs/shim.error.log
+
+   [Install]
+   WantedBy=default.target
+   EOF
+
+   systemctl --user daemon-reload
+   systemctl --user enable --now nanoclaw-shim.service
+   systemctl --user status nanoclaw-shim --no-pager
+   ```
+
+   **macOS (launchd agent):** Create `~/Library/LaunchAgents/com.nanoclaw.shim.plist` with `ProgramArguments = [<bun-path>, "run", "<repo>/tools/anthropic-shim.ts"]` and `EnvironmentVariables` containing `SHIM_PORT=3003`, `CREDENTIAL_PROXY_URL=http://host.docker.internal:3001`, `NEURALWATT_API_KEY`, and optionally `NEURALWATT_BASE_URL`. launchd has no `EnvironmentFile` equivalent, so inline the values. Load with `launchctl load ~/Library/LaunchAgents/com.nanoclaw.shim.plist`.
+
+4. **Verify the shim is responding:**
+   ```bash
+   curl -s http://localhost:3003/models | head
+   ```
+   You should see a JSON list of provider models. If nothing is listening, check `logs/shim.error.log` for bun path, missing env vars, or port conflicts.
+
+5. **Tell the user how to use it:**
+   > The shim is running. Create a shim-backed worker with `ncf create <name> --backend neuralwatt --model <model-id>`, or ask master in `#master`: "create a worker called kimi-test using neuralwatt with model moonshotai/Kimi-K2.5". Claude-backed workers are unaffected — they bypass the shim and go direct to Anthropic.
+
+See `docs/architecture/inference-routing.md` for how the routing works end-to-end.
 
 ## 10. Start Service
 

--- a/.env.example
+++ b/.env.example
@@ -50,8 +50,13 @@ DISCORD_GUILD_ID=
 # Used by ncf test for true end-to-end Discord testing
 # DISCORD_DEBUG_BOT_TOKEN_PATH=~/.config/nanoclaw/debug_bot_token
 
-# ── OpenAI-Compatible Backend (optional) ─────────────────────────
-# For open-weight models via OpenAI-compatible APIs (e.g., Neuralwatt, Together,
-# Fireworks, etc.) Set both URL and key to enable this backend.
-# OPENAI_COMPATIBLE_API_URL=https://api.example.com/v1
-# OPENAI_COMPATIBLE_API_KEY=sk-...
+# ── OpenAI-Compatible Inference Shim (optional) ─────────────────
+# Required to run workers through an OpenAI-compatible inference backend
+# (e.g., Neuralwatt at portal.neuralwatt.com, or any other provider that
+# speaks the OpenAI chat-completions API).
+# Read by tools/anthropic-shim.ts (listens on port 3003).
+# Env var names are NEURALWATT_* for historical reasons — any OpenAI-
+# compatible provider works by overriding NEURALWATT_BASE_URL.
+# See docs/guides/setup.md § 9 for installation.
+# NEURALWATT_API_KEY=sk-...
+# NEURALWATT_BASE_URL=https://api.neuralwatt.com/v1

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -22,6 +22,7 @@ If you prefer to set things up by hand, follow the steps below.
 - Node.js 22+
 - Docker installed and accessible to your user
 - A Discord bot application (https://discord.com/developers/applications)
+- [Bun](https://bun.sh) _(optional)_ — required only if you want to route workers through an OpenAI-compatible inference backend (e.g., Neuralwatt). See section 9.
 
 ### What Setup Covers
 
@@ -188,7 +189,66 @@ npm run build
 systemctl --user restart nanoclaw
 ```
 
-## 9. Test
+## 9. Inference Shim (Optional — OpenAI-compatible backend)
+
+NanoClaw can route a worker's API traffic through an OpenAI-compatible inference provider (e.g., [Neuralwatt](https://portal.neuralwatt.com), or any other provider that speaks the OpenAI chat-completions API) instead of Anthropic. This is handled by a local HTTP proxy (`tools/anthropic-shim.ts`) that translates between the Anthropic and OpenAI-compatible APIs and listens on port `3003`.
+
+**Skip this section** if you only plan to run workers against Anthropic. Workers default to Anthropic without the shim running.
+
+### Prerequisites
+
+The shim is written for [Bun](https://bun.sh) (it uses `Bun.serve`). Install it once per host:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+### API key + base URL
+
+Get an API key from your provider (e.g., https://portal.neuralwatt.com) and add it to your `.env`. The env vars are named `NEURALWATT_*` for historical reasons, but any OpenAI-compatible `v1/chat/completions` endpoint works — just point `NEURALWATT_BASE_URL` at your provider.
+
+```env
+NEURALWATT_API_KEY=sk-...
+# Defaults to https://api.neuralwatt.com/v1 — override for other providers:
+# NEURALWATT_BASE_URL=https://api.example.com/v1
+```
+
+### Systemd unit (Linux)
+
+Create `~/.config/systemd/user/nanoclaw-shim.service`:
+
+```ini
+[Unit]
+Description=NanoClaw Inference Shim (Anthropic <-> Neuralwatt proxy)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/nanoclaw-fleet
+ExecStart=/home/YOU/.bun/bin/bun run tools/anthropic-shim.ts
+Restart=always
+RestartSec=5
+EnvironmentFile=/path/to/nanoclaw-fleet/.env
+StandardOutput=append:/path/to/nanoclaw-fleet/logs/shim.log
+StandardError=append:/path/to/nanoclaw-fleet/logs/shim.error.log
+
+[Install]
+WantedBy=default.target
+```
+
+Enable, start, and verify:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now nanoclaw-shim
+curl -s http://localhost:3003/models | head
+```
+
+You should see a JSON list of available models. If the shim isn't running, master will report the inference proxy on port 3003 is down when asked to create a worker with an OpenAI-compatible model — that's your signal to check `logs/shim.error.log` and `systemctl --user status nanoclaw-shim`.
+
+Once the shim is up, you can create a shim-backed worker with `ncf create <name> --backend neuralwatt --model <model-id>` or by asking master in `#master`. (The `--backend neuralwatt` flag name is historical — it routes any worker through the shim, regardless of which OpenAI-compatible provider you've configured.)
+
+## 10. Test
 
 In `#master`, send:
 


### PR DESCRIPTION
## Summary

Supersedes #65. Brings the Anthropic↔OpenAI-compatible translation shim (`tools/anthropic-shim.ts`) into the setup flow across three surfaces:

- **`.claude/skills/setup/SKILL.md`** — new optional step 9 walks the `/setup` skill-driven agent through `bun` install, systemd user unit (`EnvironmentFile=\${REPO}/.env`), macOS launchd equivalent, `/models` curl check, and `ncf create --backend neuralwatt` usage example.
- **`docs/guides/setup.md`** — parallel human-readable § 9 for manual installs (taken from #65).
- **`.env.example`** — replaces the stale `OPENAI_COMPATIBLE_*` placeholder (which didn't match the shim code) with the real `NEURALWATT_*` vars, noting any OpenAI-compatible endpoint works via `NEURALWATT_BASE_URL` (from #65).

## Why

`/setup` previously only wrote `NEURALWATT_API_URL` / `NEURALWATT_API_KEY` to `.env`. Those aren't even the names the shim reads, and nothing started the shim service, so new installs hit "inference proxy on port 3003 is down" the first time they tried a non-Anthropic worker. The skill now actually installs and starts the shim.

## Relationship to #65

#65 documented the shim in `docs/guides/setup.md` and `.env.example` only. This PR folds those changes in verbatim and adds the skill coverage that #65 doesn't touch. Close #65 after merging this.

## Test plan

- [x] `/simplify` pass: removed duplicated key storage, dead curl fallback, vague macOS placeholders, stale `<runtime-command>` wording
- [x] Verified `tools/anthropic-shim.ts` uses `Bun.serve()` → bun is a hard requirement (not `tsx`)
- [x] Verified `/models` endpoint exists in the shim for the health check
- [ ] Reviewer sanity-check the systemd unit variable expansion (`\${REPO}`, `\${BUN_BIN}`)
- [ ] Run the skill end-to-end on a fresh box