### PR TITLE
fix(compaction): pre-compact Discord notice + don't treat compact_boundary as turn end

### DIFF
--- a/container/agent-runner/src/providers/claude.test.ts
+++ b/container/agent-runner/src/providers/claude.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { closeSessionDb, getInboundDb, initTestSessionDb } from '../db/connection.js';
+import { getUndeliveredMessages } from '../db/messages-out.js';
+import { sendCompactionNotice } from './claude.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+function setSessionRouting(channel_type: string | null, platform_id: string | null, thread_id: string | null) {
+  const db = getInboundDb();
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS session_routing (
+       id INTEGER PRIMARY KEY CHECK (id = 1),
+       channel_type TEXT,
+       platform_id TEXT,
+       thread_id TEXT
+     )`,
+  ).run();
+  db.prepare(
+    `INSERT OR REPLACE INTO session_routing (id, channel_type, platform_id, thread_id) VALUES (1, ?, ?, ?)`,
+  ).run(channel_type, platform_id, thread_id);
+}
+
+describe('sendCompactionNotice', () => {
+  it('writes a chat message to outbound when session routing is set', () => {
+    setSessionRouting('discord', 'channel-123', null);
+    sendCompactionNotice('auto');
+
+    const out = getUndeliveredMessages();
+    expect(out.length).toBe(1);
+    expect(out[0].kind).toBe('chat');
+    expect(out[0].channel_type).toBe('discord');
+    expect(out[0].platform_id).toBe('channel-123');
+    const content = JSON.parse(out[0].content);
+    expect(content.text).toContain('Compacting context');
+    expect(content.text).toContain('auto');
+  });
+
+  it('preserves thread_id from session routing', () => {
+    setSessionRouting('discord', 'channel-123', 'thread-456');
+    sendCompactionNotice('manual');
+
+    const out = getUndeliveredMessages();
+    expect(out.length).toBe(1);
+    expect(out[0].thread_id).toBe('thread-456');
+    const content = JSON.parse(out[0].content);
+    expect(content.text).toContain('manual');
+  });
+
+  it('silently skips when session routing is missing', () => {
+    sendCompactionNotice('auto');
+    expect(getUndeliveredMessages().length).toBe(0);
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -1,9 +1,12 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { writeMessageOut } from '../db/messages-out.js';
+import { getSessionRouting } from '../db/session-routing.js';
 import { registerProvider } from './provider-registry.js';
 import type {
   AgentProvider,
@@ -196,10 +199,44 @@ const postToolUseHook: HookCallback = async () => {
   return { continue: true };
 };
 
+/**
+ * Post a Discord notice to the user's channel before compaction begins.
+ * Compaction can take several seconds; without this the user sees the
+ * agent go silent mid-turn with no signal that anything's happening.
+ *
+ * Mirrors v1's `sendCompactionNotice` (container/agent-runner/src/index.ts
+ * in the v1-old tree) — same wording, but writes to the v2 outbound DB
+ * instead of the v1 IPC file drop.
+ */
+export function sendCompactionNotice(trigger: string): void {
+  try {
+    const routing = getSessionRouting();
+    if (!routing.channel_type || !routing.platform_id) {
+      log('Skipping compaction notice — no session routing');
+      return;
+    }
+    writeMessageOut({
+      id: randomUUID(),
+      kind: 'chat',
+      platform_id: routing.platform_id,
+      channel_type: routing.channel_type,
+      thread_id: routing.thread_id,
+      content: JSON.stringify({
+        text: `⏳ Compacting context (${trigger})… I'll be back in a moment.`,
+      }),
+    });
+    log(`Sent compaction notice (trigger=${trigger})`);
+  } catch (err) {
+    log(`Failed to send compaction notice: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 function createPreCompactHook(assistantName?: string): HookCallback {
   return async (input) => {
     const preCompact = input as PreCompactHookInput;
     const { transcript_path: transcriptPath, session_id: sessionId } = preCompact;
+
+    sendCompactionNotice(preCompact.trigger || 'auto');
 
     if (!transcriptPath || !fs.existsSync(transcriptPath)) {
       log('No transcript found for archiving');
@@ -397,9 +434,16 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {
           yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
+          // compact_boundary is a mid-stream system event — the SDK keeps
+          // streaming the agent's actual response after compaction. Yielding
+          // `result` here (as we used to) caused the poll-loop to treat the
+          // turn as done, mark messages completed, and dispatch
+          // "Context compacted (X tokens)." as if it were the agent's reply.
+          // The user's pre-compact "I'll be back" notice now comes from the
+          // PreCompact hook; this branch is informational only.
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
           const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';
-          yield { type: 'result', text: `Context compacted${detail}.`, usage: undefined };
+          yield { type: 'progress', message: `Context compacted${detail}.` };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
           const tn = message as { summary?: string };
           yield { type: 'progress', message: tn.summary || 'Task notification' };


### PR DESCRIPTION
## Summary

Two regressions from v1 fleet to v2 fleet, both in `container/agent-runner/src/providers/claude.ts`:

1. **PreCompact hook lost its Discord notice.** v1 posted `⏳ Compacting context (auto)…` before compacting; v2 only archived the transcript. Restored with a v2-equivalent helper that writes directly to `messages_out` using session routing.

2. **`compact_boundary` was being yielded as a `result` event**, which the poll-loop treated as turn end — so it called `markCompleted` and dispatched `"Context compacted (X tokens)."` as if it were the agent's reply. The SDK keeps streaming the real response after compaction, so this also broke the "did the worker auto-resume?" experience. Now yields `progress` instead.

## Why

User reported workers going silent after compaction. Trace showed `compact_boundary` synthesizing a `result` event mid-stream, terminating the turn before the real reply landed. v1 didn't hit this because v1's main loop ignored `compact_boundary` entirely — the SDK's continued streaming was the "auto-resume" the user remembered.

v1 reference: `container/agent-runner/src/index.ts` (`sendCompactionNotice` at L164, main loop ignored compact_boundary at L585).

## Test plan

- [x] 3 new bun tests in `claude.test.ts` — notice writes with full routing, thread_id preserved, silent skip when routing missing
- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- [x] All existing tests pass (227 host, 56 agent-runner)
- [x] Live verified — workers picked up the new code via bind-mount restart, no more synthetic "Context compacted" turn-end
- [ ] CI green