### PR TITLE
test: lock in throbber retarget + restart banner behaviour

### DIFF
--- a/container/agent-runner/src/restart-banner.test.ts
+++ b/container/agent-runner/src/restart-banner.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { closeSessionDb, getInboundDb, initTestSessionDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { clearStoredSessionId, setStoredSessionId } from './db/session-state.js';
+import { runPollLoop } from './poll-loop.js';
+import { MockProvider } from './providers/mock.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES ('discord-test', 'Discord Test', 'channel', 'discord', 'chan-1', NULL)`,
+    )
+    .run();
+  clearStoredSessionId();
+});
+
+afterEach(() => {
+  clearStoredSessionId();
+  closeSessionDb();
+});
+
+function insertMessage(id: string, text: string): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+       VALUES (?, 'chat', datetime('now'), 'pending', 'chan-1', 'discord', 'thread-1', ?)`,
+    )
+    .run(id, JSON.stringify({ sender: 'Test', text }));
+}
+
+async function runUntil(provider: MockProvider, predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const controller = new AbortController();
+  const timeoutCtl = new AbortController();
+  const timer = setTimeout(() => timeoutCtl.abort(), timeoutMs);
+  const combined = AbortSignal.any([controller.signal, timeoutCtl.signal]);
+  const loop = runPollLoop({ provider, cwd: '/tmp', signal: combined });
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  controller.abort();
+  try {
+    await loop;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+describe('restart banner', () => {
+  it("prepends '[CONTAINER RESTARTED at ...]' to the first prompt when resuming a session", async () => {
+    setStoredSessionId('prior-session-id');
+    insertMessage('m1', 'hello');
+
+    let firstPrompt: string | null = null;
+    const provider = new MockProvider({}, (prompt) => {
+      if (firstPrompt === null) firstPrompt = prompt;
+      return '<message to="discord-test">ok</message>';
+    });
+
+    await runUntil(provider, () => getUndeliveredMessages().length > 0);
+
+    expect(firstPrompt).not.toBeNull();
+    expect(firstPrompt!).toMatch(/^\[CONTAINER RESTARTED at /);
+    expect(firstPrompt!).toContain('workspace and repos are intact');
+    expect(firstPrompt!).toContain('hello');
+  });
+
+  it('does not prepend the banner on a fresh session (no stored session id)', async () => {
+    insertMessage('m1', 'hello');
+
+    let firstPrompt: string | null = null;
+    const provider = new MockProvider({}, (prompt) => {
+      if (firstPrompt === null) firstPrompt = prompt;
+      return '<message to="discord-test">ok</message>';
+    });
+
+    await runUntil(provider, () => getUndeliveredMessages().length > 0);
+
+    expect(firstPrompt).not.toBeNull();
+    expect(firstPrompt!).not.toContain('CONTAINER RESTARTED');
+  });
+
+  it('only prepends the banner on the first batch — subsequent batches are clean', async () => {
+    setStoredSessionId('prior-session-id');
+    insertMessage('m1', 'first');
+
+    const prompts: string[] = [];
+    const provider = new MockProvider({}, (prompt) => {
+      prompts.push(prompt);
+      return '<message to="discord-test">ok</message>';
+    });
+
+    // Run, observe first batch processed, insert second message, observe second.
+    const controller = new AbortController();
+    const timeoutCtl = new AbortController();
+    const timer = setTimeout(() => timeoutCtl.abort(), 5000);
+    const combined = AbortSignal.any([controller.signal, timeoutCtl.signal]);
+    const loop = runPollLoop({ provider, cwd: '/tmp', signal: combined });
+
+    // Wait for first turn to land.
+    const start = Date.now();
+    while (prompts.length < 1 && Date.now() - start < 3000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    insertMessage('m2', 'second');
+
+    while (prompts.length < 2 && Date.now() - start < 5000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    controller.abort();
+    try {
+      await loop;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    expect(prompts.length).toBeGreaterThanOrEqual(2);
+    expect(prompts[0]).toMatch(/^\[CONTAINER RESTARTED at /);
+    expect(prompts[1]).not.toContain('CONTAINER RESTARTED');
+  });
+});

--- a/src/modules/throbber/index.test.ts
+++ b/src/modules/throbber/index.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { _throbberInflightForTest, setThrobberAdapter, startThrobber, stopThrobber } from './index.js';
+
+type Call = ['add' | 'remove', string, string];
+
+let calls: Call[];
+
+function makeAdapter() {
+  return {
+    addReaction: async (
+      _channelType: string,
+      _platformId: string,
+      _threadId: string | null,
+      messageId: string,
+      emoji: string,
+    ): Promise<void> => {
+      calls.push(['add', messageId, emoji]);
+    },
+    removeReaction: async (
+      _channelType: string,
+      _platformId: string,
+      _threadId: string | null,
+      messageId: string,
+      emoji: string,
+    ): Promise<void> => {
+      calls.push(['remove', messageId, emoji]);
+    },
+  };
+}
+
+const SESSION = 'sess-test';
+const AG = 'ag-test';
+const CHANNEL_TYPE = 'discord';
+const PLATFORM_ID = 'discord:guild:channel';
+
+beforeEach(() => {
+  calls = [];
+  setThrobberAdapter(makeAdapter());
+});
+
+afterEach(() => {
+  // Always tear down so the next test gets a fresh map. stopThrobber
+  // is idempotent if no throbber is registered for this session.
+  stopThrobber(SESSION);
+});
+
+describe('throbber', () => {
+  it('startThrobber registers a single inflight message id', () => {
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    expect(_throbberInflightForTest(SESSION)).toEqual(['m1']);
+  });
+
+  it('retarget appends new inbound id to inflight without stripping the prior one', () => {
+    // The PR #80 regression: retargeting the throbber to a newer
+    // message used to unreact every emoji on the older message,
+    // making older inbound messages read as silent. The fix tracks
+    // every inflight message and only cycles on the latest while
+    // leaving prior ones with their last emoji as an "I saw it"
+    // badge until the turn ends.
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm2');
+    expect(_throbberInflightForTest(SESSION)).toEqual(['m1', 'm2']);
+
+    // No unreact should fire on m1 just because m2 came in.
+    const removesOnM1 = calls.filter((c) => c[0] === 'remove' && c[1] === 'm1');
+    expect(removesOnM1).toHaveLength(0);
+  });
+
+  it('retarget is idempotent — repeating the same message id does not duplicate', () => {
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    expect(_throbberInflightForTest(SESSION)).toEqual(['m1']);
+  });
+
+  it('stopThrobber clears reactions on every tracked inflight message', () => {
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm2');
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm3');
+
+    stopThrobber(SESSION);
+
+    const removedMessageIds = new Set(calls.filter((c) => c[0] === 'remove').map((c) => c[1]));
+    expect(removedMessageIds.has('m1')).toBe(true);
+    expect(removedMessageIds.has('m2')).toBe(true);
+    expect(removedMessageIds.has('m3')).toBe(true);
+
+    // After stop, the throbber is gone — inflight returns undefined.
+    expect(_throbberInflightForTest(SESSION)).toBeUndefined();
+  });
+
+  it('stopThrobber on an unknown session is a no-op', () => {
+    expect(() => stopThrobber('sess-never-started')).not.toThrow();
+    expect(calls).toEqual([]);
+  });
+
+  it('startThrobber without an addReaction-capable adapter is a no-op', () => {
+    setThrobberAdapter({}); // no addReaction
+    startThrobber(SESSION, AG, CHANNEL_TYPE, PLATFORM_ID, null, 'm1');
+    expect(_throbberInflightForTest(SESSION)).toBeUndefined();
+  });
+});

--- a/src/modules/throbber/index.ts
+++ b/src/modules/throbber/index.ts
@@ -197,6 +197,15 @@ function readMtime(hbPath: string): number {
   }
 }
 
+/**
+ * Test-only — surface the in-flight message list a session is tracking.
+ * Used by src/modules/throbber/index.test.ts to verify retarget keeps
+ * prior messages instead of stripping their reactions.
+ */
+export function _throbberInflightForTest(sessionId: string): string[] | undefined {
+  return throbbers.get(sessionId)?.inflight.map((m) => m.messageId);
+}
+
 export function stopThrobber(sessionId: string): void {
   const t = throbbers.get(sessionId);
   if (!t) return;


### PR DESCRIPTION
## Summary
PR #80 (throbber retarget keeps prior reactions) and PR #81 (container restart banner) both shipped without direct unit coverage. Add tests so the regressions can't silently come back.

\`src/modules/throbber/index.test.ts\` (vitest, 6 tests):

- startThrobber registers single inflight id
- retarget appends new id without stripping prior — the exact PR #80 regression
- retarget is idempotent on repeat id
- stopThrobber clears reactions on every tracked id, drops the map entry
- stopThrobber on unknown session is a no-op
- startThrobber with an adapter that has no addReaction is a no-op

A tiny \`_throbberInflightForTest(sessionId)\` export surfaces the inflight list without leaking the \`ThrobberTarget\` shape.

\`container/agent-runner/src/restart-banner.test.ts\` (bun:test, 3 tests):

- Prepends \`[CONTAINER RESTARTED at ...]\` on first prompt when resuming
- Does NOT prepend on a fresh session (no stored session id)
- Only prepends on the first batch — second batch in same container lifetime is clean

## Test plan
- [x] vitest: 6/6 throbber tests pass.
- [x] bun: 3/3 banner tests pass.
- [x] Full \`bash .husky/pre-push\` green: 53 pass total.