### PR TITLE
feat(shim,ncf): log every /v1/messages req/resp + ncf trace command

### DIFF
--- a/docs/fleet/architecture/observability.md
+++ b/docs/fleet/architecture/observability.md
@@ -35,13 +35,13 @@ Grep one id across host and container logs to follow a request end-to-end. There
 {"timestamp":"2026-04-24T...","event":"destroyed","worker":"foo","folder":"discord_foo"}
 ```
 
-| Field | Meaning |
-|-|-|
-| `timestamp` | ISO 8601 UTC |
-| `event` | `created` \| `destroyed` \| `backend_switched` \| `resumed` |
-| `worker` | display name |
-| `folder` | folder slug (e.g. `discord_foo`) |
-| `details` | event-specific (backend, model, parent folder, etc.) |
+| Field       | Meaning                                                     |
+| ----------- | ----------------------------------------------------------- |
+| `timestamp` | ISO 8601 UTC                                                |
+| `event`     | `created` \| `destroyed` \| `backend_switched` \| `resumed` |
+| `worker`    | display name                                                |
+| `folder`    | folder slug (e.g. `discord_foo`)                            |
+| `details`   | event-specific (backend, model, parent folder, etc.)        |
 
 Written by `src/modules/fleet/events.ts::logWorkerEvent()` from each delivery handler. Queryable from the host via `ncf history` and from inside any container via the `worker_history` MCP tool, both with filters on worker, event type, since-date, and limit.
 
@@ -66,6 +66,34 @@ Source: `container/agent-runner/src/audit-log.ts`. Tokens come straight from the
 
 `ncf turns <name> [--limit N] [--slow MS]` reads this file. Useful when triaging "this worker is slow" — `ncf turns foo --slow 5000` shows turns over five seconds.
 
+## Shim req/resp traces
+
+`turns.jsonl` answers "did this turn finish, and how long did it take?" but not "what did the agent ask the model, and what came back?" For that, the shim writes one line per `/v1/messages` call into `logs/shim-traces/<folder>.jsonl`:
+
+```json
+{
+  "ts": "2026-04-27T...",
+  "worker": "discord_foo",
+  "backend": "neuralwatt",
+  "model_in": "claude-sonnet-4-6",
+  "model_out": "Qwen/Qwen3.5-397B-A17B-FP8",
+  "status": 200,
+  "stream": true,
+  "latency_ms": 4321,
+  "input_tokens": 35506,
+  "output_tokens": 612,
+  "stop_reason": "end_turn",
+  "req_body": { "model": "...", "messages": [...], "system": "...", "tools": [...] },
+  "resp_body": { "content": [{"type":"text","text":"..."}, {"type":"tool_use","name":"Bash","input":{...}}], "stop_reason": "end_turn" }
+}
+```
+
+The full request body and an Anthropic-shape final response are stored — for streaming, the response is reconstructed from the SSE we already emit, so no extra parsing happens on the hot path. Tool-use inputs are reassembled from `input_json_delta` fragments and JSON-parsed.
+
+`ncf trace <name> [--limit N] [--full] [--errors-only] [--json]` reads this file. The default print summarises each entry — system prompt + last few messages + assistant content blocks, each truncated. `--full` keeps everything verbatim.
+
+This only covers traffic that flows through the shim — neuralwatt-backed workers and any anthropic-backed workers that route through it. A claude-direct worker that talks straight to `api.anthropic.com` won't appear here. Disable with `SHIM_TRACES=0` or change the directory with `SHIM_TRACES_DIR=...`. There's no automatic rotation: delete the files when they get too big — they're diagnostic, not historical.
+
 ## Energy read-through
 
 The Neuralwatt shim writes per-folder usage into a shared accumulator file. When `NW_SHIM_USAGE_PATH` points at it, the fleet reads through:
@@ -84,14 +112,15 @@ This is not a log — it's a side-channel for liveness. Mentioned here because i
 
 ## Log surfaces
 
-| Surface | What's there | How to read |
-|-|-|-|
-| `logs/host.log` (or systemd journal) | Host pretty logs | `tail -f logs/host.log` |
-| `logs/host.jsonl` | Host JSONL (one line per event) | `jq 'select(.level >= 50)' logs/host.jsonl` |
-| `logs/worker-events.jsonl` | Lifecycle audit | `ncf history` |
-| `data/v2-sessions/<ag>/<sess>/turns.jsonl` | Per-turn audit | `ncf turns <worker>` |
-| `docker logs <container>` | Container stdout/stderr | `ncf logs <worker> --follow` |
-| `data/worker-usage.json` | Shim's per-folder accumulator | `curl http://localhost:3003/usage` (when shim is up) |
+| Surface                                    | What's there                    | How to read                                          |
+| ------------------------------------------ | ------------------------------- | ---------------------------------------------------- |
+| `logs/host.log` (or systemd journal)       | Host pretty logs                | `tail -f logs/host.log`                              |
+| `logs/host.jsonl`                          | Host JSONL (one line per event) | `jq 'select(.level >= 50)' logs/host.jsonl`          |
+| `logs/worker-events.jsonl`                 | Lifecycle audit                 | `ncf history`                                        |
+| `data/v2-sessions/<ag>/<sess>/turns.jsonl` | Per-turn audit                  | `ncf turns <worker>`                                 |
+| `logs/shim-traces/<folder>.jsonl`          | Per-request shim req/resp       | `ncf trace <worker>`                                 |
+| `docker logs <container>`                  | Container stdout/stderr         | `ncf logs <worker> --follow`                         |
+| `data/worker-usage.json`                   | Shim's per-folder accumulator   | `curl http://localhost:3003/usage` (when shim is up) |
 
 ## Tracing one request
 
@@ -111,11 +140,12 @@ Or, simpler: run `ncf logs <worker> --follow` while you send the message, and yo
 
 ## Files
 
-| File | Role |
-|-|-|
-| `src/modules/fleet/events.ts` | Worker event log |
-| `container/agent-runner/src/audit-log.ts` | Per-turn audit writer |
-| `src/router.ts`, `src/delivery.ts` | Trace id logging on host critical path |
-| `container/agent-runner/src/poll-loop.ts` | Trace id logging in container |
-| `container/agent-runner/src/mcp-tools/introspect.ts` | `get_backend`, `get_usage`, `get_models` MCP tools |
-| `scripts/ncf.ts` | `history`, `turns`, `logs`, `session` commands |
+| File                                                 | Role                                                    |
+| ---------------------------------------------------- | ------------------------------------------------------- |
+| `src/modules/fleet/events.ts`                        | Worker event log                                        |
+| `container/agent-runner/src/audit-log.ts`            | Per-turn audit writer                                   |
+| `src/router.ts`, `src/delivery.ts`                   | Trace id logging on host critical path                  |
+| `container/agent-runner/src/poll-loop.ts`            | Trace id logging in container                           |
+| `container/agent-runner/src/mcp-tools/introspect.ts` | `get_backend`, `get_usage`, `get_models` MCP tools      |
+| `scripts/ncf.ts`                                     | `history`, `turns`, `trace`, `logs`, `session` commands |
+| `tools/anthropic-shim.ts`                            | Inference proxy + shim-traces.jsonl writer              |

--- a/docs/fleet/reference/cli.md
+++ b/docs/fleet/reference/cli.md
@@ -109,26 +109,41 @@ ncf turns foo --slow 5000           # turns over five seconds
 ncf turns foo --json | jq
 ```
 
+### `ncf trace <name> [--limit N] [--full] [--errors-only] [--json]`
+
+Read `logs/shim-traces/<folder>.jsonl` — one entry per `/v1/messages` call through the shim, with the full request body and an Anthropic-shape final response. Use this when a worker isn't responding and you need to see what it actually sent the model and what came back.
+
+```bash
+ncf trace foo                       # last 5 entries, summarised
+ncf trace foo --limit 1             # most recent only
+ncf trace foo --full                # don't truncate any field
+ncf trace foo --errors-only         # only non-2xx + transport errors
+ncf trace foo --json | jq           # raw JSONL
+```
+
+Only covers traffic that flows through the shim — neuralwatt-backed workers, plus anthropic-backed ones if their `ANTHROPIC_BASE_URL` points at the shim. A claude-direct worker that talks straight to `api.anthropic.com` won't appear here. Disable globally with `SHIM_TRACES=0`; relocate with `SHIM_TRACES_DIR=/some/path`.
+
 ### `ncf rebuild`
 
 Wraps `container/build.sh`. Rebuilds the base image, layers your personal Dockerfile if present, retags `:latest`.
 
 ## Cheat sheet
 
-| Task | Command |
-|-|-|
-| Health check | `ncf status` |
-| Diagnostic dump | `ncf debug` |
-| Make a worker | `ncf create <name>` |
-| Switch backend | `ncf switch <name> <backend> [model]` |
-| Restart worker | `ncf restart <name>` |
-| Reset session | `ncf restart <name> --fresh` |
-| Image rebuild | `ncf rebuild` |
-| Watch live logs | `ncf logs <name> --follow` |
-| Slow-turn audit | `ncf turns <name> --slow 5000` |
-| Lifecycle audit | `ncf history` |
-| Cleanup orphans | `ncf reap-orphans --confirm` |
-| Send a probe | `ncf inject --wait <name> "ping"` |
+| Task                      | Command                               |
+| ------------------------- | ------------------------------------- |
+| Health check              | `ncf status`                          |
+| Diagnostic dump           | `ncf debug`                           |
+| Make a worker             | `ncf create <name>`                   |
+| Switch backend            | `ncf switch <name> <backend> [model]` |
+| Restart worker            | `ncf restart <name>`                  |
+| Reset session             | `ncf restart <name> --fresh`          |
+| Image rebuild             | `ncf rebuild`                         |
+| Watch live logs           | `ncf logs <name> --follow`            |
+| Slow-turn audit           | `ncf turns <name> --slow 5000`        |
+| Inspect last API exchange | `ncf trace <name> --limit 1 --full`   |
+| Lifecycle audit           | `ncf history`                         |
+| Cleanup orphans           | `ncf reap-orphans --confirm`          |
+| Send a probe              | `ncf inject --wait <name> "ping"`     |
 
 ## After code changes
 

--- a/scripts/ncf.ts
+++ b/scripts/ncf.ts
@@ -43,6 +43,7 @@ Usage:
   ncf reap-orphans [--dry-run]
   ncf history [name] [--since <iso>] [--limit N] [--event <kind>] [--json]
   ncf turns <name> [--limit N] [--slow <ms>]
+  ncf trace <name> [--limit N] [--full] [--json] [--errors-only]
   ncf rebuild
 `;
 
@@ -74,7 +75,9 @@ interface SessionRow {
 function getMaster(): AgentRow {
   const db = openCentral();
   try {
-    const row = db.prepare("SELECT * FROM agent_groups WHERE fleet_role = 'master' LIMIT 1").get() as AgentRow | undefined;
+    const row = db.prepare("SELECT * FROM agent_groups WHERE fleet_role = 'master' LIMIT 1").get() as
+      | AgentRow
+      | undefined;
     if (!row) {
       console.error("No fleet master found. Seed one with 'pnpm exec tsx scripts/init-fleet-master.ts' first.");
       process.exit(2);
@@ -120,7 +123,9 @@ function writeSystemAction(action: string, payload: Record<string, unknown>): vo
   const session = getMasterSession(master.id);
   const dbPath = outboundDbPath(session.agent_group_id, session.id);
   if (!fs.existsSync(dbPath)) {
-    console.error(`Master outbound.db missing: ${dbPath}\nIs the host running and has the master ever processed a message?`);
+    console.error(
+      `Master outbound.db missing: ${dbPath}\nIs the host running and has the master ever processed a message?`,
+    );
     process.exit(2);
   }
   const db = new Database(dbPath);
@@ -139,9 +144,7 @@ function writeSystemAction(action: string, payload: Record<string, unknown>): vo
 function listWorkers(): AgentRow[] {
   const db = openCentral();
   try {
-    return db
-      .prepare(`SELECT * FROM agent_groups WHERE fleet_role = 'worker' ORDER BY name`)
-      .all() as AgentRow[];
+    return db.prepare(`SELECT * FROM agent_groups WHERE fleet_role = 'worker' ORDER BY name`).all() as AgentRow[];
   } finally {
     db.close();
   }
@@ -180,7 +183,9 @@ function findAgentByName(name: string): AgentRow | undefined {
       .trim()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '');
-    return db.prepare('SELECT * FROM agent_groups WHERE folder = ? OR name = ?').get(folder, name) as AgentRow | undefined;
+    return db.prepare('SELECT * FROM agent_groups WHERE folder = ? OR name = ?').get(folder, name) as
+      | AgentRow
+      | undefined;
   } finally {
     db.close();
   }
@@ -330,12 +335,16 @@ function cmdSession(args: string[]): void {
   try {
     console.log(`== ${worker.folder} / ${sess.id} ==\n`);
     const ins = inDb
-      .prepare('SELECT timestamp, kind, substr(content, 1, 200) AS content FROM messages_in ORDER BY timestamp DESC LIMIT 10')
+      .prepare(
+        'SELECT timestamp, kind, substr(content, 1, 200) AS content FROM messages_in ORDER BY timestamp DESC LIMIT 10',
+      )
       .all() as Array<{ timestamp: string; kind: string; content: string }>;
     console.log('-- inbound --');
     for (const r of ins.reverse()) console.log(`  [${r.timestamp}] ${r.kind}: ${r.content}`);
     const outs = out
-      .prepare('SELECT timestamp, kind, substr(content, 1, 200) AS content FROM messages_out ORDER BY timestamp DESC LIMIT 10')
+      .prepare(
+        'SELECT timestamp, kind, substr(content, 1, 200) AS content FROM messages_out ORDER BY timestamp DESC LIMIT 10',
+      )
       .all() as Array<{ timestamp: string; kind: string; content: string }>;
     console.log('\n-- outbound --');
     for (const r of outs.reverse()) console.log(`  [${r.timestamp}] ${r.kind}: ${r.content}`);
@@ -507,9 +516,7 @@ function cmdRestart(args: string[]): void {
         if (!fs.existsSync(p)) continue;
         const db = new Database(p);
         try {
-          db.prepare(
-            "DELETE FROM session_state WHERE key = 'stored_session_id'",
-          ).run();
+          db.prepare("DELETE FROM session_state WHERE key = 'stored_session_id'").run();
         } catch {
           /* table might not exist on inbound side */
         } finally {
@@ -533,10 +540,14 @@ function cmdDebug(): void {
   const db = openCentral();
   try {
     const rows = db
-      .prepare(`SELECT name, folder, fleet_role, status, fleet_backend, fleet_model FROM agent_groups ORDER BY fleet_role, name`)
+      .prepare(
+        `SELECT name, folder, fleet_role, status, fleet_backend, fleet_model FROM agent_groups ORDER BY fleet_role, name`,
+      )
       .all();
     for (const r of rows as Array<Record<string, unknown>>) {
-      console.log(`  ${r.fleet_role ?? '—'}\t${r.status}\t${r.folder}\t${r.fleet_backend ?? '—'}${r.fleet_model ? ` (${r.fleet_model})` : ''}`);
+      console.log(
+        `  ${r.fleet_role ?? '—'}\t${r.status}\t${r.folder}\t${r.fleet_backend ?? '—'}${r.fleet_model ? ` (${r.fleet_model})` : ''}`,
+      );
     }
   } finally {
     db.close();
@@ -733,6 +744,138 @@ function cmdTurns(args: string[]): void {
   if (entries.length === 0) console.log('(no matching turns)');
 }
 
+const TRACES_DIR = path.resolve(process.cwd(), 'logs', 'shim-traces');
+
+interface TraceEntry {
+  ts: string;
+  worker: string;
+  backend: 'anthropic' | 'neuralwatt';
+  model_in?: string;
+  model_out?: string;
+  method: string;
+  path: string;
+  status: number;
+  stream: boolean;
+  latency_ms: number;
+  req_size: number;
+  resp_size: number;
+  stop_reason?: string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  req_body?: unknown;
+  resp_body?: unknown;
+  error?: string | null;
+}
+
+function summariseAnthropicMessage(msg: any, full: boolean): string {
+  if (!msg || typeof msg !== 'object') return String(msg ?? '');
+  // Request shape: { model, messages: [...], system, tools, max_tokens, stream }
+  if (Array.isArray(msg.messages)) {
+    const parts: string[] = [];
+    if (msg.system) {
+      const sys = typeof msg.system === 'string' ? msg.system : JSON.stringify(msg.system);
+      parts.push(`system: ${full ? sys : truncate(sys, 240)}`);
+    }
+    for (const m of msg.messages) {
+      const role = m.role ?? '?';
+      const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+      parts.push(`${role}: ${full ? content : truncate(content, 320)}`);
+    }
+    if (msg.tools?.length) parts.push(`tools: ${msg.tools.map((t: any) => t.name).join(', ')}`);
+    return parts.join('\n');
+  }
+  // Response shape: { content: [...], stop_reason, usage }
+  if (Array.isArray(msg.content)) {
+    const parts: string[] = [];
+    for (const block of msg.content) {
+      if (block.type === 'text') parts.push(`text: ${full ? block.text : truncate(block.text ?? '', 480)}`);
+      else if (block.type === 'thinking')
+        parts.push(`thinking: ${full ? block.thinking : truncate(block.thinking ?? '', 240)}`);
+      else if (block.type === 'tool_use')
+        parts.push(
+          `tool_use ${block.name}(${full ? JSON.stringify(block.input) : truncate(JSON.stringify(block.input ?? {}), 240)})`,
+        );
+      else parts.push(`${block.type}: ${truncate(JSON.stringify(block), 240)}`);
+    }
+    return parts.join('\n');
+  }
+  const s = JSON.stringify(msg);
+  return full ? s : truncate(s, 600);
+}
+
+function truncate(s: string, n: number): string {
+  if (!s || s.length <= n) return s;
+  return `${s.slice(0, n)}… (+${s.length - n}ch)`;
+}
+
+function cmdTrace(args: string[]): void {
+  const name = args[0];
+  if (!name) {
+    console.error('usage: ncf trace <name> [--limit N] [--full] [--json] [--errors-only]');
+    process.exit(1);
+  }
+  let limit = 5;
+  let full = false;
+  let json = false;
+  let errorsOnly = false;
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--limit') limit = parseInt(args[++i], 10);
+    else if (args[i] === '--full') full = true;
+    else if (args[i] === '--json') json = true;
+    else if (args[i] === '--errors-only') errorsOnly = true;
+  }
+
+  const worker = findAgentByName(name);
+  if (!worker) {
+    console.error(`unknown worker: ${name}`);
+    process.exit(1);
+  }
+  const file = path.join(TRACES_DIR, `${worker.folder}.jsonl`);
+  if (!fs.existsSync(file)) {
+    console.log(`(no traces yet at ${file})`);
+    console.log(
+      `tip: shim writes here only after a worker hits /v1/messages — confirm via 'ncf inject ${worker.folder} ping --wait'`,
+    );
+    return;
+  }
+  const lines = fs.readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean);
+  let entries: TraceEntry[] = [];
+  for (const ln of lines) {
+    try {
+      entries.push(JSON.parse(ln) as TraceEntry);
+    } catch {
+      // skip malformed
+    }
+  }
+  if (errorsOnly) entries = entries.filter((e) => e.error || e.status >= 400 || e.status === 0);
+  entries = entries.slice(-limit);
+
+  if (json) {
+    for (const e of entries) console.log(JSON.stringify(e));
+    return;
+  }
+  if (entries.length === 0) {
+    console.log('(no matching traces)');
+    return;
+  }
+  for (const e of entries) {
+    const status = e.status === 0 ? 'ERR' : String(e.status);
+    const tokens =
+      e.input_tokens != null || e.output_tokens != null
+        ? ` in=${e.input_tokens ?? '?'} out=${e.output_tokens ?? '?'}`
+        : '';
+    const stop = e.stop_reason ? ` stop=${e.stop_reason}` : '';
+    const stream = e.stream ? ' (stream)' : '';
+    const model = e.model_out && e.model_out !== e.model_in ? `${e.model_in}→${e.model_out}` : (e.model_in ?? '?');
+    console.log(`\n── [${e.ts}] ${e.backend}/${model} ${e.path} ${status}${stream} ${e.latency_ms}ms${tokens}${stop}`);
+    if (e.error) console.log(`  error: ${e.error}`);
+    console.log(`  req (${e.req_size}b):`);
+    for (const ln of summariseAnthropicMessage(e.req_body, full).split('\n')) console.log(`    ${ln}`);
+    console.log(`  resp (${e.resp_size}b):`);
+    for (const ln of summariseAnthropicMessage(e.resp_body, full).split('\n')) console.log(`    ${ln}`);
+  }
+}
+
 // ── Entry ────────────────────────────────────────────────────────────────
 
 function main(): void {
@@ -771,6 +914,8 @@ function main(): void {
       return;
     case 'turns':
       return cmdTurns(rest);
+    case 'trace':
+      return cmdTrace(rest);
     case 'rebuild':
       return cmdRebuild(rest);
     case '-h':

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -375,11 +375,11 @@ async function forwardToAnthropic(request: Request, body: Buffer, rewrittenUrl?:
   });
 }
 
-// Anthropic pass-through with trace. Buffers the response body so we can
-// log it; cost is one extra in-memory copy per request. SSE responses
-// (stream=true) come back as the same Anthropic SSE bytes the SDK already
-// parses, so we re-serve them verbatim — but parse them ourselves to
-// reconstruct the final message shape for the trace log.
+// Anthropic pass-through with trace. Tees the response body — one branch
+// streams to the client unchanged, the other accumulates into a buffer
+// asynchronously for the trace log. Critical: do NOT buffer the whole
+// response before returning, or SDK streaming UX (throbber + partial
+// rendering) breaks on every claude-direct call.
 async function traceAnthropic(
   request: Request,
   bodyBuffer: Buffer,
@@ -416,46 +416,83 @@ async function traceAnthropic(
     throw err;
   }
 
-  const respBuf = Buffer.from(await resp.arrayBuffer());
-  let parsedResp: any = null;
-  let stopReason: string | null = null;
-  let inTok: number | null = null;
-  let outTok: number | null = null;
-
-  if (isStream) {
-    parsedResp = assembleAnthropicSse(respBuf.toString('utf-8'));
-    stopReason = parsedResp.stop_reason;
-    inTok = parsedResp.usage?.input_tokens ?? null;
-    outTok = parsedResp.usage?.output_tokens ?? null;
-  } else {
-    parsedResp = safeJson(respBuf);
-    stopReason = parsedResp?.stop_reason ?? null;
-    inTok = parsedResp?.usage?.input_tokens ?? null;
-    outTok = parsedResp?.usage?.output_tokens ?? null;
+  // No body (HEAD, 204, etc.) — log and return as-is.
+  if (!resp.body) {
+    appendTrace({
+      ts: new Date().toISOString(),
+      worker: workerFolder,
+      backend: 'anthropic',
+      model_in: reqJson?.model,
+      model_out: reqJson?.model,
+      method: request.method,
+      path: url.pathname,
+      status: resp.status,
+      stream: isStream,
+      latency_ms: Date.now() - startMs,
+      req_size: bodyBuffer.length,
+      resp_size: 0,
+      req_body: reqJson,
+      resp_body: null,
+      error: resp.ok ? null : `upstream ${resp.status}`,
+    });
+    return new Response(null, { status: resp.status, headers: resp.headers });
   }
 
-  appendTrace({
-    ts: new Date().toISOString(),
-    worker: workerFolder,
-    backend: 'anthropic',
-    model_in: reqJson?.model,
-    model_out: reqJson?.model,
-    method: request.method,
-    path: url.pathname,
-    status: resp.status,
-    stream: isStream,
-    latency_ms: Date.now() - startMs,
-    req_size: bodyBuffer.length,
-    resp_size: respBuf.length,
-    stop_reason: stopReason,
-    input_tokens: inTok,
-    output_tokens: outTok,
-    req_body: reqJson,
-    resp_body: parsedResp,
-    error: resp.ok ? null : `upstream ${resp.status}`,
-  });
+  const [forClient, forTrace] = resp.body.tee();
 
-  return new Response(respBuf, { status: resp.status, headers: resp.headers });
+  // Drain the trace branch off the hot path — fire-and-forget. Errors here
+  // must never block the client response or the request from completing.
+  void (async () => {
+    try {
+      const reader = forTrace.getReader();
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      const respBuf = Buffer.concat(chunks);
+      let parsedResp: any = null;
+      let stopReason: string | null = null;
+      let inTok: number | null = null;
+      let outTok: number | null = null;
+      if (isStream) {
+        parsedResp = assembleAnthropicSse(respBuf.toString('utf-8'));
+        stopReason = parsedResp.stop_reason;
+        inTok = parsedResp.usage?.input_tokens ?? null;
+        outTok = parsedResp.usage?.output_tokens ?? null;
+      } else {
+        parsedResp = safeJson(respBuf);
+        stopReason = parsedResp?.stop_reason ?? null;
+        inTok = parsedResp?.usage?.input_tokens ?? null;
+        outTok = parsedResp?.usage?.output_tokens ?? null;
+      }
+      appendTrace({
+        ts: new Date().toISOString(),
+        worker: workerFolder,
+        backend: 'anthropic',
+        model_in: reqJson?.model,
+        model_out: reqJson?.model,
+        method: request.method,
+        path: url.pathname,
+        status: resp.status,
+        stream: isStream,
+        latency_ms: Date.now() - startMs,
+        req_size: bodyBuffer.length,
+        resp_size: respBuf.length,
+        stop_reason: stopReason,
+        input_tokens: inTok,
+        output_tokens: outTok,
+        req_body: reqJson,
+        resp_body: parsedResp,
+        error: resp.ok ? null : `upstream ${resp.status}`,
+      });
+    } catch (err: any) {
+      console.error(`[proxy:trace] anthropic tee drain failed: ${err.message}`);
+    }
+  })();
+
+  return new Response(forClient, { status: resp.status, headers: resp.headers });
 }
 
 // ── Trace logging ──────────────────────────────────────────────
@@ -1003,6 +1040,13 @@ const server = Bun.serve({
                   }
                   traceContent.push({ type: 'tool_use', id: tc.id, name: tc.name, input: parsedInput });
                 }
+                // resp_size: total assembled chars across content blocks.
+                // Bytes-on-the-wire isn't tracked for the streaming neuralwatt
+                // path because we re-emit Anthropic SSE rather than re-buffer
+                // the OpenAI bytes. Char count is enough for "is the response
+                // tiny / huge?" triage; turns.jsonl carries the accurate
+                // result_text_length.
+                const traceToolJsonLen = Object.values(toolCallAccum).reduce((a, t) => a + (t.args?.length ?? 0), 0);
                 appendTrace({
                   ts: new Date().toISOString(),
                   worker: workerFolder,
@@ -1015,7 +1059,7 @@ const server = Bun.serve({
                   stream: true,
                   latency_ms: Date.now() - startMs,
                   req_size: bodyBuffer.length,
-                  resp_size: traceText.length + traceThinking.length,
+                  resp_size: traceText.length + traceThinking.length + traceToolJsonLen,
                   stop_reason: stopReason,
                   input_tokens: usage.prompt_tokens ?? null,
                   output_tokens: usage.completion_tokens ?? null,

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -22,9 +22,10 @@ import fs from 'fs';
 import path from 'path';
 
 const PORT = Number(process.env.SHIM_PORT || '3003');
-const NEURALWATT_BASE = (
-  process.env.NEURALWATT_BASE_URL || 'https://api.neuralwatt.com/v1'
-).replace(/\/$/, '');
+const TRACES_DIR = process.env.SHIM_TRACES_DIR || 'logs/shim-traces';
+const TRACES_DISABLED = process.env.SHIM_TRACES === '0';
+fs.mkdirSync(TRACES_DIR, { recursive: true });
+const NEURALWATT_BASE = (process.env.NEURALWATT_BASE_URL || 'https://api.neuralwatt.com/v1').replace(/\/$/, '');
 const NEURALWATT_URL = `${NEURALWATT_BASE}/chat/completions`;
 const NEURALWATT_API_KEY = process.env.NEURALWATT_API_KEY || '';
 const WORKER_API_KEY_PREFIX = 'sk-ant-worker-';
@@ -48,8 +49,7 @@ function detectCredentialProxyUrl(): string {
   return 'http://127.0.0.1:3001';
 }
 const CREDENTIAL_PROXY_URL = detectCredentialProxyUrl();
-const CONFIG_PATH =
-  process.env.BACKEND_CONFIG_PATH || 'data/worker-backends.json';
+const CONFIG_PATH = process.env.BACKEND_CONFIG_PATH || 'data/worker-backends.json';
 
 // ── Config ─────────────────────────────────────────────────────
 
@@ -212,10 +212,7 @@ const NEURALWATT_MODEL_MAP: Record<string, string> = {
 };
 const DEFAULT_NEURALWATT_MODEL = 'Qwen/Qwen3.5-397B-A17B-FP8';
 
-function resolveNeuralwattModel(
-  anthropicModel: string,
-  configModel?: string,
-): string {
+function resolveNeuralwattModel(anthropicModel: string, configModel?: string): string {
   if (configModel) return configModel;
   return NEURALWATT_MODEL_MAP[anthropicModel] || DEFAULT_NEURALWATT_MODEL;
 }
@@ -226,10 +223,7 @@ function anthropicToOpenAI(body: any, model: string) {
   const messages: any[] = [];
 
   if (body.system) {
-    const systemText =
-      typeof body.system === 'string'
-        ? body.system
-        : body.system.map((b: any) => b.text).join('\n');
+    const systemText = typeof body.system === 'string' ? body.system : body.system.map((b: any) => b.text).join('\n');
     messages.push({ role: 'system', content: systemText });
   }
 
@@ -255,9 +249,7 @@ function anthropicToOpenAI(body: any, model: string) {
       if (toolCalls.length > 0) m.tool_calls = toolCalls;
       messages.push(m);
     } else if (msg.role === 'user') {
-      const toolResults = msg.content.filter(
-        (b: any) => b.type === 'tool_result',
-      );
+      const toolResults = msg.content.filter((b: any) => b.type === 'tool_result');
       if (toolResults.length > 0) {
         for (const tr of toolResults) {
           const resultContent =
@@ -315,16 +307,13 @@ function openAIToAnthropic(resp: any, requestedModel: string) {
   const message = choice?.message;
   const contentBlocks: any[] = [];
 
-  const reasoning =
-    message?.reasoning_content ||
-    message?.provider_specific_fields?.reasoning_content;
+  const reasoning = message?.reasoning_content || message?.provider_specific_fields?.reasoning_content;
   if (reasoning) {
     contentBlocks.push({ type: 'thinking', thinking: reasoning });
   }
 
   if (message?.tool_calls?.length) {
-    if (message.content)
-      contentBlocks.push({ type: 'text', text: message.content });
+    if (message.content) contentBlocks.push({ type: 'text', text: message.content });
     for (const tc of message.tool_calls) {
       contentBlocks.push({
         type: 'tool_use',
@@ -365,11 +354,7 @@ function openAIToAnthropic(resp: any, requestedModel: string) {
 
 // ── Anthropic pass-through (to credential proxy) ───────────────
 
-async function forwardToAnthropic(
-  request: Request,
-  body: Buffer,
-  rewrittenUrl?: URL,
-): Promise<Response> {
+async function forwardToAnthropic(request: Request, body: Buffer, rewrittenUrl?: URL): Promise<Response> {
   const url = rewrittenUrl || new URL(request.url);
   const targetUrl = `${CREDENTIAL_PROXY_URL}${url.pathname}${url.search}`;
 
@@ -390,6 +375,197 @@ async function forwardToAnthropic(
   });
 }
 
+// Anthropic pass-through with trace. Buffers the response body so we can
+// log it; cost is one extra in-memory copy per request. SSE responses
+// (stream=true) come back as the same Anthropic SSE bytes the SDK already
+// parses, so we re-serve them verbatim — but parse them ourselves to
+// reconstruct the final message shape for the trace log.
+async function traceAnthropic(
+  request: Request,
+  bodyBuffer: Buffer,
+  url: URL,
+  workerFolder: string,
+  startMs: number,
+): Promise<Response> {
+  const reqJson = safeJson(bodyBuffer);
+  const isStream = reqJson?.stream === true;
+  const targetUrl = `${CREDENTIAL_PROXY_URL}${url.pathname}${url.search}`;
+  const headers = new Headers(request.headers);
+  headers.delete('host');
+
+  let resp: Response;
+  try {
+    resp = await fetch(targetUrl, { method: request.method, headers, body: bodyBuffer });
+  } catch (err: any) {
+    appendTrace({
+      ts: new Date().toISOString(),
+      worker: workerFolder,
+      backend: 'anthropic',
+      model_in: reqJson?.model,
+      method: request.method,
+      path: url.pathname,
+      status: 0,
+      stream: isStream,
+      latency_ms: Date.now() - startMs,
+      req_size: bodyBuffer.length,
+      resp_size: 0,
+      req_body: reqJson,
+      resp_body: null,
+      error: err.message,
+    });
+    throw err;
+  }
+
+  const respBuf = Buffer.from(await resp.arrayBuffer());
+  let parsedResp: any = null;
+  let stopReason: string | null = null;
+  let inTok: number | null = null;
+  let outTok: number | null = null;
+
+  if (isStream) {
+    parsedResp = assembleAnthropicSse(respBuf.toString('utf-8'));
+    stopReason = parsedResp.stop_reason;
+    inTok = parsedResp.usage?.input_tokens ?? null;
+    outTok = parsedResp.usage?.output_tokens ?? null;
+  } else {
+    parsedResp = safeJson(respBuf);
+    stopReason = parsedResp?.stop_reason ?? null;
+    inTok = parsedResp?.usage?.input_tokens ?? null;
+    outTok = parsedResp?.usage?.output_tokens ?? null;
+  }
+
+  appendTrace({
+    ts: new Date().toISOString(),
+    worker: workerFolder,
+    backend: 'anthropic',
+    model_in: reqJson?.model,
+    model_out: reqJson?.model,
+    method: request.method,
+    path: url.pathname,
+    status: resp.status,
+    stream: isStream,
+    latency_ms: Date.now() - startMs,
+    req_size: bodyBuffer.length,
+    resp_size: respBuf.length,
+    stop_reason: stopReason,
+    input_tokens: inTok,
+    output_tokens: outTok,
+    req_body: reqJson,
+    resp_body: parsedResp,
+    error: resp.ok ? null : `upstream ${resp.status}`,
+  });
+
+  return new Response(respBuf, { status: resp.status, headers: resp.headers });
+}
+
+// ── Trace logging ──────────────────────────────────────────────
+//
+// One JSONL file per worker at logs/shim-traces/<folder>.jsonl. Each line
+// is a single /v1/messages POST: full request body, full assembled response,
+// status, latency, tokens. Used by `ncf trace <worker>` for "why is this
+// worker stuck?" debugging — turns.jsonl shows IF something hung, this
+// shows WHAT the agent sent and WHAT came back.
+//
+// No size cap at write time. If files grow large, delete them — they're
+// purely diagnostic. Disable entirely with SHIM_TRACES=0.
+
+interface ShimTraceEntry {
+  ts: string;
+  worker: string;
+  backend: 'anthropic' | 'neuralwatt';
+  model_in?: string;
+  model_out?: string;
+  method: string;
+  path: string;
+  status: number;
+  stream: boolean;
+  latency_ms: number;
+  req_size: number;
+  resp_size: number;
+  stop_reason?: string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  req_body?: unknown;
+  resp_body?: unknown;
+  error?: string | null;
+}
+
+function appendTrace(entry: ShimTraceEntry): void {
+  if (TRACES_DISABLED) return;
+  if (!entry.worker) return;
+  const file = path.join(TRACES_DIR, `${entry.worker}.jsonl`);
+  try {
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+  } catch (err: any) {
+    console.error(`[proxy:trace] write failed: ${err.message}`);
+  }
+}
+
+function safeJson(buf: Buffer): any {
+  try {
+    return JSON.parse(buf.toString('utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+// Best-effort assembly of an Anthropic SSE response body into a single
+// final-shape message. Reads the streamed event/data lines, accumulates
+// content_block_delta text/thinking/input_json into matching blocks,
+// pulls stop_reason and usage from message_delta. If parsing fails on any
+// chunk, that chunk is skipped — the trace still gets whatever we could
+// reconstruct, plus the raw SSE text in `_raw` for forensic use.
+function assembleAnthropicSse(raw: string): any {
+  const blocks: any[] = [];
+  let stopReason: string | null = null;
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
+
+  const lines = raw.split('\n');
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+    let evt: any;
+    try {
+      evt = JSON.parse(line.slice(6));
+    } catch {
+      continue;
+    }
+    if (evt.type === 'content_block_start') {
+      blocks[evt.index] = { ...evt.content_block };
+      if (evt.content_block?.type === 'tool_use') blocks[evt.index].input = '';
+    } else if (evt.type === 'content_block_delta') {
+      const b = blocks[evt.index];
+      if (!b) continue;
+      const d = evt.delta;
+      if (d?.type === 'text_delta') b.text = (b.text ?? '') + (d.text ?? '');
+      else if (d?.type === 'thinking_delta') b.thinking = (b.thinking ?? '') + (d.thinking ?? '');
+      else if (d?.type === 'input_json_delta') b.input = (b.input ?? '') + (d.partial_json ?? '');
+    } else if (evt.type === 'message_delta') {
+      if (evt.delta?.stop_reason) stopReason = evt.delta.stop_reason;
+      if (evt.usage?.output_tokens != null) outputTokens = evt.usage.output_tokens;
+    } else if (evt.type === 'message_start') {
+      if (evt.message?.usage?.input_tokens != null) inputTokens = evt.message.usage.input_tokens;
+    }
+  }
+  // Tool-use input arrived as JSON-string fragments; parse the final accumulated string.
+  for (const b of blocks) {
+    if (b?.type === 'tool_use' && typeof b.input === 'string') {
+      try {
+        b.input = JSON.parse(b.input || '{}');
+      } catch {
+        /* leave as-is */
+      }
+    }
+  }
+  return {
+    type: 'message',
+    role: 'assistant',
+    content: blocks.filter(Boolean),
+    stop_reason: stopReason,
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  };
+}
+
 // ── Server ─────────────────────────────────────────────────────
 
 const server = Bun.serve({
@@ -397,10 +573,7 @@ const server = Bun.serve({
   // Catch unhandled errors — never return Bun's default HTML error page.
   error(err) {
     console.error(`[proxy] Unhandled error: ${err.message}`);
-    return Response.json(
-      { type: 'error', error: { type: 'server_error', message: err.message } },
-      { status: 500 },
-    );
+    return Response.json({ type: 'error', error: { type: 'server_error', message: err.message } }, { status: 500 });
   },
   async fetch(request) {
     const url = new URL(request.url);
@@ -416,7 +589,11 @@ const server = Bun.serve({
       url.pathname.startsWith('/api/') ||
       url.pathname.startsWith('/v1/organizations') ||
       url.pathname.startsWith('/v1/sessions') ||
-      (request.method === 'GET' && !url.pathname.startsWith('/w/') && !url.pathname.startsWith('/usage') && !url.pathname.startsWith('/health') && !url.pathname.startsWith('/models'))
+      (request.method === 'GET' &&
+        !url.pathname.startsWith('/w/') &&
+        !url.pathname.startsWith('/usage') &&
+        !url.pathname.startsWith('/health') &&
+        !url.pathname.startsWith('/models'))
     ) {
       return Response.json({});
     }
@@ -437,9 +614,7 @@ const server = Bun.serve({
     }
     // Resolve a fuzzy model name to the best matching model ID
     if (url.pathname.startsWith('/models/resolve/')) {
-      const query = decodeURIComponent(
-        url.pathname.slice('/models/resolve/'.length),
-      ).toLowerCase();
+      const query = decodeURIComponent(url.pathname.slice('/models/resolve/'.length)).toLowerCase();
       await refreshModelsCache();
       if (!modelsCache?.length) {
         return Response.json({ error: 'no models available' }, { status: 503 });
@@ -448,11 +623,8 @@ const server = Bun.serve({
       const exact = modelsCache.find((m) => m.toLowerCase() === query);
       if (exact) return Response.json({ model: exact, match: 'exact' });
       // Contains match (e.g., "kimi-k2.5-fast" matches "kimi-k2.5-fast")
-      const contains = modelsCache.filter((m) =>
-        m.toLowerCase().includes(query),
-      );
-      if (contains.length === 1)
-        return Response.json({ model: contains[0], match: 'contains' });
+      const contains = modelsCache.filter((m) => m.toLowerCase().includes(query));
+      if (contains.length === 1) return Response.json({ model: contains[0], match: 'contains' });
       // Fuzzy: split query into parts, score by how many parts match
       const parts = query.split(/[-_/.]+/);
       const scored = modelsCache
@@ -470,10 +642,7 @@ const server = Bun.serve({
           candidates: scored.slice(0, 5).map((s) => s.model),
         });
       }
-      return Response.json(
-        { error: `no match for "${query}"`, available: modelsCache },
-        { status: 404 },
-      );
+      return Response.json({ error: `no match for "${query}"`, available: modelsCache }, { status: 404 });
     }
     // List available Neuralwatt models (queries API, cached 5 min)
     if (url.pathname === '/models') {
@@ -492,21 +661,17 @@ const server = Bun.serve({
 
     // Worker config lookup endpoint (workers can read their own config)
     // Access via /w/<folder>/worker-config or /worker-config with x-api-key
-    if (
-      url.pathname === '/worker-config' ||
-      url.pathname.endsWith('/worker-config')
-    ) {
+    if (url.pathname === '/worker-config' || url.pathname.endsWith('/worker-config')) {
       const pathMatch = url.pathname.match(/^\/w\/([^/]+)\//);
       const folder = pathMatch ? pathMatch[1] : '';
       const config = getWorkerConfig(folder);
       const model =
-        config.backend === 'neuralwatt'
-          ? resolveNeuralwattModel('', config.model)
-          : 'claude (via anthropic)';
+        config.backend === 'neuralwatt' ? resolveNeuralwattModel('', config.model) : 'claude (via anthropic)';
       return Response.json({ ...config, resolved_model: model });
     }
 
     // Global error handler: never return HTML, always JSON.
+    const startMs = Date.now();
     try {
       // Read request body once
       const bodyBuffer = Buffer.from(await request.arrayBuffer());
@@ -520,9 +685,16 @@ const server = Bun.serve({
         url.pathname = workerMatch[2];
       }
       const workerConfig = getWorkerConfig(workerFolder);
+      const isMessagesPost = url.pathname === '/v1/messages' && request.method === 'POST';
 
-      // Anthropic backend: pass through to credential proxy
+      // Anthropic backend: pass through to credential proxy. Wrap /v1/messages
+      // POSTs so we can record the full req/resp pair into shim-traces.jsonl;
+      // other endpoints (oauth, profile, models) are noisy and not useful for
+      // worker-stuck debugging.
       if (workerConfig.backend === 'anthropic') {
+        if (isMessagesPost) {
+          return await traceAnthropic(request, bodyBuffer, url, workerFolder, startMs);
+        }
         return forwardToAnthropic(request, bodyBuffer, url);
       }
 
@@ -534,10 +706,7 @@ const server = Bun.serve({
 
       {
         const anthropicBody = JSON.parse(bodyBuffer.toString());
-        const nwModel = resolveNeuralwattModel(
-          anthropicBody.model,
-          workerConfig.model,
-        );
+        const nwModel = resolveNeuralwattModel(anthropicBody.model, workerConfig.model);
         const openaiReq = anthropicToOpenAI(anthropicBody, nwModel);
 
         const reqBodySize = JSON.stringify(openaiReq).length;
@@ -555,9 +724,7 @@ const server = Bun.serve({
           console.log(
             `[proxy:debug] Messages: ${openaiReq.messages.map((m: any) => `${m.role}:${(m.content || '').length}chars`).join(', ')}`,
           );
-          console.log(
-            `[proxy:debug] Anthropic max_tokens: ${anthropicBody.max_tokens}`,
-          );
+          console.log(`[proxy:debug] Anthropic max_tokens: ${anthropicBody.max_tokens}`);
         }
 
         // Streaming: translate OpenAI SSE → Anthropic SSE on the fly.
@@ -576,6 +743,23 @@ const server = Bun.serve({
           if (!resp.ok) {
             const err = await resp.text();
             console.error(`[proxy] Neuralwatt stream error: ${resp.status}`);
+            appendTrace({
+              ts: new Date().toISOString(),
+              worker: workerFolder,
+              backend: 'neuralwatt',
+              model_in: anthropicBody.model,
+              model_out: nwModel,
+              method: 'POST',
+              path: '/v1/messages',
+              status: resp.status,
+              stream: true,
+              latency_ms: Date.now() - startMs,
+              req_size: bodyBuffer.length,
+              resp_size: err.length,
+              req_body: anthropicBody,
+              resp_body: { error_text: err },
+              error: `upstream ${resp.status}`,
+            });
             return Response.json(
               {
                 type: 'error',
@@ -593,11 +777,7 @@ const server = Bun.serve({
               const emit = (event: string, data: any) => {
                 if (streamClosed) return;
                 try {
-                  controller.enqueue(
-                    encoder.encode(
-                      `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
-                    ),
-                  );
+                  controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
                 } catch {
                   streamClosed = true;
                 }
@@ -625,10 +805,12 @@ const server = Bun.serve({
               let stopReason = 'end_turn';
               let usage: any = {};
               let energy: any = undefined;
-              let toolCallAccum: Record<
-                number,
-                { id: string; name: string; args: string }
-              > = {};
+              let toolCallAccum: Record<number, { id: string; name: string; args: string }> = {};
+              // Trace accumulators — reconstruct final Anthropic message
+              // shape for the trace log without re-parsing the SSE we
+              // already emit.
+              let traceText = '';
+              let traceThinking = '';
 
               const reader = resp.body!.getReader();
               const decoder = new TextDecoder();
@@ -678,6 +860,7 @@ const server = Bun.serve({
 
                     // Reasoning/thinking
                     if (delta.reasoning != null) {
+                      traceThinking += delta.reasoning;
                       if (!inThinking) {
                         inThinking = true;
                         emit('content_block_start', {
@@ -698,6 +881,7 @@ const server = Bun.serve({
 
                     // Text content (skip null — API sends null during tool calls)
                     if (delta.content != null && delta.content !== '') {
+                      traceText += delta.content;
                       if (inThinking) {
                         emit('content_block_stop', {
                           type: 'content_block_stop',
@@ -775,10 +959,8 @@ const server = Bun.serve({
 
                     // Finish reason
                     if (choice?.finish_reason) {
-                      if (choice.finish_reason === 'tool_calls')
-                        stopReason = 'tool_use';
-                      else if (choice.finish_reason === 'length')
-                        stopReason = 'max_tokens';
+                      if (choice.finish_reason === 'tool_calls') stopReason = 'tool_use';
+                      else if (choice.finish_reason === 'length') stopReason = 'max_tokens';
                       else stopReason = 'end_turn';
                     }
                   }
@@ -806,8 +988,68 @@ const server = Bun.serve({
                 console.log(
                   `[proxy] → stream ${stopReason} (${usage.completion_tokens || '?'} out, ${usage.prompt_tokens || '?'} in)`,
                 );
+
+                // Trace: assemble the final Anthropic-shape message from
+                // accumulators and log alongside the request.
+                const traceContent: any[] = [];
+                if (traceThinking) traceContent.push({ type: 'thinking', thinking: traceThinking });
+                if (traceText) traceContent.push({ type: 'text', text: traceText });
+                for (const tc of Object.values(toolCallAccum)) {
+                  let parsedInput: any = tc.args;
+                  try {
+                    parsedInput = JSON.parse(tc.args || '{}');
+                  } catch {
+                    /* keep string */
+                  }
+                  traceContent.push({ type: 'tool_use', id: tc.id, name: tc.name, input: parsedInput });
+                }
+                appendTrace({
+                  ts: new Date().toISOString(),
+                  worker: workerFolder,
+                  backend: 'neuralwatt',
+                  model_in: anthropicBody.model,
+                  model_out: nwModel,
+                  method: 'POST',
+                  path: '/v1/messages',
+                  status: 200,
+                  stream: true,
+                  latency_ms: Date.now() - startMs,
+                  req_size: bodyBuffer.length,
+                  resp_size: traceText.length + traceThinking.length,
+                  stop_reason: stopReason,
+                  input_tokens: usage.prompt_tokens ?? null,
+                  output_tokens: usage.completion_tokens ?? null,
+                  req_body: anthropicBody,
+                  resp_body: {
+                    id: msgId,
+                    type: 'message',
+                    role: 'assistant',
+                    model: anthropicBody.model,
+                    content: traceContent,
+                    stop_reason: stopReason,
+                    usage: { input_tokens: usage.prompt_tokens ?? 0, output_tokens: usage.completion_tokens ?? 0 },
+                  },
+                  error: null,
+                });
               } catch (err: any) {
                 console.error(`[proxy] Stream error: ${err.message}`);
+                appendTrace({
+                  ts: new Date().toISOString(),
+                  worker: workerFolder,
+                  backend: 'neuralwatt',
+                  model_in: anthropicBody.model,
+                  model_out: nwModel,
+                  method: 'POST',
+                  path: '/v1/messages',
+                  status: 0,
+                  stream: true,
+                  latency_ms: Date.now() - startMs,
+                  req_size: bodyBuffer.length,
+                  resp_size: 0,
+                  req_body: anthropicBody,
+                  resp_body: null,
+                  error: err.message,
+                });
               } finally {
                 if (!streamClosed) {
                   try {
@@ -841,6 +1083,23 @@ const server = Bun.serve({
         if (!resp.ok) {
           const err = await resp.text();
           console.error(`[proxy] Neuralwatt error: ${resp.status} ${err}`);
+          appendTrace({
+            ts: new Date().toISOString(),
+            worker: workerFolder,
+            backend: 'neuralwatt',
+            model_in: anthropicBody.model,
+            model_out: nwModel,
+            method: 'POST',
+            path: '/v1/messages',
+            status: resp.status,
+            stream: false,
+            latency_ms: Date.now() - startMs,
+            req_size: bodyBuffer.length,
+            resp_size: err.length,
+            req_body: anthropicBody,
+            resp_body: { error_text: err },
+            error: `upstream ${resp.status}`,
+          });
           return Response.json(
             {
               type: 'error',
@@ -851,10 +1110,7 @@ const server = Bun.serve({
         }
 
         const openaiResp = await resp.json();
-        const anthropicResp = openAIToAnthropic(
-          openaiResp,
-          anthropicBody.model,
-        );
+        const anthropicResp = openAIToAnthropic(openaiResp, anthropicBody.model);
 
         // Track usage + energy per worker
         recordUsage(workerFolder, openaiResp.usage, openaiResp.energy);
@@ -863,13 +1119,30 @@ const server = Bun.serve({
           `[proxy] → ${anthropicResp.stop_reason} (${anthropicResp.usage.output_tokens} out, ${openaiResp.usage?.prompt_tokens || '?'} in)`,
         );
         if (DEBUG) {
-          console.log(
-            `[proxy:debug] Raw usage: ${JSON.stringify(openaiResp.usage)}`,
-          );
-          console.log(
-            `[proxy:debug] Raw energy: ${JSON.stringify(openaiResp.energy)}`,
-          );
+          console.log(`[proxy:debug] Raw usage: ${JSON.stringify(openaiResp.usage)}`);
+          console.log(`[proxy:debug] Raw energy: ${JSON.stringify(openaiResp.energy)}`);
         }
+
+        appendTrace({
+          ts: new Date().toISOString(),
+          worker: workerFolder,
+          backend: 'neuralwatt',
+          model_in: anthropicBody.model,
+          model_out: nwModel,
+          method: 'POST',
+          path: '/v1/messages',
+          status: 200,
+          stream: false,
+          latency_ms: Date.now() - startMs,
+          req_size: bodyBuffer.length,
+          resp_size: JSON.stringify(anthropicResp).length,
+          stop_reason: anthropicResp.stop_reason,
+          input_tokens: openaiResp.usage?.prompt_tokens ?? null,
+          output_tokens: openaiResp.usage?.completion_tokens ?? null,
+          req_body: anthropicBody,
+          resp_body: anthropicResp,
+          error: null,
+        });
 
         return Response.json(anthropicResp);
       }


### PR DESCRIPTION
## Summary

Adds end-to-end visibility into worker inference. The shim writes one JSONL line per `/v1/messages` POST into `logs/shim-traces/<folder>.jsonl` with the full request body and an Anthropic-shape final response. `ncf trace <worker>` reads it back.

Closes a real diagnostic gap: `turns.jsonl` told us "did this finish and how long?" but not "what did the agent ask the model and what came back?" — needed for "why is worker-foo unresponsive?".

## Why

Today, when a worker isn't responding, you can see which inbound message stuck (`ncf session`) and that turns are slow (`ncf turns --slow`), but never the actual prompt sent or the response received. SDK is opaque, container logs are too. The shim is the one place the full HTTP exchange already passes through — easy place to record it.

## How

- `tools/anthropic-shim.ts` — three call sites instrumented:
  - Anthropic forward path: `ReadableStream.tee()` so the client still streams while a parallel branch drains into the trace log. Critical: do NOT buffer before returning, that breaks SDK throbber + partial rendering.
  - Neuralwatt streaming success/error: trace assembled from accumulators we already maintain to translate OpenAI SSE → Anthropic SSE. No extra parsing on hot path.
  - Neuralwatt non-streaming success/error: trace built from already-parsed Anthropic-shape response.
- `scripts/ncf.ts` — `cmdTrace` with `--limit N` (default 5), `--full`, `--errors-only`, `--json`. Default print summarises req (system + last messages) + resp (content blocks).
- Disable with `SHIM_TRACES=0`, relocate with `SHIM_TRACES_DIR=...`. No automatic rotation: delete files when too big — they're diagnostic, not historical.

## Caveat

Only covers traffic through the shim — neuralwatt-backed workers plus any anthropic-backed routed through it. claude-direct workers that talk straight to api.anthropic.com won't appear; routing those through the shim too is a follow-up.

## Test plan

- [x] Host typecheck
- [x] Container typecheck
- [x] Host tests (204/204)
- [x] Container tests (53/53)
- [x] ncf trace rejects unknown worker
- [x] Pre-push hook green (full CI mirror)
- [ ] Live: shim restart, send a message to a neuralwatt worker, run ncf trace, see req/resp pair (requires shim service restart, blocked on user OK)