### PR TITLE
test(compose): unit + lifecycle assertions for instructions fragment wiring

### DIFF
--- a/scripts/test-fleet-lifecycle.ts
+++ b/scripts/test-fleet-lifecycle.ts
@@ -412,6 +412,21 @@ async function main(): Promise<void> {
   );
   step('worker recited codeword (instructions honored)', true, markerReply.content.slice(0, 80));
 
+  // After the worker has spawned (container-runner.buildMounts runs the
+  // composer), every *.instructions.md in container/agent-runner/src/
+  // mcp-tools/ should have a corresponding module-*.md in the worker's
+  // .claude-fragments/. Catches regressions where a new fragment is
+  // added but composer wiring drops it.
+  const fragmentsDir = `groups/${WORKER_NAME}/.claude-fragments`;
+  const fragmentFiles = fs.existsSync(fragmentsDir) ? fs.readdirSync(fragmentsDir) : [];
+  const requiredFragments = ['module-core.md', 'module-discord-formatting.md'];
+  const missing = requiredFragments.filter((f) => !fragmentFiles.includes(f));
+  step(
+    `composed fragments include ${requiredFragments.join(', ')}`,
+    missing.length === 0,
+    missing.length === 0 ? `${fragmentFiles.length} fragments` : `missing: ${missing.join(', ')}`,
+  );
+
   const workerPreSwitchId = worker.id;
 
   // ── 4. switch backend to neuralwatt GLM-5.1-FP8 ──

--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import { GROUPS_DIR } from './config.js';
+import { initContainerConfig } from './container-config.js';
+import type { AgentGroup } from './types.js';
+
+// Compose runs against the real GROUPS_DIR + the real
+// container/agent-runner/src/mcp-tools/ checkout. Tests use a folder
+// name unlikely to collide with a live install and clean up after.
+const TEST_FOLDER = '__compose_test_fixture__';
+
+const fixtureGroup: AgentGroup = {
+  id: 'ag-test',
+  name: 'compose-test',
+  folder: TEST_FOLDER,
+  agent_provider: 'claude',
+  created_at: new Date().toISOString(),
+  status: 'active',
+  fleet_role: 'worker',
+};
+
+const groupDir = path.join(GROUPS_DIR, TEST_FOLDER);
+
+function cleanup(): void {
+  if (fs.existsSync(groupDir)) {
+    fs.rmSync(groupDir, { recursive: true, force: true });
+  }
+}
+
+describe('composeGroupClaudeMd', () => {
+  beforeEach(() => {
+    cleanup();
+    fs.mkdirSync(groupDir, { recursive: true });
+    initContainerConfig(TEST_FOLDER);
+  });
+
+  afterEach(cleanup);
+
+  it('creates a fragment for every *.instructions.md in mcp-tools', () => {
+    const mcpToolsDir = path.join(process.cwd(), 'container', 'agent-runner', 'src', 'mcp-tools');
+    const expectedModules = fs
+      .readdirSync(mcpToolsDir)
+      .filter((f) => f.endsWith('.instructions.md'))
+      .map((f) => `module-${f.replace(/\.instructions\.md$/, '')}.md`);
+
+    composeGroupClaudeMd(fixtureGroup);
+
+    const fragmentsDir = path.join(groupDir, '.claude-fragments');
+    const found = fs.readdirSync(fragmentsDir);
+    for (const expected of expectedModules) {
+      expect(found).toContain(expected);
+    }
+  });
+
+  it('symlinks each module fragment to /app/src/mcp-tools/<name>.instructions.md', () => {
+    composeGroupClaudeMd(fixtureGroup);
+
+    const fragPath = path.join(groupDir, '.claude-fragments', 'module-core.md');
+    const target = fs.readlinkSync(fragPath);
+    expect(target).toBe('/app/src/mcp-tools/core.instructions.md');
+  });
+
+  it('imports every module fragment from CLAUDE.md', () => {
+    composeGroupClaudeMd(fixtureGroup);
+
+    const claudeMd = fs.readFileSync(path.join(groupDir, 'CLAUDE.md'), 'utf-8');
+    const fragmentsDir = path.join(groupDir, '.claude-fragments');
+    for (const fragment of fs.readdirSync(fragmentsDir)) {
+      expect(claudeMd).toContain(`@./.claude-fragments/${fragment}`);
+    }
+  });
+
+  it('regression: discord-formatting fragment is composed for every agent', () => {
+    composeGroupClaudeMd(fixtureGroup);
+
+    const fragPath = path.join(groupDir, '.claude-fragments', 'module-discord-formatting.md');
+    // lstat (not existsSync) — fragments are symlinks pointing at container
+    // paths (/app/src/...), so existsSync follows the dangling link.
+    expect(fs.lstatSync(fragPath).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(fragPath)).toBe('/app/src/mcp-tools/discord-formatting.instructions.md');
+  });
+
+  it('creates an empty CLAUDE.local.md if missing', () => {
+    composeGroupClaudeMd(fixtureGroup);
+    expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(true);
+  });
+
+  it('is deterministic — re-running over the same group produces the same fragment set', () => {
+    composeGroupClaudeMd(fixtureGroup);
+    const first = fs.readdirSync(path.join(groupDir, '.claude-fragments')).sort();
+
+    composeGroupClaudeMd(fixtureGroup);
+    const second = fs.readdirSync(path.join(groupDir, '.claude-fragments')).sort();
+
+    expect(second).toEqual(first);
+  });
+
+  it('prunes stale fragments when their source is removed', () => {
+    composeGroupClaudeMd(fixtureGroup);
+
+    // Plant a fake stale fragment that has no source. Re-run should drop it.
+    const stalePath = path.join(groupDir, '.claude-fragments', 'module-no-such-tool.md');
+    fs.writeFileSync(stalePath, '# stale');
+
+    composeGroupClaudeMd(fixtureGroup);
+    expect(fs.existsSync(stalePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- composeGroupClaudeMd had zero coverage. When discord-formatting was added (PR #73), nothing automatically validated the composer picked it up — only a manual restart + ls check would catch a regression.
- Adds unit tests over a temp group folder (every `*.instructions.md` produces a `module-*.md` symlink, CLAUDE.md @imports each, deterministic, stale fragments pruned, plus a pinned regression for `module-discord-formatting.md`).
- Adds a lifecycle e2e assertion after step 3: post-spawn, the worker's `.claude-fragments/` contains the required modules. Catches end-to-end regressions where the composer runs but the fragments don't reach the worker.

## Test plan
- [x] \`pnpm test\` — 192 passed (was 185), all 7 new tests green.
- [x] Manual sanity: composed fragments verified on the live master earlier today after PR #73 landed.