### PR TITLE
docs(claude.md): build before restart — host runs dist/, not src/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,9 @@ After implementing a feature or fix, do all three before declaring done.
 
 1. **Update docs.** `docs/fleet/architecture/` if behaviour changed; `docs/fleet/guides/testing.md` if a new test path was added; `.env.example` if env vars were added; `docs/fleet/reference/cli.md` if `ncf` flags changed.
 2. **Personally exercise the change.** Compiling and `pnpm test` are not enough.
-   - Code change in `src/`: build, restart the host (with confirmation per CLAUDE.local.md), `ncf inject --wait <worker> "ping"`, watch the reply.
+   - Code change in `src/`: **`pnpm run build` FIRST**, then restart the host (with confirmation per CLAUDE.local.md), then `ncf inject --wait <worker> "ping"`, watch the reply. The systemd unit runs `dist/index.js` — without a rebuild the restart silently loads the old code and your test "passes" against stale behavior. Confirm `dist/<your-file>.js` mtime is newer than the source before restarting.
    - Container-side change (`container/Dockerfile`, `worker-init.sh`, `agent-runner/src/`): rebuild the image (`./container/build.sh` or `ncf rebuild`), `ncf restart <worker>`, message the worker.
+   - Inference shim (`tools/anthropic-shim.ts`): runs straight from source via `bun run`, no build step — restart `nanoclaw-shim.service` and confirm new code is on disk (right git branch / merged to main) before the restart.
    - Worker lifecycle change: create a worker, message it, switch its backend, destroy it, recreate with the same name (resume), confirm DB state and Discord channel state at every step.
    - Inference / shim change: curl the shim, then send a real turn through a Neuralwatt worker.
 3. **Check logs after each test.** `tail -f logs/host.log`, `ncf logs <worker> --follow`, and `jq 'select(.level >= 50)' logs/host.jsonl` for errors. See [`docs/fleet/guides/testing.md`](docs/fleet/guides/testing.md) for the full E2E checklist.

--- a/docs/fleet/guides/testing.md
+++ b/docs/fleet/guides/testing.md
@@ -17,18 +17,18 @@ If anything is red, see [troubleshooting.md](troubleshooting.md).
 
 ## What changed → what to test
 
-| You touched | Run |
-|-|-|
-| `src/modules/fleet/create-worker.ts` | Smoke + lifecycle script (creates, messages, destroys) |
-| `src/modules/fleet/destroy-worker.ts` | Lifecycle script step "destroy then resume" |
-| `src/modules/fleet/switch-backend.ts` | Lifecycle script "switch to neuralwatt" |
-| `src/modules/fleet/discord-channel.ts` or `provision.ts` | Lifecycle script "channel created" assertion |
-| `src/providers/{claude,neuralwatt}.ts` | Smoke + `ncf debug` (verify env injection) |
-| `src/modules/status-pin/` | Smoke (verifies pin landed and edits) |
-| `src/modules/throbber/` | Manual: send message, watch reaction emoji cycle |
-| `container/agent-runner/src/mcp-tools/fleet.ts` | Lifecycle script (master tool calls) |
-| `container/worker-init.sh` | Create a worker with repos/tools, exec in, verify |
-| `scripts/ncf.ts` | Manual `ncf <command>` checks |
+| You touched                                              | Run                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------ |
+| `src/modules/fleet/create-worker.ts`                     | Smoke + lifecycle script (creates, messages, destroys) |
+| `src/modules/fleet/destroy-worker.ts`                    | Lifecycle script step "destroy then resume"            |
+| `src/modules/fleet/switch-backend.ts`                    | Lifecycle script "switch to neuralwatt"                |
+| `src/modules/fleet/discord-channel.ts` or `provision.ts` | Lifecycle script "channel created" assertion           |
+| `src/providers/{claude,neuralwatt}.ts`                   | Smoke + `ncf debug` (verify env injection)             |
+| `src/modules/status-pin/`                                | Smoke (verifies pin landed and edits)                  |
+| `src/modules/throbber/`                                  | Manual: send message, watch reaction emoji cycle       |
+| `container/agent-runner/src/mcp-tools/fleet.ts`          | Lifecycle script (master tool calls)                   |
+| `container/worker-init.sh`                               | Create a worker with repos/tools, exec in, verify      |
+| `scripts/ncf.ts`                                         | Manual `ncf <command>` checks                          |
 
 ## Smoke test
 
@@ -163,21 +163,22 @@ ncf restart <worker>
 
 ## Common failures
 
-| Symptom | Likely cause | Fix |
-|-|-|-|
-| Worker channel created, no agent reply | Master never wrote to inbound | Check `ncf debug` for sessions; tail host.log |
-| `ncf create` returns "channel already exists" | Orphan from a prior failed run | `ncf reap-orphans` |
-| Neuralwatt worker 401s on first turn | Shim's `worker-backends.json` missing the entry | Set `NW_SHIM_CONFIG_PATH` and rerun `ncf switch <worker> neuralwatt <model>` |
-| Status pin appears multiple times | Stale pins from a prior bot identity | Restart the host; the sweep runs on startup |
-| Container builds don't pick up changes | Docker layer cache | `./container/build.sh` rebuilds the agent layer |
-| Master doesn't see fleet MCP tools | `fleet_role` not set on master agent_group | Re-run `init-fleet-master-discord.ts` |
+| Symptom                                         | Likely cause                                                                                                   | Fix                                                                                          |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Worker channel created, no agent reply          | Master never wrote to inbound                                                                                  | Check `ncf debug` for sessions; tail host.log                                                |
+| `ncf create` returns "channel already exists"   | Orphan from a prior failed run                                                                                 | `ncf reap-orphans`                                                                           |
+| Neuralwatt worker 401s on first turn            | Shim's `worker-backends.json` missing the entry                                                                | Set `NW_SHIM_CONFIG_PATH` and rerun `ncf switch <worker> neuralwatt <model>`                 |
+| Restarted host, change still didn't take effect | Forgot `pnpm run build` — host runs `dist/index.js`, not `src/`. The restart silently loaded old compiled code | `pnpm run build`, confirm `stat -c %y dist/<file>.js` is newer than the source, then restart |
+| Status pin appears multiple times               | Stale pins from a prior bot identity                                                                           | Restart the host; the sweep runs on startup                                                  |
+| Container builds don't pick up changes          | Docker layer cache                                                                                             | `./container/build.sh` rebuilds the agent layer                                              |
+| Master doesn't see fleet MCP tools              | `fleet_role` not set on master agent_group                                                                     | Re-run `init-fleet-master-discord.ts`                                                        |
 
 ## Files
 
-| File | Role |
-|-|-|
-| `scripts/smoke.sh` | Quick end-to-end smoke |
-| `scripts/test-fleet-lifecycle.ts` | Deeper 8-step lifecycle |
-| `scripts/init-fleet-master-discord.ts` | Master seeding |
-| `scripts/ncf.ts` | The CLI itself |
-| `~/.config/nanoclaw/debug_bot_token` | Debug bot token |
+| File                                   | Role                    |
+| -------------------------------------- | ----------------------- |
+| `scripts/smoke.sh`                     | Quick end-to-end smoke  |
+| `scripts/test-fleet-lifecycle.ts`      | Deeper 8-step lifecycle |
+| `scripts/init-fleet-master-discord.ts` | Master seeding          |
+| `scripts/ncf.ts`                       | The CLI itself          |
+| `~/.config/nanoclaw/debug_bot_token`   | Debug bot token         |


### PR DESCRIPTION
## Summary

Strengthen the "After making changes" section in CLAUDE.md so the next agent doesn't repeat today's mistake — twice — of editing `src/`, restarting the host service, and "verifying" against stale compiled code in `dist/`.

## Why

Hit this twice in one session:

1. PR #87 (shim trace) e2e: edited `tools/anthropic-shim.ts`, restarted shim service, saw no `logs/shim-traces/` directory created. Cause: I was on a different git branch and the file on disk was the old version. Different gotcha but same family.
2. PR #91 (bridge attachment URL fetch) e2e: edited `src/channels/chat-sdk-bridge.ts`, restarted nanoclaw service, sent a Discord message with attachment, saw the `attachments` array reach `messages_in.content` with no `url` field — meaning the new code path wasn't exercised. Cause: I forgot `pnpm run build`. The systemd unit runs `dist/index.js`. The restart silently loaded the old compiled bridge.

The original CLAUDE.md said "build" inside a longer sentence — easy to skim past.

## How

- CLAUDE.md "Personally exercise the change" gets a more emphatic build step + states the failure mode + adds a confirmation step (`stat -c %y dist/<file>.js` newer than source).
- Add a separate bullet for `tools/anthropic-shim.ts` — it runs straight from source via `bun run`, no build, but you do need to be on the right branch / merged-to-main on disk before the restart.
- `docs/fleet/guides/testing.md` "Common failures" table gets a new row mapping the symptom ("restarted host, change still didn't take effect") to the fix.

## Test plan

Doc-only, no code. Visual review of both files.