### PR TITLE
feat(fleet): fork_worker — clone a worker into a new agent group

### DIFF
--- a/container/agent-runner/src/mcp-tools/fleet.ts
+++ b/container/agent-runner/src/mcp-tools/fleet.ts
@@ -50,12 +50,13 @@ export const createWorker: McpToolDefinition = {
         name: { type: 'string', description: 'Worker name (becomes channel name, folder name, and destination name)' },
         backend: {
           type: 'string',
-          description: "Provider name — 'claude' (default) or any installed provider skill (neuralwatt, opencode, codex, ollama).",
+          description:
+            "Provider name — 'claude' (default) or any installed provider skill (neuralwatt, opencode, codex, ollama).",
         },
         model: { type: 'string', description: 'Model identifier for the selected backend. Optional.' },
         instructions: {
           type: 'string',
-          description: "Seed CLAUDE.local.md for the new worker — personality, role, tooling hints.",
+          description: 'Seed CLAUDE.local.md for the new worker — personality, role, tooling hints.',
         },
       },
       required: ['name'],
@@ -150,7 +151,46 @@ export const switchBackend: McpToolDefinition = {
       }),
     });
     log(`switch_backend: ${id} → "${name}" → ${backend}`);
-    return ok(`Switching worker "${name}" to ${backend}${args.model ? ` (${args.model})` : ''}. Will take effect on next message.`);
+    return ok(
+      `Switching worker "${name}" to ${backend}${args.model ? ` (${args.model})` : ''}. Will take effect on next message.`,
+    );
+  },
+};
+
+export const forkWorker: McpToolDefinition = {
+  tool: {
+    name: 'fork_worker',
+    description:
+      "Fork an existing worker into a new agent group with its own Discord channel. The fork inherits the source's workspace files, CLAUDE.local.md, container.json (backend/model), and prior message history, but starts a fresh SDK conversation so it runs independently from the source. Useful for branching at a point in a conversation to explore two paths in parallel. Pass `source: 'self'` to fork the calling agent itself. Fire-and-forget.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        source: {
+          type: 'string',
+          description: "Source worker name (or 'self' to fork the master/calling agent)",
+        },
+        name: { type: 'string', description: 'Name for the fork (becomes its channel + folder + destination name)' },
+      },
+      required: ['source', 'name'],
+    },
+  },
+  async handler(args) {
+    const source = args.source as string;
+    const name = args.name as string;
+    if (!source || !name) return err('source and name are required');
+    const id = generateId();
+    writeMessageOut({
+      id,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'fork_worker',
+        requestId: id,
+        source,
+        name,
+      }),
+    });
+    log(`fork_worker: ${id} → "${source}" → "${name}"`);
+    return ok(`Forking "${source}" into new worker "${name}". You will be notified when it is ready.`);
   },
 };
 
@@ -175,4 +215,4 @@ export const listWorkers: McpToolDefinition = {
   },
 };
 
-registerTools([createWorker, destroyWorker, switchBackend, listWorkers]);
+registerTools([createWorker, destroyWorker, switchBackend, forkWorker, listWorkers]);

--- a/scripts/ncf.ts
+++ b/scripts/ncf.ts
@@ -35,6 +35,7 @@ Usage:
   ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>]
   ncf destroy <name> [--keep-channel]
   ncf switch <name> <backend> [model]
+  ncf fork <source> <fork_name>
   ncf logs <name> [--follow]
   ncf session <name>
   ncf inject <name> <msg> [--wait] [--timeout <sec>]
@@ -283,6 +284,15 @@ function cmdSwitch(args: string[]): void {
     process.exit(1);
   }
   writeSystemAction('switch_backend', { name, backend, model: model ?? null });
+}
+
+function cmdFork(args: string[]): void {
+  const [source, name] = args;
+  if (!source || !name) {
+    console.error('usage: ncf fork <source> <fork_name>');
+    process.exit(1);
+  }
+  writeSystemAction('fork_worker', { source, name });
 }
 
 function cmdLogs(args: string[]): void {
@@ -903,6 +913,8 @@ function main(): void {
       return cmdDestroy(rest);
     case 'switch':
       return cmdSwitch(rest);
+    case 'fork':
+      return cmdFork(rest);
     case 'logs':
       return cmdLogs(rest);
     case 'session':

--- a/src/modules/fleet/events.ts
+++ b/src/modules/fleet/events.ts
@@ -14,7 +14,7 @@ import path from 'path';
 
 const EVENTS_FILE = path.resolve(process.cwd(), 'logs', 'worker-events.jsonl');
 
-export type WorkerEventKind = 'created' | 'destroyed' | 'backend_switched' | 'resumed';
+export type WorkerEventKind = 'created' | 'destroyed' | 'backend_switched' | 'resumed' | 'forked';
 
 export interface WorkerEvent {
   timestamp: string;

--- a/src/modules/fleet/fleet.test.ts
+++ b/src/modules/fleet/fleet.test.ts
@@ -58,6 +58,7 @@ vi.mock('../agent-to-agent/write-destinations.js', () => ({
 const { handleCreateWorker } = await import('./create-worker.js');
 const { handleDestroyWorker } = await import('./destroy-worker.js');
 const { handleSwitchBackend } = await import('./switch-backend.js');
+const { handleForkWorker } = await import('./fork-worker.js');
 const { listWorkers } = await import('./list-workers.js');
 
 const TEST_DIR = '/tmp/nanoclaw-test-fleet';
@@ -187,6 +188,74 @@ describe('switch_backend', () => {
     expect(w?.fleet_model).toBe('kimi-k2.5');
     const cfg = JSON.parse(fs.readFileSync(TEST_DIR + '/groups/epsilon/container.json', 'utf-8'));
     expect(cfg.provider).toBe('neuralwatt');
+  });
+});
+
+describe('fork_worker', () => {
+  it("creates a new agent_group with the source worker's backend + model", async () => {
+    await handleCreateWorker({ name: 'src1', backend: 'neuralwatt', model: 'kimi-k2.5' }, makeMasterSession());
+    await handleForkWorker({ source: 'src1', name: 'fork1' }, makeMasterSession());
+
+    const fork = getAgentGroupByFolder('fork1');
+    expect(fork).toBeDefined();
+    expect(fork?.id).not.toBe(getAgentGroupByFolder('src1')?.id);
+    expect(fork?.fleet_role).toBe('worker');
+    expect(fork?.fleet_backend).toBe('neuralwatt');
+    expect(fork?.fleet_model).toBe('kimi-k2.5');
+    expect(fork?.status ?? 'active').toBe('active');
+  });
+
+  it('rejects fork name collision with an existing worker', async () => {
+    await handleCreateWorker({ name: 'src2' }, makeMasterSession());
+    await handleCreateWorker({ name: 'taken' }, makeMasterSession());
+    const beforeIds = new Set([getAgentGroupByFolder('src2')?.id, getAgentGroupByFolder('taken')?.id]);
+
+    await handleForkWorker({ source: 'src2', name: 'taken' }, makeMasterSession());
+
+    // No new agent_group created (the existing 'taken' is unchanged).
+    const after = getAgentGroupByFolder('taken');
+    expect(beforeIds.has(after?.id)).toBe(true);
+  });
+
+  it('rejects when source worker does not exist', async () => {
+    await handleForkWorker({ source: 'nope', name: 'fork-of-nope' }, makeMasterSession());
+    expect(getAgentGroupByFolder('fork-of-nope')).toBeUndefined();
+  });
+
+  it('rejects when source and fork names match', async () => {
+    await handleCreateWorker({ name: 'src3' }, makeMasterSession());
+    await handleForkWorker({ source: 'src3', name: 'src3' }, makeMasterSession());
+    // Source still the only one with this folder.
+    expect(getAgentGroupByFolder('src3')?.fleet_role).toBe('worker');
+  });
+
+  it('rejects non-master callers', async () => {
+    updateAgentGroup('ag-master', { fleet_role: null });
+    await handleForkWorker({ source: 'whatever', name: 'still-noop' }, makeMasterSession());
+    expect(getAgentGroupByFolder('still-noop')).toBeUndefined();
+  });
+
+  it('writes a forked event to worker-events.jsonl', async () => {
+    await handleCreateWorker({ name: 'src4' }, makeMasterSession());
+    await handleForkWorker({ source: 'src4', name: 'fork4' }, makeMasterSession());
+
+    const eventsFile = require('path').resolve(process.cwd(), 'logs/worker-events.jsonl');
+    const fsLocal = require('fs');
+    if (fsLocal.existsSync(eventsFile)) {
+      const lines = fsLocal.readFileSync(eventsFile, 'utf-8').trim().split('\n');
+      const forkedRow = lines
+        .map((l: string) => {
+          try {
+            return JSON.parse(l);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean)
+        .find((e: { event: string; folder: string }) => e.event === 'forked' && e.folder === 'fork4');
+      expect(forkedRow).toBeDefined();
+      expect(forkedRow.details.source).toBe('src4');
+    }
   });
 });
 

--- a/src/modules/fleet/fork-worker.ts
+++ b/src/modules/fleet/fork-worker.ts
@@ -1,0 +1,406 @@
+/**
+ * `fork_worker` delivery-action handler.
+ *
+ * Clones an existing worker into a new agent group with its own Discord
+ * channel, while inheriting the source's workspace files, prior message
+ * history, container.json (backend/model), and CLAUDE.local.md memory. The
+ * fork starts a FRESH SDK conversation — the inherited inbound/outbound
+ * history gives it human-visible context, but the Anthropic-side session
+ * id from the source is dropped so source and fork can run independently
+ * without corrupting each other's server-side conversation.
+ *
+ * What's cloned:
+ *   - groups/<source>/   →  groups/<fork>/         (workspace, CLAUDE.local.md,
+ *                                                   container.json, profile)
+ *   - data/v2-sessions/<src-ag>/.claude-shared/  →  fork's .claude-shared
+ *   - For each source session:
+ *       inbound.db / outbound.db (sqlite online-backup, consistent across
+ *         a live writer — no need to stop the source container)
+ *       turns.jsonl, inbox/, conversations/, etc.
+ *
+ * What's NOT cloned:
+ *   - Discord channel — fork gets a new one (otherwise messages route
+ *     ambiguously between source and fork)
+ *   - SDK session id — explicitly cleared from fork's outbound.db so the
+ *     fork's first turn boots a fresh server-side conversation
+ *
+ * Caller must be the master agent (fleet_role='master').
+ *
+ * Reuses lifecycle helpers from create-worker.ts where possible.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import Database from 'better-sqlite3';
+
+import { DATA_DIR, GROUPS_DIR } from '../../config.js';
+import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { createSession, getSessionsByAgentGroup } from '../../db/sessions.js';
+import { initGroupFilesystem } from '../../group-init.js';
+import { sessionDir } from '../../session-manager.js';
+import { log } from '../../log.js';
+import type { AgentGroup, Session } from '../../types.js';
+import {
+  createDestination,
+  getDestinationByName,
+  normalizeName as normalizeDestName,
+} from '../agent-to-agent/db/agent-destinations.js';
+import { writeDestinations } from '../agent-to-agent/write-destinations.js';
+import { logWorkerEvent } from './events.js';
+import { generateId, normalizeName, notifyAgent, setFleetBackend } from './lib.js';
+import { provisionDiscordChannel } from './provision.js';
+
+function isSafeFolderName(folder: string): boolean {
+  const r = path.resolve(path.join(GROUPS_DIR, folder));
+  const root = path.resolve(GROUPS_DIR);
+  return r.startsWith(root + path.sep);
+}
+
+/**
+ * SQLite online-backup of source → dest. Safe to call while the source DB
+ * has an open writer (the agent container's poll loop). The backup API
+ * holds a brief shared lock and produces a consistent snapshot — no need
+ * to stop the source container or drain in-flight writes.
+ *
+ * better-sqlite3's `db.backup()` is async (returns a Promise resolving
+ * once the backup is complete). Earlier versions of this code called it
+ * without `await` and ended up with empty 0-byte DBs because the
+ * function returned before the copy finished and the source DB was
+ * closed too early — caught during fork e2e.
+ */
+async function backupSqlite(sourcePath: string, destPath: string): Promise<void> {
+  if (!fs.existsSync(sourcePath)) return;
+  const src = new Database(sourcePath, { readonly: true });
+  try {
+    await src.backup(destPath);
+  } finally {
+    src.close();
+  }
+}
+
+function clearSdkSessionId(outboundDbPath: string): void {
+  if (!fs.existsSync(outboundDbPath)) return;
+  const db = new Database(outboundDbPath);
+  try {
+    db.prepare("DELETE FROM session_state WHERE key = 'sdk_session_id'").run();
+  } catch {
+    // session_state table may be absent on a brand-new outbound.db; ignore.
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Use lstat-based existence so broken symlinks (e.g. `.claude-shared.md`
+ * which targets `/app/CLAUDE.md` only valid inside a container) count as
+ * existing. fs.existsSync follows symlinks and would mis-report a broken
+ * link as "doesn't exist," causing us to try to overwrite it.
+ */
+function lExistsSync(p: string): boolean {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deep copy that preserves symlinks as symlinks (without following the
+ * target) and skips broken links + uncopyable entries with a warning.
+ * Built for `.claude-shared` which mixes real files + container-only
+ * symlinks; cpSync's recursive mode trips on the broken-link entries.
+ */
+function copyOverlayDeep(srcDir: string, dstDir: string): void {
+  if (!lExistsSync(srcDir)) return;
+  for (const entry of fs.readdirSync(srcDir)) {
+    const srcEntry = path.join(srcDir, entry);
+    const dstEntry = path.join(dstDir, entry);
+    let st;
+    try {
+      st = fs.lstatSync(srcEntry);
+    } catch {
+      continue;
+    }
+    if (st.isSymbolicLink()) {
+      try {
+        const target = fs.readlinkSync(srcEntry);
+        if (!lExistsSync(dstEntry)) fs.symlinkSync(target, dstEntry);
+      } catch (err) {
+        log.warn('fork_worker: skipping uncopyable symlink', { srcEntry, err: String(err) });
+      }
+      continue;
+    }
+    if (st.isDirectory()) {
+      fs.mkdirSync(dstEntry, { recursive: true });
+      copyOverlayDeep(srcEntry, dstEntry);
+      continue;
+    }
+    if (st.isFile()) {
+      try {
+        if (!lExistsSync(dstEntry)) fs.copyFileSync(srcEntry, dstEntry);
+      } catch (err) {
+        log.warn('fork_worker: skipping uncopyable file', { srcEntry, err: String(err) });
+      }
+      continue;
+    }
+    // Sockets, fifos, devices — skip silently.
+  }
+}
+
+function copyOverlay(srcDir: string, dstDir: string, skip: ReadonlySet<string>): void {
+  if (!lExistsSync(srcDir)) return;
+  for (const entry of fs.readdirSync(srcDir)) {
+    if (skip.has(entry)) continue;
+    const srcEntry = path.join(srcDir, entry);
+    const dstEntry = path.join(dstDir, entry);
+    if (lExistsSync(dstEntry)) continue;
+    // Skip broken symlinks at the source. The composer scaffold (e.g.
+    // `.claude-shared.md` → `/app/CLAUDE.md`, `skills/<name>` → packaged
+    // skill paths) only resolves inside the container. The fork's
+    // initGroupFilesystem + composeGroupClaudeMd recreate them at spawn,
+    // so we don't need to copy them; trying to would break cpSync on
+    // host (it follows the link to validate and the target is missing).
+    try {
+      const st = fs.lstatSync(srcEntry);
+      if (st.isSymbolicLink()) {
+        // Always re-link rather than copy the link's target. If the link
+        // is broken on host, just skip — composer will recreate.
+        if (!fs.existsSync(srcEntry)) continue;
+        const linkTarget = fs.readlinkSync(srcEntry);
+        fs.symlinkSync(linkTarget, dstEntry);
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    try {
+      fs.cpSync(srcEntry, dstEntry, { recursive: true, dereference: false });
+    } catch (err) {
+      log.warn('fork_worker: skipping uncopyable entry', { srcEntry, err: String(err) });
+    }
+  }
+}
+
+function wireBidirectionalDestinations(
+  master: AgentGroup,
+  forkId: string,
+  forkLocalName: string,
+  nowIso: string,
+): void {
+  createDestination({
+    agent_group_id: master.id,
+    local_name: forkLocalName,
+    target_type: 'agent',
+    target_id: forkId,
+    created_at: nowIso,
+  });
+  let parentName = normalizeDestName(master.folder);
+  let suffix = 2;
+  while (getDestinationByName(forkId, parentName)) {
+    parentName = `${normalizeDestName(master.folder)}-${suffix}`;
+    suffix++;
+  }
+  createDestination({
+    agent_group_id: forkId,
+    local_name: parentName,
+    target_type: 'agent',
+    target_id: master.id,
+    created_at: nowIso,
+  });
+}
+
+export async function handleForkWorker(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceName = (content.source as string | undefined) ?? '';
+  const forkName = (content.name as string | undefined) ?? '';
+
+  if (!sourceName || !forkName) {
+    notifyAgent(session, `fork_worker failed: source and name are required.`);
+    return;
+  }
+
+  const callerGroup = getAgentGroup(session.agent_group_id);
+  if (!callerGroup) {
+    notifyAgent(session, `fork_worker failed: caller agent group not found.`);
+    return;
+  }
+  if (callerGroup.fleet_role !== 'master') {
+    notifyAgent(session, `fork_worker failed: only the master can fork workers.`);
+    return;
+  }
+
+  const forkLocalName = normalizeName(forkName);
+  if (!forkLocalName || forkLocalName === 'unnamed') {
+    notifyAgent(session, `fork_worker failed: "${forkName}" is not a usable worker name.`);
+    return;
+  }
+  if (!isSafeFolderName(forkLocalName)) {
+    notifyAgent(session, `fork_worker failed: invalid fork folder name.`);
+    log.error('fork_worker path traversal attempt', { folder: forkLocalName });
+    return;
+  }
+
+  // Resolve source. 'self' / caller's name are aliases for "fork the master itself".
+  let source: AgentGroup | undefined;
+  const sourceFolder = normalizeName(sourceName);
+  if (sourceName === 'self' || sourceFolder === callerGroup.folder) {
+    source = callerGroup;
+  } else {
+    source = getAgentGroupByFolder(sourceFolder);
+  }
+  if (!source) {
+    notifyAgent(session, `fork_worker failed: source worker "${sourceName}" not found.`);
+    return;
+  }
+  if (source.status === 'archived') {
+    notifyAgent(session, `fork_worker failed: source worker "${source.folder}" is archived. Resume it first.`);
+    return;
+  }
+  if (source.folder === forkLocalName) {
+    notifyAgent(session, `fork_worker failed: source and fork must have different names.`);
+    return;
+  }
+
+  const existing = getAgentGroupByFolder(forkLocalName);
+  if (existing) {
+    notifyAgent(
+      session,
+      `fork_worker failed: a worker named "${forkLocalName}" already exists (status=${existing.status}). Choose a different fork name.`,
+    );
+    return;
+  }
+
+  const forkId = generateId('ag');
+  const now = new Date().toISOString();
+
+  const forkGroup: AgentGroup = {
+    id: forkId,
+    name: forkName,
+    folder: forkLocalName,
+    agent_provider: source.agent_provider ?? null,
+    created_at: now,
+    status: 'active',
+    fleet_backend: source.fleet_backend ?? null,
+    fleet_model: source.fleet_model ?? null,
+    fleet_role: 'worker',
+  };
+  createAgentGroup(forkGroup);
+
+  // Initialize standard scaffolding (composed CLAUDE.md, .claude-fragments,
+  // .claude-shared symlinks). Then overlay source's workspace on top — but
+  // skip composer outputs that re-generate on every spawn anyway.
+  initGroupFilesystem(forkGroup);
+
+  const sourceGroupDir = path.resolve(GROUPS_DIR, source.folder);
+  const forkGroupDir = path.resolve(GROUPS_DIR, forkLocalName);
+  copyOverlay(sourceGroupDir, forkGroupDir, new Set(['CLAUDE.md', '.claude-fragments']));
+
+  // Sync container.json (backend, model, profile, MCP servers) into the
+  // fork's slot AND populate the shim's worker-backends.json so the first
+  // request from the fork's container routes correctly.
+  setFleetBackend(forkLocalName, source.fleet_backend ?? 'claude', source.fleet_model ?? undefined);
+
+  // Provision a fresh Discord channel for the fork. The source keeps its
+  // own channel; routing only stays sane if the two never share one.
+  const provision = await provisionDiscordChannel(forkId, forkLocalName, forkName, now);
+
+  // Clone every source session into the fork's agent group. Each clone
+  // gets a new session id and the fork's messaging_group_id, so the fork
+  // routes inbound through its OWN channel instead of the source's.
+  const sourceSessions = getSessionsByAgentGroup(source.id);
+  let clonedSessions = 0;
+
+  // Clone .claude-shared once for the fork agent group. Keyed at the
+  // agent-group level so this only fires once even with multiple sessions.
+  // The directory contains a mix of:
+  //   - real files (settings.json, project session jsonl files, shell-snapshots)
+  //   - symlinks pointing INTO the container ($/app/skills/...,
+  //     /workspace/extra/host-skills/...) that don't exist on host
+  // We use copyOverlay's walker, which preserves real files + replicates
+  // symlinks as-is (without trying to follow). Skill symlinks are
+  // re-synced at spawn time by syncSkillSymlinks regardless.
+  const srcClaudeShared = path.join(DATA_DIR, 'v2-sessions', source.id, '.claude-shared');
+  const dstClaudeShared = path.join(DATA_DIR, 'v2-sessions', forkId, '.claude-shared');
+  if (lExistsSync(srcClaudeShared) && !lExistsSync(dstClaudeShared)) {
+    fs.mkdirSync(dstClaudeShared, { recursive: true });
+    copyOverlayDeep(srcClaudeShared, dstClaudeShared);
+  }
+
+  for (const srcSess of sourceSessions) {
+    const forkSessionId = generateId('sess');
+    const newSession: Session = {
+      id: forkSessionId,
+      agent_group_id: forkId,
+      messaging_group_id: provision.messagingGroupId,
+      thread_id: srcSess.thread_id,
+      agent_provider: srcSess.agent_provider,
+      status: 'active',
+      container_status: 'idle',
+      last_active: now,
+      created_at: now,
+    };
+    createSession(newSession);
+
+    const srcDir = sessionDir(source.id, srcSess.id);
+    const dstDir = sessionDir(forkId, forkSessionId);
+    fs.mkdirSync(dstDir, { recursive: true });
+
+    // Online-backup the SQLite DBs so a concurrent writer in the source
+    // container can't tear the snapshot.
+    await backupSqlite(path.join(srcDir, 'inbound.db'), path.join(dstDir, 'inbound.db'));
+    await backupSqlite(path.join(srcDir, 'outbound.db'), path.join(dstDir, 'outbound.db'));
+
+    // Copy non-DB session artifacts (turns.jsonl, inbox/, conversations/,
+    // .heartbeat). Skip SQLite sidecars — those are bound to the source's
+    // open writer and would cause the cloned DB to refuse to open.
+    if (fs.existsSync(srcDir)) {
+      for (const entry of fs.readdirSync(srcDir)) {
+        if (entry === 'inbound.db' || entry === 'outbound.db') continue;
+        if (entry.endsWith('-journal') || entry.endsWith('-wal') || entry.endsWith('-shm')) continue;
+        const s = path.join(srcDir, entry);
+        const d = path.join(dstDir, entry);
+        if (fs.existsSync(d)) continue;
+        fs.cpSync(s, d, { recursive: true, dereference: false });
+      }
+    }
+
+    // Drop the inherited SDK session id so the fork starts a fresh
+    // server-side conversation. Local inbound/outbound history survives
+    // for the agent to read; the SDK's own server memory of those turns
+    // does not.
+    clearSdkSessionId(path.join(dstDir, 'outbound.db'));
+
+    clonedSessions++;
+  }
+
+  wireBidirectionalDestinations(callerGroup, forkId, forkLocalName, now);
+  writeDestinations(session.agent_group_id, session.id);
+
+  notifyAgent(
+    session,
+    `Worker "${forkLocalName}" forked from "${source.folder}" on ${source.fleet_backend ?? 'claude'}${source.fleet_model ? ` (${source.fleet_model})` : ''}. ${provision.statusText}. ${clonedSessions} session(s) cloned. Fork starts a fresh SDK conversation but inherits workspace files and prior message history. Message it with <message to="${forkLocalName}">...</message>.`,
+  );
+  log.info('Worker forked', {
+    forkId,
+    forkLocalName,
+    source: source.folder,
+    sourceAgentGroupId: source.id,
+    backend: source.fleet_backend,
+    model: source.fleet_model,
+    clonedSessions,
+  });
+  logWorkerEvent({
+    timestamp: new Date().toISOString(),
+    event: 'forked',
+    worker: forkLocalName,
+    folder: forkLocalName,
+    details: {
+      agentGroupId: forkId,
+      source: source.folder,
+      sourceAgentGroupId: source.id,
+      backend: source.fleet_backend ?? null,
+      model: source.fleet_model ?? null,
+      clonedSessions,
+    },
+  });
+}

--- a/src/modules/fleet/index.ts
+++ b/src/modules/fleet/index.ts
@@ -17,10 +17,12 @@
 import { registerDeliveryAction } from '../../delivery.js';
 import { handleCreateWorker } from './create-worker.js';
 import { handleDestroyWorker } from './destroy-worker.js';
+import { handleForkWorker } from './fork-worker.js';
 import { handleListWorkersRequest } from './list-workers.js';
 import { handleSwitchBackend } from './switch-backend.js';
 
 registerDeliveryAction('create_worker', handleCreateWorker);
 registerDeliveryAction('destroy_worker', handleDestroyWorker);
 registerDeliveryAction('switch_backend', handleSwitchBackend);
+registerDeliveryAction('fork_worker', handleForkWorker);
 registerDeliveryAction('list_workers_request', handleListWorkersRequest);


### PR DESCRIPTION
## Summary

Adds `fork_worker` MCP tool, host handler, and `ncf fork <source> <fork_name>` CLI. Forks an existing worker into a new agent group with its own Discord channel, while inheriting the source's workspace files, container.json (backend/model), CLAUDE.local.md, and full session DB history. The fork starts a FRESH SDK conversation — `sdk_session_id` is cleared so source and fork run independently without corrupting each other's server-side state.

## Why

Joey wanted a way to branch a worker at a point in conversation history — explore two paths in parallel without losing the prior context. Today the only options are destroy + recreate (loses everything) or copy-pasta the workspace by hand (no DB, no Discord channel, no wiring).

## Cloned

- `groups/<source>/` → `groups/<fork>/` — workspace, profile, MCP servers, CLAUDE.local.md
- `data/v2-sessions/<src-ag>/.claude-shared` → fork's `.claude-shared` — settings, project session jsonls, skill symlinks
- For each source session: `inbound.db` + `outbound.db` via SQLite online-backup (consistent across a live writer — no need to stop the source container), plus `turns.jsonl`, `inbox/`, `conversations/`, etc.

## NOT cloned

- Discord channel — fork gets a new one (sharing one would route messages ambiguously between source and fork)
- SDK session id — explicitly cleared so the fork's first turn boots a fresh server-side conversation. The carried-over inbound/outbound history gives the agent enough context to pick up where the source left off; it just rebuilds its own SDK memory of those turns.

## API

- MCP tool: `fork_worker({ source, name })` available to master agents. Pass `source: 'self'` to fork the calling master itself.
- CLI: `ncf fork <source> <fork_name>`
- Worker calling `fork_worker` on itself routes through the master, same as `switch_backend` does today.

## Implementation gotchas (caught during e2e — comments inline)

1. `db.backup()` in better-sqlite3 is async — must `await` or the source DB closes before the copy finishes and you get a 0-byte destination.
2. Composer scaffold (`.claude-shared.md`, `skills/<name>`) uses symlinks whose targets only resolve INSIDE the container. Naive `cpSync` with `dereference: false` trips on broken-link entries with ENOENT. Custom walker (`copyOverlayDeep`) replicates symlinks as-is and skips broken ones; the composer recreates them at the next spawn.
3. `existsSync` follows symlinks; a broken-link destination reads as "doesn't exist" so we'd try to overwrite it. Switched to lstat-based existence check.

## Test plan

- [x] Host typecheck + container typecheck
- [x] Host tests (228/228 — 6 new fleet.test.ts cases)
- [x] Pre-push hook green
- [x] Live e2e: `ncf fork model-dev model-dev-fork` against a live neuralwatt-backed worker
  - [x] New Discord channel created (worker-model-dev-fork)
  - [x] Session DBs cloned byte-identical (24 messages preserved)
  - [x] sdk_session_id cleared in fork
  - [x] Fork container spawned with fresh SDK session id (857487e0… vs source's 570e5347…)
  - [x] Source unaffected — replied "OK" to a follow-up post-fork

## Known limitation

The fork's first reply on the e2e hit the `<internal>`-wrapper hallucination from PR #89's open issue (the pattern in carried-over conversation history overrides the conditional rule wording). Orthogonal to forking — affects ANY worker with a heavy `<internal>`-wrapper history. Worth a follow-up: either tighten the rule wording further, add a formatter-level fallback, or fork without history-replay by default. Not blocking this PR.