### PR TITLE
fix(scripts): align stale kimi-k2.6 labels with actual GLM-5.1 switch

### DIFF
--- a/scripts/init-fleet-master-discord.ts
+++ b/scripts/init-fleet-master-discord.ts
@@ -59,9 +59,9 @@ You are the fleet master. Your one and only job is worker lifecycle — create, 
 The Neuralwatt shim at http://host.docker.internal:3003 provides fuzzy model lookup:
 
   curl -sf http://host.docker.internal:3003/models/resolve/<query>
-  # {"model":"kimi-k2.6-fast","match":"contains"}
+  # {"model":"zai-org/GLM-5.1-FP8","match":"contains"}
 
-When the user asks for a model by natural name ("kimi fast", "glm"), curl that first and pass the returned id to create_worker / switch_backend. If the shim is unreachable, pass the literal string and let the tool error loudly.
+When the user asks for a model by natural name ("glm", "kimi fast"), curl that first and pass the returned id to create_worker / switch_backend. If the shim is unreachable, pass the literal string and let the tool error loudly.
 `;
 
 function genId(prefix: string): string {

--- a/scripts/init-fleet-master.ts
+++ b/scripts/init-fleet-master.ts
@@ -63,8 +63,8 @@ The Neuralwatt translation shim at \`http://host.docker.internal:3003\` exposes 
 
 When the user asks for a model by natural name ("kimi fast", "glm"), curl the resolve endpoint first (via Bash), then pass the returned id to create_worker / switch_backend:
 
-    curl -sf http://host.docker.internal:3003/models/resolve/kimi%20fast
-    # {"model":"kimi-k2.6-fast","match":"contains"}
+    curl -sf http://host.docker.internal:3003/models/resolve/glm
+    # {"model":"zai-org/GLM-5.1-FP8","match":"contains"}
 
 If the shim is unreachable, pass the user's literal string and let the tool error loudly.
 `;

--- a/scripts/test-fleet-lifecycle.ts
+++ b/scripts/test-fleet-lifecycle.ts
@@ -7,8 +7,8 @@
  *      marker FLEET-E2E-<id>". Master should ack + create.
  *   2. Assert DB: worker agent_group exists + channel provisioned.
  *   3. Post in worker's channel: "what's your marker?" — worker should recite.
- *   4. Post to master: "switch <name> to neuralwatt kimi-k2.6".
- *   5. Assert DB: agent_provider='neuralwatt', fleet_model='kimi-k2.6'.
+ *   4. Post to master: "switch <name> to neuralwatt with model zai-org/GLM-5.1-FP8".
+ *   5. Assert DB: agent_provider='neuralwatt', fleet_model='zai-org/GLM-5.1-FP8'.
  *   6. Post in worker's channel: "we talked about a marker. what was it?" —
  *      worker should remember (session preserved across provider switch).
  *   7. Post to master: "destroy worker <name>". Master acks.
@@ -355,7 +355,7 @@ async function main(): Promise<void> {
   console.log(`  worker:   ${WORKER_NAME}`);
   console.log(`  marker:   ${MARKER}`);
   console.log(`  master:   ${masterChannel}`);
-  console.log(`  backends: claude → ${SKIP_SWITCH ? 'skip switch' : 'neuralwatt kimi-k2.6'}`);
+  console.log(`  backends: claude → ${SKIP_SWITCH ? 'skip switch' : 'neuralwatt GLM-5.1-FP8'}`);
 
   console.log('\n[0] purge master backlog + reap orphan worker channels');
   purgeMasterBacklog();
@@ -414,10 +414,10 @@ async function main(): Promise<void> {
 
   const workerPreSwitchId = worker.id;
 
-  // ── 4. switch backend to neuralwatt kimi-k2.6 ──
+  // ── 4. switch backend to neuralwatt GLM-5.1-FP8 ──
   let switched: AgentGroupRow | undefined;
   if (!SKIP_SWITCH) {
-    console.log(`\n[4] master: switch worker to neuralwatt kimi-k2.6`);
+    console.log(`\n[4] master: switch worker to neuralwatt GLM-5.1-FP8`);
     await postMessage(
       masterChannel,
       debugToken,


### PR DESCRIPTION
## Summary
- `scripts/test-fleet-lifecycle.ts` actually posts \`switch worker ... to neuralwatt with model zai-org/GLM-5.1-FP8\`, but its header comment, banner log, and inline `── 4. ──` comment still say \"kimi-k2.6\". Misleading when triaging step-5 failures.
- `scripts/init-fleet-master*.ts` shim-resolve doc example used kimi-k2.6-fast — switched to GLM-5.1-FP8.

## Test plan
- [x] Re-ran lifecycle: ALL PASSED, log header reads `claude → neuralwatt GLM-5.1-FP8`.