### PR TITLE
fix(poll-loop): thread AbortSignal so tests can stop the loop cleanly

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,6 @@
 #!/usr/bin/env sh
-# Run the same checks CI runs (minus bun container tests, which currently
-# flake — see the runPollLoop leak; tests don't actually cancel the loop on
-# abort, so the loop polls onto a closed DB after teardown and bun reports
-# late-describe / sqlite errors). Drop them back in once that's fixed.
+# Run the same checks CI runs, before push. Catches format / type / test
+# regressions locally so we don't bounce off CI and burn rerun cycles.
 #
 # Skip with `git push --no-verify` only when you know what you're doing.
 
@@ -19,5 +17,8 @@ pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
 
 echo "→ host tests"
 pnpm exec vitest run
+
+echo "→ container tests"
+(cd container/agent-runner && bun test)
 
 echo "✓ all pre-push checks green"

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -21,7 +21,11 @@ afterEach(() => {
   closeSessionDb();
 });
 
-function insertMessage(id: string, content: object, opts?: { platformId?: string; channelType?: string; threadId?: string }) {
+function insertMessage(
+  id: string,
+  content: object,
+  opts?: { platformId?: string; channelType?: string; threadId?: string },
+) {
   getInboundDb()
     .prepare(
       `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
@@ -32,7 +36,11 @@ function insertMessage(id: string, content: object, opts?: { platformId?: string
 
 describe('poll loop integration', () => {
   it('should pick up a message, process it, and write a response', async () => {
-    insertMessage('m1', { sender: 'Alice', text: 'What is the meaning of life?' }, { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' });
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'What is the meaning of life?' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
 
     const provider = new MockProvider({}, () => '<message to="discord-test">42</message>');
 
@@ -93,18 +101,22 @@ describe('poll loop integration', () => {
   });
 });
 
-// Helper: run poll loop until aborted or timeout
+// Helper: run poll loop until aborted or timeout. Passes the signal
+// directly into runPollLoop so the loop exits cleanly at its next
+// iteration boundary instead of leaving a leaked while(true) running
+// past closeSessionDb (which was the source of the bun-test
+// SQLiteError + late-describe flakes).
 async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
-  return Promise.race([
-    runPollLoop({
-      provider,
-      cwd: '/tmp',
-    }),
-    new Promise<void>((_, reject) => {
-      signal.addEventListener('abort', () => reject(new Error('aborted')));
-    }),
-    new Promise<void>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
-  ]);
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+  // Combined signal: abort if either the test's controller fires or the
+  // timeout elapses. AbortSignal.any is supported in Bun + Node 22+.
+  const combined = AbortSignal.any([signal, timeoutController.signal]);
+  try {
+    await runPollLoop({ provider, cwd: '/tmp', signal: combined });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function waitFor(condition: () => boolean, timeoutMs: number): Promise<void> {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -5,7 +5,14 @@ import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { logTurn } from './audit-log.js';
 import { getStoredSessionId, setStoredSessionId, clearStoredSessionId } from './db/session-state.js';
 import { getSessionRouting } from './db/session-routing.js';
-import { formatMessages, extractRouting, categorizeMessage, isClearCommand, stripInternalTags, type RoutingContext } from './formatter.js';
+import {
+  formatMessages,
+  extractRouting,
+  categorizeMessage,
+  isClearCommand,
+  stripInternalTags,
+  type RoutingContext,
+} from './formatter.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
 
 const POLL_INTERVAL_MS = 1000;
@@ -25,10 +32,18 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * Optional abort signal. When aborted, the loop exits at its next
+   * boundary instead of running forever. In production the loop is kept
+   * alive for the container's lifetime (no signal passed); tests pass
+   * an `AbortController.signal` so they can stop the loop deterministically
+   * before tearing down the session DB.
+   */
+  signal?: AbortSignal;
 }
 
 /**
- * Main poll loop. Runs indefinitely until the process is killed.
+ * Main poll loop. Runs until aborted or the process is killed.
  *
  * 1. Poll messages_in for pending rows
  * 2. Format into prompt, call provider.query()
@@ -62,6 +77,10 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
   let pollCount = 0;
   while (true) {
+    if (config.signal?.aborted) {
+      log('Poll loop aborted via signal');
+      return;
+    }
     // Skip system messages — they're responses for MCP tools (e.g., ask_user_question)
     const messages = getPendingMessages().filter((m) => m.kind !== 'system');
     pollCount++;
@@ -191,7 +210,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     const skippedSet = new Set(skipped);
     const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
     try {
-      const result = await processQuery(query, routing, processingIds);
+      const result = await processQuery(query, routing, processingIds, config.signal);
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setStoredSessionId(continuation);
@@ -269,9 +288,27 @@ async function processQuery(
   query: AgentQuery,
   routing: RoutingContext,
   initialBatchIds: string[],
+  signal: AbortSignal | undefined,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
+
+  // If the caller's signal aborts mid-query, end the query promptly so the
+  // for-await below exits and the outer loop can return at its next
+  // iteration. Without this, mid-query aborts (e.g. test teardown) would
+  // wait forever on a long-running query stream.
+  const onAbort = (): void => {
+    try {
+      query.abort();
+    } catch {
+      // Best effort — provider may have already ended.
+    }
+  };
+  if (signal?.aborted) {
+    onAbort();
+  } else if (signal) {
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open is
@@ -359,6 +396,7 @@ async function processQuery(
   } finally {
     done = true;
     clearInterval(pollHandle);
+    signal?.removeEventListener('abort', onAbort);
   }
 
   return { continuation: queryContinuation };
@@ -373,7 +411,9 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
       log(`Result: ${event.text ? event.text.slice(0, 200) : '(empty)'}`);
       break;
     case 'error':
-      log(`Error: ${event.message} (retryable: ${event.retryable}${event.classification ? `, ${event.classification}` : ''})`);
+      log(
+        `Error: ${event.message} (retryable: ${event.retryable}${event.classification ? `, ${event.classification}` : ''})`,
+      );
       break;
     case 'progress':
       log(`Progress: ${event.message}`);


### PR DESCRIPTION
## Summary
\`runPollLoop\` ran forever — \`while (true)\` with no exit. \`integration.test.ts\` "stopped" it via Promise.race against an AbortController, but the race only rejected the wrapper; the actual loop kept running. After the test called \`closeSessionDb()\`, the still-running loop polled onto a closed handle → \`SQLiteError\`. The leaked module also kept \`factory.test.ts\` in load limbo past bun's "test run completed" boundary, producing the "Cannot call describe()" sibling error. Both surfaced as the bun container-test flake noted in PR #84.

Fix:

- \`PollLoopConfig.signal?: AbortSignal\`. Outer while-true checks \`signal?.aborted\` at every iteration top and returns when set.
- \`processQuery\` wires the signal to \`query.abort()\` so an in-flight query ends promptly. Otherwise a pushed follow-up keeps the inner \`for await (event of query.events)\` alive past the abort. Listener removed in finally.
- \`integration.test.ts\` passes the signal directly via \`AbortSignal.any([controller.signal, timeoutController.signal])\`. The Promise.race wrapper that masked the bug is gone.
- Re-enabled the bun container-tests step in \`.husky/pre-push\` (disabled in PR #84 while this fix was pending).

## Test plan
- [x] 4/4 consecutive \`bun test\` runs green (50 pass, 0 fail). The late-describe + SQLiteError pair stopped reproducing.
- [x] \`bash .husky/pre-push\` exits clean.
- [x] No host-side test changes; vitest still 198 passing.