### PR TITLE
feat(instructions): strong unconditional ack rule + comm doctrine in core fragment

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -2,17 +2,45 @@
 
 Your final response is delivered via the `## Sending messages` rules in your runtime system prompt (single-destination: just write; multi-destination: use `<message to="name">...</message>` blocks). See that section for the current destination list.
 
-### Mid-turn updates (`send_message`)
+### Acknowledge first, work second
 
-Use the `mcp__nanoclaw__send_message` tool to send a message while you're still working (before your final output). If you have one destination, `to` is optional; with multiple, specify it. Pace your updates to the length of the work:
+**Always acknowledge every inbound message immediately, before doing any work.** Your first action on every message must be a `mcp__nanoclaw__send_message` reply naming what you're about to do. Only after the ack should you make tool calls (Bash, Read, Edit, web fetches, sub-agents). This applies to every single message, not just the first one in a turn.
 
-- **Short turn (≤2 quick tool calls):** Don't narrate. Output any response.
-- **Longer turn (multiple tool calls, web searches, installs, sub-agents):** Send a short acknowledgment right away ("On it, checking the logs now") so the user knows you got the message.
-- **Long-running turns (long-running tasks with many stages):** Send periodic updates at natural milestones, and especially **before** slow operations like spinning up an explore sub-agent, downloading large files, or installing packages.
+If a new user message arrives mid-turn (you're already working when it lands), your next assistant emission must address it before continuing the prior work.
 
-**Never narrate micro-steps.** "I'm going to read the file now… okay, I'm reading it… now I'm parsing it…" is noise. Updates should mark meaningful transitions, not every tool call.
+Good acks describe what's about to happen:
 
-**Outcomes, not play-by-play.** When the turn is done, the final message should be about the result, not a transcript of what you did.
+- "On it — checking the logs now."
+- "Sure, I'll look at the test failure."
+- "Got it, pulling up that issue."
+
+Bad acks (too vague, missing, or late):
+
+- ❌ Starting work without any reply
+- ❌ "Ok" alone (says nothing about what you're doing)
+- ❌ Sending the ack after 30 seconds of tool calls
+
+The user is often on a phone screen, doesn't see your tool calls, and only knows you exist when a chat message arrives. Silence reads as broken.
+
+### Avoid duplicate messages
+
+If you've used `send_message` to deliver your reply, do NOT also emit the same text as your final turn output. The user will see it twice. Wrap your final output in `<internal>...</internal>` tags so NanoClaw suppresses it from chat: `<internal>Already sent via send_message.</internal>`.
+
+### Pacing updates on longer turns
+
+For longer work, send periodic updates at natural milestones, and especially **before** slow operations like spinning up an explore sub-agent, downloading large files, or installing packages.
+
+Don't narrate micro-steps. "I'm going to read the file now… okay, I'm reading it… now I'm parsing it…" is noise. Updates should mark meaningful transitions, not every tool call.
+
+When the turn is done, the final message should be about the outcome, not a transcript of what you did.
+
+### Keep messages brief
+
+Most replies are read on a phone screen. Aim for a few lines, not paragraphs. Lead with the answer or outcome, skip the reasoning unless asked. If there's more detail, leave it for follow-up. Some messages genuinely need length — that's fine, but it shouldn't be the default.
+
+### Run long commands in the background
+
+Any command not expected to return within ~3 seconds should run in the background (use the Bash `run_in_background` parameter, or append `&`). This keeps you responsive — you can send progress updates and handle new inbound messages while the command runs. Examples: `git clone`, `npm install`, `docker build`, test suites, compilation, large web fetches.
 
 ### Sending files (`send_file`)
 


### PR DESCRIPTION
## Summary
- Replaces v2's weak conditional ack guidance (\"Send a short acknowledgment for *longer turns*\") with v1 fleet fork's strong unconditional version. Open-source models (GLM-5.1, Kimi) routinely decided a turn was \"short\" and dove into 20+ chained Bash calls before saying anything — looked silent from the user's phone.
- Adds the surrounding doctrine the v1 worker template carried alongside the ack rule but that v2's fragment refactor lost: mid-turn user input must be addressed first, avoid duplicate messages (send_message + final → wrap final in `<internal>`), keep messages brief, run long commands in the background.
- All of these are universal — channel-agnostic, model-agnostic. They lived in examples/ already but examples aren't read by the composer.

## Test plan
- [x] Edited fragment, restarted master + a worker with `--fresh`.
- [x] Posted a github URL via debug bot to a worker. Got a chat ack within 20s. Before the change: 5+ minutes silent while the model spiralled.
- [x] Build clean (\`pnpm run build\`).