### PR TITLE
fix(formatter): auto-suppress final text when send_message ran + fork thread_id

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -82,6 +82,68 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
+  it('auto-suppresses final turn text when send_message tool_use ran this turn', async () => {
+    // Agent ran send_message early (the canonical ack-then-work flow), then
+    // its closing scratchpad ("<internal>done</internal>") falls through.
+    // dispatchResultText must drop the final text so the user doesn't see
+    // a duplicate or template-junk line. The MCP-side send_message itself
+    // is a no-op in MockProvider, so the only thing that *would* land in
+    // outbound is the scratchpad — assert nothing lands.
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'Do the thing' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
+
+    const provider = new MockProvider(
+      {},
+      () => '<internal>Sent reply via send_message. No further output needed.</internal>',
+      ['mcp__nanoclaw__send_message'],
+    );
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
+
+    // Wait for the result event by waiting for the message to be ack'd.
+    await waitFor(() => getPendingMessages().length === 0, 1500);
+    controller.abort();
+
+    expect(getUndeliveredMessages()).toHaveLength(0);
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('salvages internal-only output when no send_message ran (rather than going silent)', async () => {
+    // Bug PR #93 surfaced: agent emits ONLY <internal>...</internal> with no
+    // send_message tool_use. Old behavior stripped the wrapper, leaving
+    // empty text, leaving the user with silence. New behavior unwraps the
+    // <internal> block and surfaces the text — weird-looking but not
+    // silent, so the user can see the agent's broken state and ask again.
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'Hi' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
+
+    const provider = new MockProvider(
+      {},
+      () => '<internal>Acknowledged via send_message.</internal>',
+      [], // no tool_use this turn
+    );
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 1500);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Acknowledged via send_message.');
+
+    await loopPromise.catch(() => {});
+  });
+
   it('should process messages arriving after loop starts', async () => {
     const provider = new MockProvider({}, () => '<message to="discord-test">Processed</message>');
     const controller = new AbortController();

--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -24,11 +24,9 @@ The user is often on a phone screen, doesn't see your tool calls, and only knows
 
 ### Avoid duplicate messages
 
-`send_message` posts a chat reply immediately. Your final turn output is _also_ delivered as a chat message — so if `send_message` already ran this turn, the user sees the same content twice.
+`send_message` posts a chat reply immediately. Your final turn output is also normally delivered as a chat message. NanoClaw automatically suppresses the final turn output when `send_message` ran this turn, so you'll never get a duplicate — just write naturally. No `<internal>...</internal>` wrapping needed for de-duplication.
 
-To suppress the duplicate, wrap the final output in `<internal>...</internal>` and NanoClaw drops it from chat.
-
-**Only do this if a real `send_message` tool_use ran earlier in the same turn.** If none did, your final output IS the user-visible reply — write it as a normal chat message. A stand-alone `<internal>...</internal>` with no preceding `send_message` produces silence: the formatter drops the wrap, no other content is sent, the user gets nothing.
+(Internal scratchpad wrapping is still useful for genuinely-internal reasoning that you don't want delivered to chat — see "Internal thoughts" below.)
 
 ### Pacing updates on longer turns
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -346,6 +346,12 @@ async function processQuery(
   const traceId = initialBatchIds.join(',');
   const tStart = Date.now();
   let firstEventAt: number | null = null;
+  // Count of mcp__nanoclaw__send_message tool_use events in the current
+  // turn. Reset on every result so each turn's count stands alone.
+  // dispatchResultText reads this to decide whether the final turn text
+  // is a duplicate of a real reply already delivered via send_message
+  // (drop it) or the only output the agent produced (surface it).
+  let sendMessageToolUseCount = 0;
   try {
     for await (const event of query.events) {
       if (firstEventAt === null) {
@@ -355,7 +361,11 @@ async function processQuery(
       handleEvent(event, routing);
       touchHeartbeat();
 
-      if (event.type === 'init') {
+      if (event.type === 'tool_use') {
+        if (event.tool_name === 'mcp__nanoclaw__send_message') {
+          sendMessageToolUseCount++;
+        }
+      } else if (event.type === 'init') {
         queryContinuation = event.continuation;
         // Persist immediately so a mid-turn container crash still lets the
         // next wake resume the conversation. Without this, the session id
@@ -389,8 +399,11 @@ async function processQuery(
           stop_reason: usage?.stop_reason ?? null,
         });
         if (event.text) {
-          dispatchResultText(event.text, routing);
+          dispatchResultText(event.text, routing, { sendMessageToolUseCount });
         }
+        // Reset for the next turn (streaming-input mode pushes follow-up
+        // user messages into the same query, each producing its own result).
+        sendMessageToolUseCount = 0;
       }
     }
   } finally {
@@ -432,8 +445,18 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * cleaned text (with <internal> tags stripped) is sent to that destination.
  * This preserves the simple case of one user on one channel — the agent
  * doesn't need to know about wrapping syntax at all.
+ *
+ * `send_message` auto-suppress: when the agent issued any
+ * `mcp__nanoclaw__send_message` tool_use this turn (tracked in the poll
+ * loop via the `tool_use` ProviderEvent), the final turn text is treated
+ * as redundant and dropped — send_message already delivered the reply
+ * to chat. This relieves the agent of the burden of remembering to wrap
+ * its closing line in `<internal>...</internal>` for de-duplication.
+ * Multi-destination output (`<message to="...">` blocks) still dispatches
+ * normally regardless, since those address agents/channels other than
+ * the one send_message hit.
  */
-function dispatchResultText(text: string, routing: RoutingContext): void {
+function dispatchResultText(text: string, routing: RoutingContext, opts: { sendMessageToolUseCount: number }): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
 
   let match: RegExpExecArray | null;
@@ -462,7 +485,35 @@ function dispatchResultText(text: string, routing: RoutingContext): void {
     scratchpadParts.push(text.slice(lastIndex));
   }
 
-  const scratchpad = stripInternalTags(scratchpadParts.join(''));
+  const rawScratchpad = scratchpadParts.join('');
+  const stripped = stripInternalTags(rawScratchpad);
+  // Salvage path: if the agent's only output was `<internal>...</internal>`
+  // (so stripping leaves nothing) AND no send_message tool_use covered
+  // the reply, treat the inner content as the actual message. Surfaces
+  // the agent's template / scratchpad text rather than dropping it
+  // silently — silence reads as "agent broken"; even a weird-looking
+  // ack ("Acknowledged via send_message.") signals the user can ask
+  // for the substantive answer.
+  let scratchpad = stripped;
+  if (!stripped && opts.sendMessageToolUseCount === 0) {
+    const unwrapped = rawScratchpad.replace(/<\/?internal>/g, '').trim();
+    if (unwrapped) scratchpad = unwrapped;
+  }
+
+  // send_message ran this turn → final text is a duplicate / wrap-up;
+  // drop it. This is the canonical path for ack-then-work flows: agent
+  // calls send_message early, does its tool work, lets its closing
+  // statement fall through here, formatter suppresses it. No
+  // `<internal>` wrap required from the agent.
+  if (sent === 0 && opts.sendMessageToolUseCount > 0) {
+    if (scratchpad) {
+      log(
+        `[scratchpad] auto-suppressed (send_message ran ${opts.sendMessageToolUseCount}x this turn): ` +
+          `${scratchpad.slice(0, 200)}${scratchpad.length > 200 ? '…' : ''}`,
+      );
+    }
+    return;
+  }
 
   // Single-destination shortcut: the agent wrote plain text — send to
   // the session's originating channel. Prefer session_routing (written

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -5,7 +5,14 @@ import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
 import { registerProvider } from './provider-registry.js';
-import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import type {
+  AgentProvider,
+  AgentQuery,
+  McpServerConfig,
+  ProviderEvent,
+  ProviderOptions,
+  QueryInput,
+} from './types.js';
 
 function log(msg: string): void {
   console.error(`[claude-provider] ${msg}`);
@@ -115,10 +122,15 @@ function parseTranscript(content: string): ParsedMessage[] {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string' ? entry.message.content : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
         if (text) messages.push({ role: 'user', content: text });
       } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content.filter((c: { type: string }) => c.type === 'text').map((c: { text: string }) => c.text);
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
         const text = textParts.join('');
         if (text) messages.push({ role: 'assistant', content: text });
       }
@@ -131,7 +143,13 @@ function parseTranscript(content: string): ParsedMessage[] {
 
 function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
   const now = new Date();
-  const dateStr = now.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
+  const dateStr = now.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
   const lines = [`# ${title || 'Conversation'}`, '', `Archived: ${dateStr}`, '', '---', ''];
   for (const msg of messages) {
     const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
@@ -199,20 +217,29 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       if (fs.existsSync(indexPath)) {
         try {
           const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-          summary = index.entries?.find((e: { sessionId: string; summary?: string }) => e.sessionId === sessionId)?.summary;
+          summary = index.entries?.find(
+            (e: { sessionId: string; summary?: string }) => e.sessionId === sessionId,
+          )?.summary;
         } catch {
           /* ignore */
         }
       }
 
       const name = summary
-        ? summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 50)
+        ? summary
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 50)
         : `conversation-${new Date().getHours().toString().padStart(2, '0')}${new Date().getMinutes().toString().padStart(2, '0')}`;
 
       const conversationsDir = '/workspace/agent/conversations';
       fs.mkdirSync(conversationsDir, { recursive: true });
       const filename = `${new Date().toISOString().split('T')[0]}-${name}.md`;
-      fs.writeFileSync(path.join(conversationsDir, filename), formatTranscriptMarkdown(messages, summary, assistantName));
+      fs.writeFileSync(
+        path.join(conversationsDir, filename),
+        formatTranscriptMarkdown(messages, summary, assistantName),
+      );
       log(`Archived conversation to ${filename}`);
     } catch (err) {
       log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
@@ -277,7 +304,9 @@ export class ClaudeProvider implements AgentProvider {
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,
         pathToClaudeCodeExecutable: '/pnpm/claude',
-        systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
+        systemPrompt: instructions
+          ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions }
+          : undefined,
         allowedTools: TOOL_ALLOWLIST,
         disallowedTools: SDK_DISALLOWED_TOOLS,
         env: this.env,
@@ -315,11 +344,26 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'assistant') {
           // Claude Code SDK wraps the raw Anthropic API message in
           // message.message; usage + stop_reason live there.
-          const inner = (message as { message?: { stop_reason?: string; model?: string } }).message;
+          const inner = (
+            message as {
+              message?: { stop_reason?: string; model?: string; content?: Array<{ type?: string; name?: string }> };
+            }
+          ).message;
           if (inner?.stop_reason) lastStopReason = inner.stop_reason;
           if (inner?.model) lastModel = inner.model;
+          // Surface tool_use blocks to the poll loop so it can track
+          // whether `mcp__nanoclaw__send_message` ran this turn (used by
+          // dispatchResultText to suppress the final turn text when a
+          // real send_message already delivered the reply).
+          if (Array.isArray(inner?.content)) {
+            for (const block of inner.content) {
+              if (block?.type === 'tool_use' && typeof block.name === 'string') {
+                yield { type: 'tool_use', tool_name: block.name };
+              }
+            }
+          }
         } else if (message.type === 'result') {
-          const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
+          const text = 'result' in message ? ((message as { result?: string }).result ?? null) : null;
           // Aggregate token usage from the SDK's result summary (the SDK
           // sums per-turn usage across an entire query).
           const rawUsage = (
@@ -335,7 +379,8 @@ export class ClaudeProvider implements AgentProvider {
           const usage = rawUsage
             ? {
                 model: lastModel,
-                input_tokens: (rawUsage.input_tokens ?? 0) +
+                input_tokens:
+                  (rawUsage.input_tokens ?? 0) +
                   (rawUsage.cache_read_input_tokens ?? 0) +
                   (rawUsage.cache_creation_input_tokens ?? 0),
                 output_tokens: rawUsage.output_tokens ?? 0,

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -4,14 +4,24 @@ import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryIn
 /**
  * Mock provider for testing. Returns canned responses.
  * Supports push() — queued messages produce additional results.
+ *
+ * `toolUsesPerTurn` lets a test simulate the agent issuing tool_use
+ * events before the result is yielded — used to cover dispatchResultText's
+ * `send_message` auto-suppress branch.
  */
 export class MockProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
   private responseFactory: (prompt: string) => string;
+  private toolUsesPerTurn: string[];
 
-  constructor(_options: ProviderOptions = {}, responseFactory?: (prompt: string) => string) {
+  constructor(
+    _options: ProviderOptions = {},
+    responseFactory?: (prompt: string) => string,
+    toolUsesPerTurn?: string[],
+  ) {
     this.responseFactory = responseFactory ?? ((prompt) => `Mock response to: ${prompt.slice(0, 100)}`);
+    this.toolUsesPerTurn = toolUsesPerTurn ?? [];
   }
 
   isSessionInvalid(_err: unknown): boolean {
@@ -24,6 +34,7 @@ export class MockProvider implements AgentProvider {
     let ended = false;
     let aborted = false;
     const responseFactory = this.responseFactory;
+    const toolUsesPerTurn = this.toolUsesPerTurn;
 
     const events: AsyncIterable<ProviderEvent> = {
       async *[Symbol.asyncIterator]() {
@@ -32,12 +43,18 @@ export class MockProvider implements AgentProvider {
 
         // Process initial prompt
         yield { type: 'activity' };
+        for (const toolName of toolUsesPerTurn) {
+          yield { type: 'tool_use', tool_name: toolName };
+        }
         yield { type: 'result', text: responseFactory(input.prompt) };
 
         // Process any pushed follow-ups
         while (!ended && !aborted) {
           if (pending.length > 0) {
             const msg = pending.shift()!;
+            for (const toolName of toolUsesPerTurn) {
+              yield { type: 'tool_use', tool_name: toolName };
+            }
             yield { type: 'result', text: responseFactory(msg) };
             continue;
           }
@@ -51,6 +68,9 @@ export class MockProvider implements AgentProvider {
         // Drain remaining
         while (pending.length > 0) {
           const msg = pending.shift()!;
+          for (const toolName of toolUsesPerTurn) {
+            yield { type: 'tool_use', tool_name: toolName };
+          }
           yield { type: 'result', text: responseFactory(msg) };
         }
       },

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -93,4 +93,12 @@ export type ProviderEvent =
    * event (tool call, thinking, partial message, anything) so the
    * poll-loop's idle timer stays honest during long tool runs.
    */
-  | { type: 'activity' };
+  | { type: 'activity' }
+  /**
+   * Emitted whenever the agent issues a tool_use, exposing the tool name
+   * to the poll loop. Used by `dispatchResultText` to know whether
+   * `send_message` already delivered a reply this turn — when it did,
+   * the final turn text gets suppressed automatically (the host stops
+   * leaning on the agent to remember to wrap in `<internal>...</internal>`).
+   */
+  | { type: 'tool_use'; tool_name: string };

--- a/src/modules/fleet/fork-worker.ts
+++ b/src/modules/fleet/fork-worker.ts
@@ -35,6 +35,7 @@ import Database from 'better-sqlite3';
 
 import { DATA_DIR, GROUPS_DIR } from '../../config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { createSession, getSessionsByAgentGroup } from '../../db/sessions.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { sessionDir } from '../../session-manager.js';
@@ -326,13 +327,26 @@ export async function handleForkWorker(content: Record<string, unknown>, session
     copyOverlayDeep(srcClaudeShared, dstClaudeShared);
   }
 
+  // Each fork session's thread_id needs to match what the router will
+  // synthesize when an inbound from fork's NEW Discord channel arrives —
+  // otherwise findSession misses the cloned session and auto-creates a
+  // second one (with empty DBs), orphaning the cloned history. The
+  // convention is thread_id = mg.platform_id for non-threaded channel
+  // messages, so derive it from the freshly-provisioned messaging group.
+  const forkMg = provision.messagingGroupId ? getMessagingGroup(provision.messagingGroupId) : undefined;
+  const forkThreadId = forkMg?.platform_id ?? null;
+
   for (const srcSess of sourceSessions) {
     const forkSessionId = generateId('sess');
     const newSession: Session = {
       id: forkSessionId,
       agent_group_id: forkId,
       messaging_group_id: provision.messagingGroupId,
-      thread_id: srcSess.thread_id,
+      // Inherit source's thread_id was wrong — that's the source's
+      // channel, not the fork's. Use the fork mg's platform_id instead so
+      // the router routes inbound traffic into the cloned session
+      // instead of auto-creating a second one with empty DBs.
+      thread_id: forkThreadId,
       agent_provider: srcSess.agent_provider,
       status: 'active',
       container_status: 'idle',


### PR DESCRIPTION
## Summary

Two related fixes that together kill the post-compaction <internal>-wrapper hallucination loop and unstick the fork's cloned conversation history.

### 1. Auto-suppress + salvage (the main fix)

The wrap-in-<internal> instruction has been the source of two production silences this session:
- worker `k2.6-dbg` — silent for hours after SDK auto-compaction (PR #89 partial fix)
- worker `model-dev-fork` — silent on first reply after PR #93 fork (inherited <internal>-history poisoning)

PR #89 made the wrap rule conditional. That wasn't enough — pattern-matching post-compaction overrides the new wording when conversation history shows the wrap many times in a row.

This PR pulls the de-duplication responsibility off the agent entirely:

- **Auto-suppress**: poll-loop tracks `mcp__nanoclaw__send_message` tool_use events per turn (via a new `tool_use` ProviderEvent emitted from claude.ts). When the count > 0 and the result text has no `<message to>` blocks, dispatchResultText drops the final text — send_message already delivered the reply.
- **Salvage**: when send_message did NOT run AND the agent's only output was `<internal>...</internal>` (so stripping leaves empty), unwrap the inner text instead of dropping. Surfaces the agent's template/scratchpad rather than silence — the user sees the broken state and can ask again.
- **Instruction change**: `core.instructions.md` drops the wrap-in-<internal> requirement entirely. NanoClaw handles dedup; agent writes naturally.

### 2. Fork session thread_id fix

PR #93's fork code copied source's thread_id into the cloned session. For Discord channels that's source's encoded channel reference, which doesn't match what the router synthesizes when an inbound from FORK's new channel arrives. Result: findSession missed the cloned session, auto-created a second one with empty DBs, orphaned the cloned 24-message history. New traffic was landing in the empty session.

Fix: derive thread_id from the fork's own messaging group platform_id (matches the router convention for non-threaded channel sessions). findSession now matches the cloned session on first inbound.

## Test plan

- [x] Container typecheck + 55/55 bun tests (added 2: auto-suppress + salvage paths via MockProvider tool_use simulation)
- [x] Host typecheck + 228/228 vitest (no regressions; existing fleet.test.ts fork tests still pass)
- [x] Pre-push hook green
- [x] Live e2e on the existing model-dev-fork worker after this fix + host restart:
  - Fork received "FORK-RETRY-XYZ what was the marker on the recent FORK-VERIFY message?"
  - Fork called send_message with: "The marker was **FORK-VERIFY-XYZ**." 
  - Fork's final turn text was the old `<internal>...</internal>` template → auto-suppressed (not posted as duplicate)
  - User saw exactly one clean reply on Discord
  - Trace via `ncf trace model-dev-fork --limit 1` confirms: send_message tool_use fired, final wrap auto-dropped

Compare to pre-fix behavior on same fork: 0 outbound, "agent output had no <message to> blocks — nothing was sent" warning every turn.