### PR TITLE
fix(container): prefer .env OAuth token over rotating credentials.json

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -571,13 +571,20 @@ async function buildContainerArgs(
       'CLAUDE_CODE_OAUTH_TOKEN',
       'ANTHROPIC_BASE_URL',
     ]);
-    // Prefer a live OAuth token from ~/.claude/.credentials.json over the
-    // static one in .env. Claude Code keeps the credentials file refreshed
-    // via its refreshToken flow, so reading live on every spawn gives us
-    // always-fresh auth without a manual .env swap every hour. Falls back
-    // to .env's CLAUDE_CODE_OAUTH_TOKEN if the credentials file is absent.
+    // Prefer the long-lived OAuth token from `.env` (`claude setup-token`,
+    // valid for months) over the short-lived one in
+    // ~/.claude/.credentials.json (Claude Code's interactive session token,
+    // rotates every ~hour). The container env is frozen at spawn time and
+    // not refreshed for the life of the container; if we baked in the
+    // rotating token, every worker would 401 within hours of the next
+    // rotation. Workers in v1 didn't hit this because v1 ran a credential
+    // proxy on the host that injected `.env` per request; in v2 OneCLI is
+    // meant to fill that role, but when OneCLI isn't applied this fallback
+    // freezes the token, so we must pick the long-lived source. Falls back
+    // to the live credentials file if `.env.CLAUDE_CODE_OAUTH_TOKEN` is
+    // unset (best-effort short-lived auth beats no auth).
     const liveOauth = readLiveClaudeOauthToken();
-    const oauth = liveOauth ?? fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    const oauth = fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN ?? liveOauth;
     const preferOauth = !!oauth;
     for (const key of [
       'ANTHROPIC_API_KEY',
@@ -596,7 +603,7 @@ async function buildContainerArgs(
     log.info('Env credential fallback applied', {
       containerName,
       preferOauth,
-      oauthSource: liveOauth ? 'credentials.json' : fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN ? '.env' : 'none',
+      oauthSource: fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN ? '.env' : liveOauth ? 'credentials.json' : 'none',
     });
   }
 


### PR DESCRIPTION
## Summary

Swap OAuth token precedence in the env-fallback path so `.env.CLAUDE_CODE_OAUTH_TOKEN` (long-lived `claude setup-token`, valid for months) wins over `~/.claude/.credentials.json` (Claude Code's interactive session token, rotates ~hourly).

## Why

Worker containers were 401'ing hours after spawn with `Invalid authentication credentials`. Trace showed the worker's `CLAUDE_CODE_OAUTH_TOKEN` env var was a token Claude Code had since rotated out of `credentials.json`. The container env is **frozen at spawn time** — no per-request refresh — so freezing in the auto-rotating token guaranteed a 401 on the next rotation.

v1 didn't hit this because v1 ran a host-side credential proxy (`src/credential-proxy.ts`) that injected `.env` per request; the container only ever saw a `placeholder`. v2's intended equivalent is OneCLI per-request injection. When OneCLI isn't applied (no gateway, empty vault, etc.) v2 falls back to baking the token straight into the container env — and in that fallback path, the precedence was backwards.

This restores v1 behavior for installs without OneCLI.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm run build\` clean
- [x] \`pnpm test\` — 227/227 host vitest pass
- [x] Behavior verified locally — workers spawned with the long-lived \`.env\` token instead of the rotating one, no 401s
- [ ] CI green