### PR TITLE
fix(ncf): --fresh actually clears the SDK session id

### DIFF
--- a/scripts/ncf.ts
+++ b/scripts/ncf.ts
@@ -509,22 +509,28 @@ function cmdRestart(args: string[]): void {
     spawnSync('docker', ['rm', '-f', container], { stdio: 'inherit' });
   }
   if (args.includes('--fresh')) {
+    // Container writes/reads its SDK session id under the key `sdk_session_id`
+    // — see container/agent-runner/src/db/session-state.ts:SDK_SESSION_KEY.
+    // Earlier code deleted `stored_session_id` here, which was a silent no-op
+    // (no row by that name) so --fresh effectively did nothing and the next
+    // wake resumed the same SDK session. Caught while debugging k2.6-dbg
+    // post-compaction hallucination loop — `--fresh` looked successful from
+    // the CLI but the agent kept resuming the poisoned session.
+    let cleared = 0;
     for (const s of listSessions(worker.id)) {
       const outPath = outboundDbPath(s.agent_group_id, s.id);
-      const inPath = outPath.replace(/outbound\.db$/, 'inbound.db');
-      for (const p of [outPath, inPath]) {
-        if (!fs.existsSync(p)) continue;
-        const db = new Database(p);
-        try {
-          db.prepare("DELETE FROM session_state WHERE key = 'stored_session_id'").run();
-        } catch {
-          /* table might not exist on inbound side */
-        } finally {
-          db.close();
-        }
+      if (!fs.existsSync(outPath)) continue;
+      const db = new Database(outPath);
+      try {
+        const res = db.prepare("DELETE FROM session_state WHERE key = 'sdk_session_id'").run();
+        cleared += res.changes;
+      } catch {
+        /* session_state may be absent on a brand-new outbound.db */
+      } finally {
+        db.close();
       }
     }
-    console.log(`restarted ${worker.folder} (fresh session)`);
+    console.log(`restarted ${worker.folder} (fresh session — cleared ${cleared} sdk_session_id row(s))`);
   } else {
     console.log(`restarted ${worker.folder} (resumes session on next message)`);
   }


### PR DESCRIPTION
## Summary

`ncf restart --fresh` was a silent no-op — it deleted `session_state` rows where `key = 'stored_session_id'`, but the container reads/writes that row under `key = 'sdk_session_id'` (see `container/agent-runner/src/db/session-state.ts:SDK_SESSION_KEY`). The DELETE always matched zero rows; CLI printed "fresh session" but the next inbound respawned the same SDK session.

## How caught

Today's worker k2.6-dbg incident: post-compaction hallucination loop emitting `<internal>Acknowledged via send_message.</internal>` every turn (root-cause fixed in #89). After running `ncf restart --fresh`, container logs showed:

    [poll-loop] Resuming agent session aed000b9-a70f-4139-98a3-894520d357b5

Same session id pre- and post-`--fresh`. Manually `DELETE FROM session_state WHERE key = 'sdk_session_id'` + `docker kill` broke the loop, confirming the wrong-key theory.

## How

- Use the correct key: `sdk_session_id`.
- Drop the inbound.db pass — `session_state` lives only in outbound.db.
- Count deleted rows and surface the count in the success line so a future silent no-op is visible from the CLI:

      restarted k2-6-dbg (fresh session — cleared 1 sdk_session_id row(s))

- Comment cites the container-side `SDK_SESSION_KEY` constant so the next reader can find the source-of-truth.

## Test plan

- [x] Host typecheck
- [x] Host tests (206/206)
- [x] Pre-push hook green
- [ ] Live: next `ncf restart <worker> --fresh` will report `cleared 1 sdk_session_id row(s)` and the next inbound spawns a fresh SDK session id (rather than resuming the prior one)