### PR TITLE
fix(instructions): make <internal> wrap-up conditional on real send_message

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -24,7 +24,11 @@ The user is often on a phone screen, doesn't see your tool calls, and only knows
 
 ### Avoid duplicate messages
 
-If you've used `send_message` to deliver your reply, do NOT also emit the same text as your final turn output. The user will see it twice. Wrap your final output in `<internal>...</internal>` tags so NanoClaw suppresses it from chat: `<internal>Already sent via send_message.</internal>`.
+`send_message` posts a chat reply immediately. Your final turn output is _also_ delivered as a chat message — so if `send_message` already ran this turn, the user sees the same content twice.
+
+To suppress the duplicate, wrap the final output in `<internal>...</internal>` and NanoClaw drops it from chat.
+
+**Only do this if a real `send_message` tool_use ran earlier in the same turn.** If none did, your final output IS the user-visible reply — write it as a normal chat message. A stand-alone `<internal>...</internal>` with no preceding `send_message` produces silence: the formatter drops the wrap, no other content is sent, the user gets nothing.
 
 ### Pacing updates on longer turns
 


### PR DESCRIPTION
## Summary

Reword `core.instructions.md` so the `<internal>...</internal>` wrap-up rule fires **only** when a real `send_message` tool_use actually ran in the same turn. Drop the parroted example literal. Spell out the failure mode (silence) when an agent emits a stand-alone `<internal>` block with no preceding send_message.

## Why — concrete incident today

Worker `k2.6-dbg` went silent for hours after SDK auto-compaction at 01:24Z. Every subsequent turn emitted exactly:

    <internal>Acknowledged via send_message.</internal>

Formatter correctly suppressed it (no `<message>` blocks → nothing posted). Container kept processing inbounds, kept emitting the same template, kept never replying. Inject-forcing prompts didn't break it; even after `ncf restart` the SDK resumed the same poisoned session and the loop continued. Recovery required `ncf restart --fresh` to drop the corrupted session memory.

Root cause:

1. Two adjacent rules in `core.instructions.md` — A: "first action must be `send_message` tool_use", B: "wrap final output in `<internal>...</internal>` if you used send_message".
2. SDK auto-compaction flattens per-turn structure into a narrative summary. Post-compaction, the model loses the link between "tool_use happened" and "wrap-up applies" — it sees the example string, parrots it, skips the tool_use.
3. Each silent turn appends another `<internal>` reply to history. Self-reinforcing.

## How

- Drop the parroted literal `<internal>Already sent via send_message.</internal>` example so models can't latch onto it as a canonical reply shape.
- Add explicit precondition: "only wrap when a real `send_message` tool_use actually ran this turn".
- Add the failure mode: stand-alone `<internal>` with no preceding send_message → user gets nothing.

## Scope

Doc fix only — touches `container/agent-runner/src/mcp-tools/core.instructions.md`. Existing sessions need a fresh restart to pick up the new wording. Already-poisoned sessions need `--fresh`.

## Future-kaizen (NOT this PR)

Formatter-level enforcement: auto-suppress final text output when `send_message` tool_use ran this turn. Removes the burden from the agent entirely. Lives in `container/agent-runner/src/format/` (or wherever `<message>` extraction happens). Separate PR.

## Test plan

- [x] Host typecheck
- [x] Container typecheck
- [x] Container tests (53/53)
- [x] Pre-push hook green
- [x] Live: `ncf restart k2.6-dbg --fresh` performed, fresh container picked up new instructions on first inbound (will re-test after this lands and `ncf rebuild` if needed — the file is mounted read-only into containers so existing-session pickup happens via container-runner spawn, not image rebuild)