### PR TITLE
feat(fleet): create_worker fresh=true purges archived prior for clean slate

### DIFF
--- a/container/agent-runner/src/mcp-tools/fleet.ts
+++ b/container/agent-runner/src/mcp-tools/fleet.ts
@@ -43,7 +43,7 @@ export const createWorker: McpToolDefinition = {
   tool: {
     name: 'create_worker',
     description:
-      "Create a new fleet worker. Each worker gets its own Discord channel and container. Use when the user asks for a new worker. Fire-and-forget — you'll get a system message when it's ready.",
+      "Create a new fleet worker. Each worker gets its own Discord channel and container. Fire-and-forget — you'll get a system message when it's ready.\n\nResume vs fresh: if a worker with the requested name was previously destroyed (status='archived'), the default behavior is to RESUME from archive — workspace files, CLAUDE.local.md, and prior conversation history come back. Backend/model can change on resume.\n\nWhen the user asks for a fresh / clean / new-from-scratch worker on a name that has archived history, you MUST first confirm with them that the prior workspace + conversation history will be PERMANENTLY DELETED, then call this tool with `fresh: true`. Setting fresh=true silently destroys the prior state — there is no undo. Skip the confirmation only when the user explicitly asked for fresh AND acknowledged the data loss in the same message.",
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -57,6 +57,11 @@ export const createWorker: McpToolDefinition = {
         instructions: {
           type: 'string',
           description: 'Seed CLAUDE.local.md for the new worker — personality, role, tooling hints.',
+        },
+        fresh: {
+          type: 'boolean',
+          description:
+            'Force a clean slate even if an archived worker with this name exists. PERMANENTLY DELETES the prior workspace + session history. Confirm with the user FIRST. Default false (resume from archive when one exists).',
         },
       },
       required: ['name'],
@@ -76,10 +81,13 @@ export const createWorker: McpToolDefinition = {
         backend: args.backend ?? null,
         model: args.model ?? null,
         instructions: args.instructions ?? null,
+        fresh: args.fresh === true,
       }),
     });
-    log(`create_worker: ${id} → "${name}"`);
-    return ok(`Creating worker "${name}". You will be notified when it is ready.`);
+    log(`create_worker: ${id} → "${name}"${args.fresh ? ' (fresh)' : ''}`);
+    return ok(
+      `Creating worker "${name}"${args.fresh ? ' (fresh — purging any archived prior)' : ''}. You will be notified when it is ready.`,
+    );
   },
 };
 

--- a/scripts/ncf.ts
+++ b/scripts/ncf.ts
@@ -14,7 +14,7 @@
  *   ncf                          — usage
  *   ncf status [--json]
  *   ncf list [--json]
- *   ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>]
+ *   ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>] [--fresh]
  *   ncf destroy <name> [--keep-channel]
  *   ncf switch <name> <backend> [model]
  *   ncf logs <name> [--follow]   — docker logs for the worker's container
@@ -32,7 +32,7 @@ const SCRIPT_USAGE = `ncf — NanoClaw Fleet CLI
 Usage:
   ncf status [--json]
   ncf list [--json]
-  ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>]
+  ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>] [--fresh]
   ncf destroy <name> [--keep-channel]
   ncf switch <name> <backend> [model]
   ncf fork <source> <fork_name>
@@ -248,22 +248,25 @@ function cmdList(args: string[]): void {
 function cmdCreate(args: string[]): void {
   const name = args[0];
   if (!name || name.startsWith('--')) {
-    console.error('usage: ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>]');
+    console.error('usage: ncf create <name> [--backend <b>] [--model <m>] [--instructions <text>] [--fresh]');
     process.exit(1);
   }
   let backend: string | undefined;
   let model: string | undefined;
   let instructions: string | undefined;
+  let fresh = false;
   for (let i = 1; i < args.length; i++) {
     if (args[i] === '--backend') backend = args[++i];
     else if (args[i] === '--model') model = args[++i];
     else if (args[i] === '--instructions') instructions = args[++i];
+    else if (args[i] === '--fresh') fresh = true;
   }
   writeSystemAction('create_worker', {
     name,
     backend: backend ?? null,
     model: model ?? null,
     instructions: instructions ?? null,
+    fresh,
   });
 }
 

--- a/src/modules/fleet/create-worker.ts
+++ b/src/modules/fleet/create-worker.ts
@@ -12,11 +12,24 @@
  * (NANOCLAW_FLEET_ROLE=master). This handler re-checks fleet_role on the
  * calling session's agent_group as defense-in-depth.
  */
+import fs from 'fs';
 import path from 'path';
 
-import { GROUPS_DIR } from '../../config.js';
-import { createAgentGroup, getAgentGroup, getAgentGroupByFolder, updateAgentGroup } from '../../db/agent-groups.js';
-import { getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
+import { DATA_DIR, GROUPS_DIR } from '../../config.js';
+import {
+  createAgentGroup,
+  deleteAgentGroup,
+  getAgentGroup,
+  getAgentGroupByFolder,
+  updateAgentGroup,
+} from '../../db/agent-groups.js';
+import {
+  deleteMessagingGroup,
+  deleteMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupsByAgentGroup,
+} from '../../db/messaging-groups.js';
+import { deleteSession, getSessionsByAgentGroup } from '../../db/sessions.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { log } from '../../log.js';
 import type { AgentGroup, Session } from '../../types.js';
@@ -31,6 +44,10 @@ import { logWorkerEvent } from './events.js';
 import { generateId, normalizeName, notifyAgent, setFleetBackend } from './lib.js';
 import { provisionDiscordChannel } from './provision.js';
 import { applyProfileToContainerConfig, loadWorkerProfile } from './worker-profile.js';
+import { createDestination as _ensureCreateDestImported } from '../agent-to-agent/db/agent-destinations.js';
+import { getDb } from '../../db/connection.js';
+
+void _ensureCreateDestImported;
 
 const DEFAULT_BACKEND = 'claude';
 
@@ -38,6 +55,75 @@ function isSafeFolderName(folder: string): boolean {
   const resolvedPath = path.resolve(path.join(GROUPS_DIR, folder));
   const resolvedGroupsDir = path.resolve(GROUPS_DIR);
   return resolvedPath.startsWith(resolvedGroupsDir + path.sep);
+}
+
+/**
+ * Hard-delete an archived worker so a subsequent create_worker with the
+ * same name starts truly fresh. Removes:
+ *
+ *   - groups/<folder>/                    (workspace, CLAUDE.local.md, container.json, profile)
+ *   - data/v2-sessions/<agent_group_id>/  (inbound.db, outbound.db, .claude-shared, turns.jsonl, inbox/)
+ *   - sessions rows
+ *   - any leftover messaging_group_agents + exclusive messaging_groups
+ *   - agent_destinations referencing this group (both directions)
+ *   - the agent_groups row itself
+ *
+ * SAFETY: only operates on `archived` groups. Active workers must be
+ * destroyed first. Folder path traversal is rejected.
+ */
+function purgeArchivedWorker(existing: AgentGroup): void {
+  if (existing.status !== 'archived') {
+    throw new Error(`purgeArchivedWorker refused — group ${existing.id} is not archived (status=${existing.status})`);
+  }
+  if (!isSafeFolderName(existing.folder)) {
+    throw new Error(`purgeArchivedWorker refused — unsafe folder ${existing.folder}`);
+  }
+
+  // Sessions + their disk dirs.
+  for (const sess of getSessionsByAgentGroup(existing.id)) {
+    deleteSession(sess.id);
+  }
+  const agentDataDir = path.join(DATA_DIR, 'v2-sessions', existing.id);
+  if (fs.existsSync(agentDataDir)) {
+    fs.rmSync(agentDataDir, { recursive: true, force: true });
+  }
+
+  // messaging_group_agents + any messaging_group with no remaining agents.
+  // destroy_worker normally cleans these up; this is defense-in-depth for
+  // workers that were destroyed pre-cleanup-fix or imported from elsewhere.
+  for (const mg of getMessagingGroupsByAgentGroup(existing.id)) {
+    const mga = getMessagingGroupAgentByPair(mg.id, existing.id);
+    if (mga) deleteMessagingGroupAgent(mga.id);
+    const remainingAgents = getDb()
+      .prepare('SELECT COUNT(*) as n FROM messaging_group_agents WHERE messaging_group_id = ?')
+      .get(mg.id) as { n: number };
+    if (remainingAgents.n === 0) {
+      deleteMessagingGroup(mg.id);
+    }
+  }
+
+  // Drop both directions of agent_destinations referencing this worker.
+  // Using direct SQL because the public delete API needs (agent_group_id,
+  // local_name) pairs and we want to clear by target_id too.
+  getDb()
+    .prepare('DELETE FROM agent_destinations WHERE agent_group_id = ? OR target_id = ?')
+    .run(existing.id, existing.id);
+
+  // Workspace dir.
+  const workspaceDir = path.resolve(GROUPS_DIR, existing.folder);
+  if (fs.existsSync(workspaceDir)) {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+
+  // Finally drop the agent_groups row.
+  deleteAgentGroup(existing.id);
+
+  log.warn('Worker purged', {
+    agentGroupId: existing.id,
+    folder: existing.folder,
+    deletedWorkspace: workspaceDir,
+    deletedSessionData: agentDataDir,
+  });
 }
 
 /**
@@ -79,6 +165,7 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
   const backend = (content.backend as string | undefined) ?? DEFAULT_BACKEND;
   const model = content.model as string | undefined;
   const instructions = content.instructions as string | null | undefined;
+  const fresh = content.fresh === true;
 
   const sourceGroup = getAgentGroup(session.agent_group_id);
   if (!sourceGroup) {
@@ -104,8 +191,30 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
 
   const existing = getAgentGroupByFolder(localName);
   if (existing && existing.status === 'archived') {
-    await resumeWorker(existing, sourceGroup, session, { backend, model });
-    return;
+    if (fresh) {
+      // Caller asked for a clean slate on a name that already has archived
+      // history. Master is expected to confirm with the human user before
+      // setting fresh=true (the tool description spells this out) — the
+      // workspace + conversation history disappear here.
+      try {
+        purgeArchivedWorker(existing);
+      } catch (err) {
+        notifyAgent(session, `create_worker fresh failed: ${err instanceof Error ? err.message : String(err)}`);
+        log.error('purgeArchivedWorker failed', { err: String(err), folder: localName });
+        return;
+      }
+      logWorkerEvent({
+        timestamp: new Date().toISOString(),
+        event: 'destroyed',
+        worker: localName,
+        folder: localName,
+        details: { agentGroupId: existing.id, reason: 'purged for fresh create' },
+      });
+      // Fall through to fresh create below.
+    } else {
+      await resumeWorker(existing, sourceGroup, session, { backend, model });
+      return;
+    }
   }
   if (existing && existing.status !== 'archived') {
     notifyAgent(

--- a/src/modules/fleet/fleet.test.ts
+++ b/src/modules/fleet/fleet.test.ts
@@ -178,6 +178,83 @@ describe('resume from archive', () => {
   });
 });
 
+describe('create_worker fresh flag', () => {
+  it('with fresh=true, purges archived prior + creates a new agent_group', async () => {
+    await handleCreateWorker({ name: 'kappa', backend: 'claude' }, makeMasterSession());
+    const original = getAgentGroupByFolder('kappa');
+    await handleDestroyWorker({ name: 'kappa' }, makeMasterSession());
+    expect(getAgentGroupByFolder('kappa')?.status).toBe('archived');
+
+    await handleCreateWorker(
+      { name: 'kappa', backend: 'neuralwatt', model: 'glm-5.1', fresh: true },
+      makeMasterSession(),
+    );
+    const fresh = getAgentGroupByFolder('kappa');
+    expect(fresh).toBeDefined();
+    // New row, not the archived one being unarchived.
+    expect(fresh?.id).not.toBe(original?.id);
+    expect(fresh?.status ?? 'active').toBe('active');
+    expect(fresh?.fleet_backend).toBe('neuralwatt');
+    expect(fresh?.fleet_model).toBe('glm-5.1');
+  });
+
+  it('with fresh=true, deletes the archived workspace dir on disk', async () => {
+    await handleCreateWorker({ name: 'mu' }, makeMasterSession());
+    await handleDestroyWorker({ name: 'mu' }, makeMasterSession());
+
+    const workspaceDir = TEST_DIR + '/groups/mu';
+    expect(fs.existsSync(workspaceDir)).toBe(true);
+
+    await handleCreateWorker({ name: 'mu', fresh: true }, makeMasterSession());
+
+    // The fresh path purged the old workspace, then init recreated a
+    // bare scaffold for the new agent_group. Verify by checking the
+    // fresh agent_group's id maps to a new directory + the prior
+    // sessions data was removed.
+    const fresh = getAgentGroupByFolder('mu');
+    expect(fresh).toBeDefined();
+    // Either the bare init recreated the dir (now empty) or it doesn't
+    // exist yet — both are valid post-purge. The pre-purge contents are
+    // gone in either case; assert no stale CLAUDE.local.md from before.
+    if (fs.existsSync(workspaceDir + '/CLAUDE.local.md')) {
+      const body = fs.readFileSync(workspaceDir + '/CLAUDE.local.md', 'utf-8');
+      // The init scaffold writes a tiny stub, not the original content.
+      expect(body.length).toBeLessThan(500);
+    }
+  });
+
+  it('without fresh on archived name, falls back to resume (existing behavior preserved)', async () => {
+    await handleCreateWorker({ name: 'nu' }, makeMasterSession());
+    const original = getAgentGroupByFolder('nu');
+    await handleDestroyWorker({ name: 'nu' }, makeMasterSession());
+
+    await handleCreateWorker({ name: 'nu' }, makeMasterSession()); // no fresh flag
+    const resumed = getAgentGroupByFolder('nu');
+    expect(resumed?.id).toBe(original?.id); // resumed, not purged
+    expect(resumed?.status).toBe('active');
+  });
+
+  it('with fresh=true on a NON-archived (no prior) name, just creates fresh', async () => {
+    await handleCreateWorker({ name: 'xi', backend: 'claude', fresh: true }, makeMasterSession());
+    const xi = getAgentGroupByFolder('xi');
+    expect(xi).toBeDefined();
+    expect(xi?.fleet_role).toBe('worker');
+  });
+
+  it('refuses fresh purge on an ACTIVE worker (must destroy first)', async () => {
+    await handleCreateWorker({ name: 'omicron' }, makeMasterSession());
+    const original = getAgentGroupByFolder('omicron');
+    expect(original?.status ?? 'active').toBe('active');
+
+    await handleCreateWorker({ name: 'omicron', fresh: true }, makeMasterSession());
+
+    // Active worker still there, untouched, no second row created.
+    const after = getAgentGroupByFolder('omicron');
+    expect(after?.id).toBe(original?.id);
+    expect(after?.status ?? 'active').toBe('active');
+  });
+});
+
 describe('switch_backend', () => {
   it('updates agent_provider + fleet fields + container.json', async () => {
     await handleCreateWorker({ name: 'epsilon', backend: 'claude' }, makeMasterSession());


### PR DESCRIPTION
## Summary

Adds a `fresh: boolean` flag to `create_worker` (MCP tool + ncf CLI). When true and an archived worker with the same name exists, the handler hard-deletes the prior agent_group row, workspace dir, session data, exclusive messaging_groups, and agent_destinations — then proceeds with a clean fresh-create.

## Why

Default `create_worker` on a name with archived history is RESUME (the existing behavior, preserved). That's right for continuity, wrong when the user wants "create foo from fresh based on glm-5.1". Today the only path to fresh is destroy + manual `rm -rf` + create, which nobody discovers from chat.

Concrete trigger today: master correctly flagged that `foo` had archived neuralwatt/kimi-k2.6-fast prior, offered (a) accept resume vs (b) different name. The user wanted (c) fresh same name; that wasn't an option.

## Safety

- Only operates on **archived** groups. Active workers refuse the purge (master must destroy first).
- `isSafeFolderName` path-traversal guard (existing) covers the workspace rm.
- The MCP tool description **explicitly tells master to confirm with the user before setting fresh=true** — the deletion is permanent. Defaults to false so legacy callers + the chat-driven default flow keep getting resume.

## Confirmation flow (v1: agent-driven)

The first version relies on the master agent to ask the human user for confirmation before calling with fresh=true. The tool description spells out exactly when to ask and what to say. v2 could add a host-side approval primitive (matches `pendingApproval` for self-mod / OneCLI credentialed actions) for belt+suspenders enforcement. Out of scope here.

## Tests

5 new fleet.test.ts cases (228 → 233):
- fresh purges archived → new agent_group (different id)
- fresh deletes workspace dir on disk
- no fresh on archived → resumes (existing behavior preserved)
- fresh on never-existed name → just creates
- fresh refuses on ACTIVE worker

## Test plan

- [x] Host typecheck + 233/233 vitest
- [x] Pre-push hook green
- [x] Live e2e: `ncf create foo --backend neuralwatt --model glm-5.1-fast --fresh` against the actual production archived `foo` (4 days old, neuralwatt/kimi-k2.6-fast, 3 prior session dirs)
  - Old `agent_groups` row dropped (id ag-1777046040907 → gone)
  - All 3 session dirs at `data/v2-sessions/ag-1777046040907-lo97wx/` deleted
  - New `agent_groups` row created (different id ag-1777418343157), backend=neuralwatt, model=glm-5.1-fast
  - `groups/foo/` reset to bare init scaffold (just CLAUDE.local.md + container.json)