### PR TITLE
feat: restore Tailscale access for workers + fix Discord URL link wrapping

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -79,6 +79,14 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
 RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
+# ---- Tailscale CLI -----------------------------------------------------------
+# Workers reach Tailscale hosts (`tailscale ssh ops@prod-db-01`,
+# `tailscale status`) by talking to the host's tailscaled via the mounted
+# /var/run/tailscale/tailscaled.sock. The CLI just needs to be on PATH.
+# Optional — if the host doesn't run tailscaled, the socket isn't mounted
+# and the CLI prints a clear "no tailscaled running" error.
+RUN curl -fsSL https://tailscale.com/install.sh | sh
+
 # ---- agent-runner deps -------------------------------------------------------
 # Deps are cached independently of CLI versions. Source is NOT baked in —
 # it's provided by the shared RO mount at runtime.

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,15 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-// Re-implement the same regex inline so this test pins behavior even if
-// the helper is refactored or moved. Equivalent to stripDuplicateLinks
-// in src/channels/discord.ts.
-function stripDuplicateLinks(text: string): string {
-  return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (full, label, url) => {
-    if (label === url) return url;
-    if (/^https?:\/\//.test(label) && /^https?:\/\//.test(url)) return url;
-    return full;
-  });
-}
+import { stripDuplicateLinks } from './discord.js';
 
 describe('Discord stripDuplicateLinks', () => {
   it('collapses [url](url) where label equals url', () => {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -20,26 +20,57 @@ function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
 
 /**
  * Discord doesn't render `[text](url)` markdown link syntax in regular
- * messages — it shows the brackets and parens as literal characters.
- * chat-sdk-discord's renderer emits links in that exact form because the
- * SDK's markdown parser turns bare URLs into link nodes upstream. By the
- * time we have the rendered string, all we can do is collapse the
- * pathological cases:
+ * messages — brackets and parens show as literal characters. chat-sdk-
+ * discord's `formatConverter.renderPostable` turns bare URLs in agent
+ * markdown into link nodes and emits them as `[url](url)`. Collapse those
+ * pathological cases back to a bare URL:
  *
- *   [url](url)             → url             (label is the same URL)
- *   [https://...](url)     → url             (label is also a URL — Discord
- *                                              auto-links the bare URL anyway)
+ *   [url](url)             → url
+ *   [http url](other url)  → url
  *
- * Leave intentional `[label](url)` (different label and url) alone — the
- * markdown is broken there too on Discord, but stripping the label loses
- * information. The instructions fragment tells agents to write bare URLs
- * directly; this transform handles the common round-trip case where they did.
+ * Leave intentional `[label](url)` (non-URL label) alone — markdown is
+ * still broken there on Discord, but losing the label is worse than
+ * showing it raw.
  */
-function stripDuplicateLinks(text: string): string {
+export function stripDuplicateLinks(text: string): string {
   return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (full, label, url) => {
     if (label === url) return url;
     if (/^https?:\/\//.test(label) && /^https?:\/\//.test(url)) return url;
     return full;
+  });
+}
+
+/**
+ * Wrap the chat-sdk-discord adapter so we can post-process the rendered
+ * Discord text after `formatConverter.renderPostable` has done its
+ * markdown→Discord conversion. The bridge's `transformOutboundText` hook
+ * runs *before* render and so doesn't see the link wrapping. Wrapping at
+ * the adapter level lets us render once, fix the duplicate-link cases,
+ * and short-circuit the second render by passing `{raw: rendered}`
+ * (which the converter forwards verbatim except for @-mention conversion).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function wrapAdapterForLinkFix(adapter: any): any {
+  const origPost = adapter.postMessage?.bind(adapter);
+  const origEdit = adapter.editMessage?.bind(adapter);
+  const renderer = adapter.formatConverter;
+  if (!origPost || !renderer) return adapter;
+
+  const fix = (msg: Record<string, unknown>): Record<string, unknown> => {
+    if (typeof msg !== 'object' || msg === null) return msg;
+    if ('raw' in msg) return msg;
+    if (!('markdown' in msg) && !('text' in msg)) return msg;
+    const rendered: string = renderer.renderPostable(msg);
+    const fixed = stripDuplicateLinks(rendered);
+    if (fixed === rendered) return msg;
+    return { ...msg, raw: fixed, markdown: undefined, text: undefined };
+  };
+
+  return Object.assign(Object.create(Object.getPrototypeOf(adapter)), adapter, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postMessage: (tid: string, message: any) => origPost(tid, fix(message)),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    editMessage: origEdit ? (tid: string, mid: string, message: any) => origEdit(tid, mid, fix(message)) : undefined,
   });
 }
 
@@ -63,7 +94,7 @@ registerChannelAdapter('discord', {
       applicationId: env.DISCORD_APPLICATION_ID,
     });
     return createChatSdkBridge({
-      adapter: discordAdapter,
+      adapter: wrapAdapterForLinkFix(discordAdapter),
       concurrency: 'concurrent',
       botToken: env.DISCORD_BOT_TOKEN,
       extractReplyContext,
@@ -75,9 +106,6 @@ registerChannelAdapter('discord', {
       // which breaks long text on paragraph → line → space → hard-char
       // boundaries and posts each chunk as a separate Discord message.
       maxTextLength: 2000,
-      // Collapse `[url](url)` round-trips back to bare URLs — Discord shows
-      // brackets/parens literal, so duplicate-label links read as junk.
-      transformOutboundText: stripDuplicateLinks,
     });
   },
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -364,6 +364,16 @@ function buildMounts(
     mounts.push(...providerContribution.mounts);
   }
 
+  // Tailscale socket — lets containers run `tailscale ssh` and other CLI ops
+  // through the host's tailscaled. The container's tailscale binary (installed
+  // by container/Dockerfile) talks to this socket directly. Optional — if
+  // tailscaled isn't running on the host, the mount is skipped and workers
+  // simply lack Tailscale access.
+  const tailscaleSock = '/var/run/tailscale/tailscaled.sock';
+  if (fs.existsSync(tailscaleSock)) {
+    mounts.push({ hostPath: tailscaleSock, containerPath: tailscaleSock, readonly: false });
+  }
+
   return mounts;
 }
 
@@ -468,6 +478,14 @@ async function buildContainerArgs(
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+
+  // Tailscale DNS — when the host runs tailscaled, MagicDNS lets the
+  // container resolve hosts like `prod-db-01` via 100.100.100.100. The
+  // public fallback (1.1.1.1) keeps github/pypi/etc working. Without
+  // these, `tailscale ssh ops@host` resolves the wrong way and fails.
+  if (fs.existsSync('/var/run/tailscale/tailscaled.sock')) {
+    args.push('--dns', '100.100.100.100', '--dns', '1.1.1.1');
+  }
 
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).


### PR DESCRIPTION
## Summary

Two v1→v2 ports/fixes hitting the same files.

### Tailscale (regression from v1)

v1 fleet workers could \`tailscale ssh ops@host\`, \`tailscale status\`, etc. v2 dropped three pieces during the port:

- \`container/Dockerfile\`: install the \`tailscale\` CLI via the official script.
- \`src/container-runner.ts\` (mounts): bind-mount \`/var/run/tailscale/tailscaled.sock\` when the host runs tailscaled.
- \`src/container-runner.ts\` (docker args): add \`--dns 100.100.100.100 --dns 1.1.1.1\` so MagicDNS resolves Tailscale hostnames and public DNS still works as fallback.

### Discord URL collapse (refinement of PR #75)

PR #75 wired \`stripDuplicateLinks\` via the chat-sdk-bridge's \`transformOutboundText\` hook. Wrong layer — that hook runs *before* chat-sdk-discord's \`formatConverter.renderPostable\` parses the markdown, so bare URLs got re-wrapped into \`[url](url)\` after the transform.

Move the fix into a Discord-adapter wrapper: render via the converter, run the regex, pass the cleaned output as \`{raw: ...}\` so the converter forwards verbatim without re-parsing. Drop the now-defunct \`transformOutboundText\` config.

## Test plan

- [x] \`pnpm test\` clean (198 tests, 6 in discord.test.ts).
- [x] Live verify Tailscale: \`docker exec <worker> tailscale status\` lists the user's whole tailnet.
- [x] Live verify URL collapse: GLM-5.1-FP8 worker asked to share back \`https://example.com/foo?bar=baz\` replied with the bare URL — no \`[url](url)\` wrapping in the Discord message.