### PR TITLE
feat(bridge): URL-fetch fallback for chat-sdk attachments without fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -5,6 +5,7 @@ import type { Adapter } from 'chat';
 import {
   createChatSdkBridge,
   fetchAttachmentFromUrl,
+  isPublicHostnameForAttachmentUrl,
   shouldFetchAttachment,
   splitForLimit,
 } from './chat-sdk-bridge.js';
@@ -157,5 +158,65 @@ describe('fetchAttachmentFromUrl', () => {
       return new Response('not found', { status: 404 });
     }) as typeof fetch;
     await expect(fetchAttachmentFromUrl('https://example.test/missing')).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('rejects non-https schemes (no fetch issued)', async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+    expect(await fetchAttachmentFromUrl('http://cdn.discordapp.com/attachments/1.txt')).toBeNull();
+    expect(await fetchAttachmentFromUrl('file:///etc/passwd')).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  it('rejects IP-literal and localhost hostnames (SSRF guard)', async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+    expect(await fetchAttachmentFromUrl('https://127.0.0.1/bytes')).toBeNull();
+    expect(await fetchAttachmentFromUrl('https://169.254.169.254/latest/meta-data/')).toBeNull();
+    expect(await fetchAttachmentFromUrl('https://localhost:3001/x')).toBeNull();
+    expect(await fetchAttachmentFromUrl('https://[::1]/x')).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  it('rejects unparseable URLs (no fetch issued)', async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+    expect(await fetchAttachmentFromUrl('not a url')).toBeNull();
+    expect(fetched).toBe(false);
+  });
+});
+
+describe('isPublicHostnameForAttachmentUrl', () => {
+  it('accepts public CDN hostnames', () => {
+    expect(isPublicHostnameForAttachmentUrl('cdn.discordapp.com')).toBe(true);
+    expect(isPublicHostnameForAttachmentUrl('media.discordapp.net')).toBe(true);
+    expect(isPublicHostnameForAttachmentUrl('files.slack.com')).toBe(true);
+  });
+
+  it('rejects IPv4 literals', () => {
+    expect(isPublicHostnameForAttachmentUrl('127.0.0.1')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('169.254.169.254')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('10.0.0.1')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('192.168.1.1')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('8.8.8.8')).toBe(false);
+  });
+
+  it('rejects IPv6 literals and localhost', () => {
+    expect(isPublicHostnameForAttachmentUrl('::1')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('fe80::1')).toBe(false);
+    expect(isPublicHostnameForAttachmentUrl('localhost')).toBe(false);
+  });
+
+  it('rejects empty hostname', () => {
+    expect(isPublicHostnameForAttachmentUrl('')).toBe(false);
   });
 });

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import type { Adapter } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import {
+  createChatSdkBridge,
+  fetchAttachmentFromUrl,
+  shouldFetchAttachment,
+  splitForLimit,
+} from './chat-sdk-bridge.js';
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
@@ -76,5 +81,81 @@ describe('createChatSdkBridge', () => {
       supportsThreads: true,
     });
     expect(typeof bridge.subscribe).toBe('function');
+  });
+});
+
+describe('shouldFetchAttachment', () => {
+  it('fetches text/* mime types', () => {
+    expect(shouldFetchAttachment({ mimeType: 'text/plain' })).toBe(true);
+    expect(shouldFetchAttachment({ mimeType: 'text/markdown' })).toBe(true);
+    expect(shouldFetchAttachment({ mimeType: 'TEXT/CSV' })).toBe(true);
+  });
+
+  it('fetches structured-data mime types', () => {
+    expect(shouldFetchAttachment({ mimeType: 'application/json' })).toBe(true);
+    expect(shouldFetchAttachment({ mimeType: 'application/xml' })).toBe(true);
+    expect(shouldFetchAttachment({ mimeType: 'application/x-yaml' })).toBe(true);
+  });
+
+  it('fetches attachments with no mimeType (Discord paste-as-txt drops content_type)', () => {
+    // The motivating case for this whole feature: a user pastes a wall of
+    // text into Discord and the client auto-uploads it as a .txt file.
+    // Discord sometimes omits content_type on those, leaving us with
+    // attachments that have only url/name/size. We want to download those.
+    expect(shouldFetchAttachment({})).toBe(true);
+    expect(shouldFetchAttachment({ mimeType: '' })).toBe(true);
+  });
+
+  it('skips images / video / audio (already surfaced via URL in formatter)', () => {
+    expect(shouldFetchAttachment({ mimeType: 'image/png' })).toBe(false);
+    expect(shouldFetchAttachment({ mimeType: 'video/mp4' })).toBe(false);
+    expect(shouldFetchAttachment({ mimeType: 'audio/mpeg' })).toBe(false);
+    expect(shouldFetchAttachment({ mimeType: 'application/pdf' })).toBe(false);
+  });
+
+  it('skips when declared size exceeds the cap', () => {
+    expect(shouldFetchAttachment({ mimeType: 'text/plain', size: 100 * 1024 * 1024 })).toBe(false);
+  });
+});
+
+describe('fetchAttachmentFromUrl', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns the body for a successful fetch under the size cap', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('hello world', { status: 200, headers: { 'content-length': '11' } });
+    }) as typeof fetch;
+    const buf = await fetchAttachmentFromUrl('https://example.test/file.txt', 11);
+    expect(buf).not.toBeNull();
+    expect(buf!.toString('utf-8')).toBe('hello world');
+  });
+
+  it('returns null when declaredSize blows past the cap (no fetch issued)', async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+    const buf = await fetchAttachmentFromUrl('https://example.test/huge', 50 * 1024 * 1024);
+    expect(buf).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  it('returns null when content-length blows past the cap', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('', { status: 200, headers: { 'content-length': String(50 * 1024 * 1024) } });
+    }) as typeof fetch;
+    const buf = await fetchAttachmentFromUrl('https://example.test/huge');
+    expect(buf).toBeNull();
+  });
+
+  it('throws on non-2xx so the caller can log + skip', async () => {
+    globalThis.fetch = (async () => {
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+    await expect(fetchAttachmentFromUrl('https://example.test/missing')).rejects.toThrow(/HTTP 404/);
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -61,11 +61,43 @@ export function shouldFetchAttachment(entry: { mimeType?: string; type?: string;
   return false;
 }
 
+/**
+ * Reject URLs whose hostname is an IP literal (any v4/v6 form) or `localhost`.
+ * SSRF guard: chat-sdk attachments are supposed to come from public CDNs
+ * (cdn.discordapp.com, media.discordapp.net, files.slack.com, etc.). A
+ * malicious or buggy adapter handing us http://169.254.169.254/ or
+ * http://127.0.0.1:3001/ could exfiltrate cloud metadata or hit the local
+ * credential proxy. None of the supported chat platforms ever surface IP
+ * literals, so blanket-rejecting them is safe.
+ */
+export function isPublicHostnameForAttachmentUrl(host: string): boolean {
+  if (!host) return false;
+  if (host === 'localhost') return false;
+  // IPv4 literal
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return false;
+  // IPv6 literal (raw or [bracketed]). The bracketed form keeps the colons.
+  if (host.includes(':')) return false;
+  return true;
+}
+
+const ATTACHMENT_FETCH_TIMEOUT_MS = Number(process.env.BRIDGE_ATTACHMENT_FETCH_TIMEOUT_MS ?? 10_000);
+
 export async function fetchAttachmentFromUrl(url: string, declaredSize?: number): Promise<Buffer | null> {
   if (declaredSize != null && declaredSize > ATTACHMENT_MAX_BYTES) {
     return null;
   }
-  const resp = await fetch(url);
+
+  // SSRF guard: https-only, no IP-literal / localhost hosts.
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!isPublicHostnameForAttachmentUrl(parsed.hostname)) return null;
+
+  const resp = await fetch(url, { signal: AbortSignal.timeout(ATTACHMENT_FETCH_TIMEOUT_MS) });
   if (!resp.ok) {
     throw new Error(`HTTP ${resp.status}`);
   }

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -33,6 +33,54 @@ interface GatewayAdapter extends Adapter {
   ): Promise<Response>;
 }
 
+/**
+ * Cap on URL-fetched attachment size. Anything bigger is silently skipped —
+ * the entry still flows through with `url` for the formatter to surface, but
+ * `data` is not populated and the host won't extract it to inbox.
+ *
+ * 5MB covers the realistic "user pasted a wall of text → Discord auto-uploaded
+ * as .txt" case (Discord caps non-Nitro attachments at 25MB, but the long-text
+ * paste rarely exceeds a few hundred KB) plus small images. Override via
+ * BRIDGE_ATTACHMENT_MAX_BYTES.
+ */
+const ATTACHMENT_MAX_BYTES = Number(process.env.BRIDGE_ATTACHMENT_MAX_BYTES ?? 5 * 1024 * 1024);
+
+/**
+ * Allowlist for the URL-fetch fallback. We only download attachments the
+ * agent has a real chance of reading — text paste, structured-data files,
+ * and unknown-type files (Discord sometimes omits content_type for
+ * paste-as-txt). Images / video / audio already display in chat with their
+ * URL surfaced to the agent, so refetching them just wastes RAM and disk.
+ */
+export function shouldFetchAttachment(entry: { mimeType?: string; type?: string; size?: number }): boolean {
+  if (entry.size != null && entry.size > ATTACHMENT_MAX_BYTES) return false;
+  const mime = (entry.mimeType ?? '').toLowerCase();
+  if (!mime) return true; // Discord paste-as-txt often arrives without content_type
+  if (mime.startsWith('text/')) return true;
+  if (mime === 'application/json' || mime === 'application/xml' || mime === 'application/x-yaml') return true;
+  return false;
+}
+
+export async function fetchAttachmentFromUrl(url: string, declaredSize?: number): Promise<Buffer | null> {
+  if (declaredSize != null && declaredSize > ATTACHMENT_MAX_BYTES) {
+    return null;
+  }
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`);
+  }
+  // Honour the size cap even if declaredSize was unset or the server lied.
+  const contentLength = Number(resp.headers.get('content-length') ?? 0);
+  if (contentLength > ATTACHMENT_MAX_BYTES) {
+    return null;
+  }
+  const buf = Buffer.from(await resp.arrayBuffer());
+  if (buf.byteLength > ATTACHMENT_MAX_BYTES) {
+    return null;
+  }
+  return buf;
+}
+
 /** Reply context extracted from a platform's raw message. */
 export interface ReplyContext {
   text: string;
@@ -133,7 +181,20 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serialized = message.toJSON() as Record<string, any>;
 
-    // Download attachment data before serialization loses fetchData()
+    // Download attachment data before serialization loses fetchData(). Two
+    // paths cover the chat-sdk fleet:
+    //
+    //   1. Adapters that expose an `att.fetchData()` callback (legacy /
+    //      Slack-style) — call it.
+    //   2. Adapters that only expose `att.url` (Discord 4.26 maps
+    //      message.attachments to {type, url, name, mimeType, size} with no
+    //      fetchData). Without a fallback, Discord paste-as-txt attachments
+    //      reach the worker as a URL the agent can't fetch from inside its
+    //      sandbox, so the content is invisible. Fall back to fetching the
+    //      URL ourselves.
+    //
+    // Size + type guarded — Discord URLs are unsigned-public CDN links and
+    // no auth is required, but we don't want to OOM on a 100MB upload.
     if (message.attachments && message.attachments.length > 0) {
       const enriched = [];
       for (const att of message.attachments) {
@@ -145,13 +206,21 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           size: att.size,
           width: (att as unknown as Record<string, unknown>).width,
           height: (att as unknown as Record<string, unknown>).height,
+          url: (att as unknown as Record<string, unknown>).url,
         };
         if (att.fetchData) {
           try {
             const buffer = await att.fetchData();
             entry.data = buffer.toString('base64');
           } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
+            log.warn('Failed to download attachment via fetchData', { type: att.type, err });
+          }
+        } else if (typeof entry.url === 'string' && shouldFetchAttachment(entry)) {
+          try {
+            const buffer = await fetchAttachmentFromUrl(entry.url, att.size);
+            if (buffer) entry.data = buffer.toString('base64');
+          } catch (err) {
+            log.warn('Failed to download attachment via url', { type: att.type, name: att.name, err });
           }
         }
         enriched.push(entry);


### PR DESCRIPTION
## Summary

Workers can now read text-paste attachments from Discord. When a Discord user pastes a wall of text → Discord auto-uploads it as a `.txt` → bridge now downloads the bytes via the attachment URL → host writes to `inbox/<msgId>/<filename>` → formatter surfaces the localPath in the `<message>` XML → agent uses `Read` to see the content.

## Why

Today the bridge looks for an `att.fetchData()` callback to pull attachment bytes. Slack-style chat-sdk adapters expose one. The Discord adapter (`@chat-adapter/discord` 4.26) only ships `{type, url, name, mimeType, size}` — no callback. So the bridge silently skipped the download, no `data` field, host's `extractAttachmentFiles` wrote nothing to inbox, formatter fell back to URL-only display, and the agent saw a Discord CDN link it can't fetch from inside its container sandbox. The pasted content was effectively invisible.

## How

- New `shouldFetchAttachment(entry)` — allowlist gate for the URL fallback. Returns true for text/*, application/{json,xml,x-yaml}, and the no-mimeType case (Discord paste-as-txt sometimes omits `content_type`). Returns false for image/video/audio/pdf — those already display via URL in chat, refetching wastes RAM and disk.
- New `fetchAttachmentFromUrl(url, declaredSize?)` — `fetch()` with a size cap (5MB default, override via `BRIDGE_ATTACHMENT_MAX_BYTES`). Three guard rails: declared `att.size` before fetch, HTTP `content-length` after headers, final buffer length after read.
- `messageToInbound` calls them as a fallback after the existing `fetchData` path.
- Downstream is unchanged: `entry.data` (base64) → `extractAttachmentFiles` → inbox/<msgId>/ → formatter → agent `Read`.

## Tests

9 new unit tests in `chat-sdk-bridge.test.ts`:

- `shouldFetchAttachment`: text/*, structured-data, no-mime, image/video/audio rejection, size cap
- `fetchAttachmentFromUrl`: success, declared-size cap (no fetch issued), content-length cap, HTTP error

215/215 vitest pass.

## Test plan

- [x] Host typecheck
- [x] Host tests
- [x] Pre-push hook green
- [ ] Live: paste a multi-page text block into a Discord worker channel → confirm `.txt` lands in `data/v2-sessions/<ag>/<sess>/inbox/<msgId>/<filename>` → confirm agent's prompt shows `[file: <name> — saved to /workspace/inbox/...]` → confirm agent reads and acknowledges content