### PR TITLE
fix(discord): split long messages instead of silently truncating

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -43,6 +43,13 @@ registerChannelAdapter('discord', {
       botToken: env.DISCORD_BOT_TOKEN,
       extractReplyContext,
       supportsThreads: true,
+      // Discord per-message hard limit. Without this, the chat-sdk-discord
+      // adapter silently truncates anything over 2000 chars with "..." —
+      // long agent replies (research summaries, file dumps, etc.) get cut
+      // mid-sentence. Setting this triggers chat-sdk-bridge's splitForLimit
+      // which breaks long text on paragraph → line → space → hard-char
+      // boundaries and posts each chunk as a separate Discord message.
+      maxTextLength: 2000,
     });
   },
 });


### PR DESCRIPTION
## Summary
- chat-sdk-bridge already implements `splitForLimit` (paragraph → line → space → hard-char) and uses it whenever `maxTextLength` is configured. Discord adapter caps content at 2000 chars and silently truncates with \"...\" when text exceeds it.
- v2's Discord channel skipped wiring `maxTextLength`. v1 fleet split at 2000 in its own send path; that behavior was lost in the chat-sdk port.
- Set `maxTextLength: 2000` so the bridge's split path activates.

## Test plan
- [x] Built with `pnpm run build`, restarted host.
- [x] Created a fresh worker on neuralwatt GLM-5.1-FP8, asked for ~2500 chars of lorem ipsum.
- [x] Got two Discord messages: 1995 chars + 964 chars. No truncation, no \"...\".
- [x] Existing chat-sdk-bridge tests for `splitForLimit` still pass (`pnpm test`).