### PR TITLE
fix(bin/ncf): resolve symlinks so the wrapper works from ~/.local/bin

### DIFF
--- a/bin/ncf
+++ b/bin/ncf
@@ -1,4 +1,8 @@
 #!/bin/sh
 # ncf — NanoClaw Fleet CLI wrapper. Invokes scripts/ncf.ts via tsx.
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Resolves $0 through any symlinks so the wrapper works when symlinked
+# into ~/.local/bin or /usr/local/bin (which is the supported install
+# pattern — symlink, don't copy, so updates flow through).
+SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
 exec "$SCRIPT_DIR/node_modules/.bin/tsx" "$SCRIPT_DIR/scripts/ncf.ts" "$@"


### PR DESCRIPTION
## Summary
Wrapper used \`dirname \"\$0\"\` to find the project root. When symlinked into \`~/.local/bin/ncf\` it resolved to \`~/.local\` and tsx + ncf.ts paths 404'd. Resolve \$0 through \`readlink -f\` first, fallback to literal if unavailable. Makes \`ln -s ~/git/nanoclaw-fleet/bin/ncf ~/.local/bin/ncf\` actually work.

## Test plan
- [x] \`ncf\` from a fresh shell with the symlink in place prints the help banner.
- [x] \`ncf list\` returns the worker JSON.
- [x] \`ncf restart <worker>\` works.