### PR TITLE
fix(formatter): drop send_message auto-suppress; restore v1 wrap-on-close convention

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -82,11 +82,13 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
-  it('auto-suppresses final turn text when send_message tool_use ran this turn', async () => {
-    // Agent ran send_message early (the canonical ack-then-work flow), then
-    // its closing scratchpad ("<internal>done</internal>") falls through.
-    // dispatchResultText must drop the final text so the user doesn't see
-    // a duplicate or template-junk line. The MCP-side send_message itself
+  it('drops trailing text when the agent wrapped it in <internal> and send_message ran', async () => {
+    // Canonical ack-then-work: agent sent the substantive reply via
+    // send_message, then closed with `<internal>done</internal>`. Stripping
+    // the wrapper leaves "" → nothing lands in outbound (correct: the
+    // reply already went via send_message). Salvage doesn't fire here
+    // because send_message ran (we shouldn't re-surface the wrapped text
+    // as if it were the missing reply). The MCP-side send_message itself
     // is a no-op in MockProvider, so the only thing that *would* land in
     // outbound is the scratchpad — assert nothing lands.
     insertMessage(
@@ -109,6 +111,35 @@ describe('poll loop integration', () => {
     controller.abort();
 
     expect(getUndeliveredMessages()).toHaveLength(0);
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('delivers substantive trailing text even when send_message ran earlier (no auto-suppress)', async () => {
+    // models-endpoint regression: agent calls send_message early ("On it…"),
+    // does the work, then writes a substantive summary as the trailing
+    // turn-result text. The previous auto-suppress-when-send_message-ran
+    // logic dropped these summaries. We now deliver them — the agent is
+    // expected to explicitly wrap closing chatter in <internal> when it
+    // wants suppression (see core.instructions.md).
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'check the pricing_tbd models' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
+
+    const summary = 'PR #2829 is up. Migration 173 covers all three base models (K2.5, MiniMax, Devstral).';
+    const provider = new MockProvider({}, () => summary, ['mcp__nanoclaw__send_message']);
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 1500);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe(summary);
 
     await loopPromise.catch(() => {});
   });

--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -24,9 +24,14 @@ The user is often on a phone screen, doesn't see your tool calls, and only knows
 
 ### Avoid duplicate messages
 
-`send_message` posts a chat reply immediately. Your final turn output is also normally delivered as a chat message. NanoClaw automatically suppresses the final turn output when `send_message` ran this turn, so you'll never get a duplicate — just write naturally. No `<internal>...</internal>` wrapping needed for de-duplication.
+`send_message` posts a chat reply immediately. Your final turn output is _also_ delivered as a chat message — so without care the user sees a duplicate. **When you've already delivered the substantive reply via `send_message`, wrap any trailing closing chatter in `<internal>...</internal>` so it gets stripped before delivery.** The wrapper is your "this is scratchpad, not for the user" marker.
 
-(Internal scratchpad wrapping is still useful for genuinely-internal reasoning that you don't want delivered to chat — see "Internal thoughts" below.)
+Rule of thumb: if the trailing text would be _useful_ to the user, leave it unwrapped — let it land in chat. If it's just "ok, done" chatter that adds nothing on top of what `send_message` already delivered, wrap it.
+
+Common patterns:
+
+- **Ack early, substantive reply at end** — `send_message` "On it…", do the work, then write the substantive findings as the trailing text. No wrap; the trailing text IS the answer.
+- **Substantive reply via send_message, brief close** — `send_message` with the answer, then `<internal>Done.</internal>` so the close doesn't double-post.
 
 ### Pacing updates on longer turns
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -446,15 +446,17 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * This preserves the simple case of one user on one channel — the agent
  * doesn't need to know about wrapping syntax at all.
  *
- * `send_message` auto-suppress: when the agent issued any
- * `mcp__nanoclaw__send_message` tool_use this turn (tracked in the poll
- * loop via the `tool_use` ProviderEvent), the final turn text is treated
- * as redundant and dropped — send_message already delivered the reply
- * to chat. This relieves the agent of the burden of remembering to wrap
- * its closing line in `<internal>...</internal>` for de-duplication.
- * Multi-destination output (`<message to="...">` blocks) still dispatches
- * normally regardless, since those address agents/channels other than
- * the one send_message hit.
+ * De-duplication when `send_message` ran: the agent is instructed (in
+ * `core.instructions.md`) to wrap closing chatter in `<internal>...
+ * </internal>` after using send_message so the trailing text is stripped
+ * to empty here. We don't auto-drop trailing text whenever send_message
+ * ran — that mistakes substantive end-of-turn summaries ("Here's the PR:
+ * #2829, summary follows…") for "Done!" duplicates and silently eats them.
+ * v1 behavior: trust the agent's wrap; surface anything that isn't wrapped.
+ *
+ * The salvage path below catches the post-compaction failure mode where
+ * the agent emits a stand-alone `<internal>` block with no send_message —
+ * we'd otherwise go silent.
  */
 function dispatchResultText(text: string, routing: RoutingContext, opts: { sendMessageToolUseCount: number }): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
@@ -498,21 +500,6 @@ function dispatchResultText(text: string, routing: RoutingContext, opts: { sendM
   if (!stripped && opts.sendMessageToolUseCount === 0) {
     const unwrapped = rawScratchpad.replace(/<\/?internal>/g, '').trim();
     if (unwrapped) scratchpad = unwrapped;
-  }
-
-  // send_message ran this turn → final text is a duplicate / wrap-up;
-  // drop it. This is the canonical path for ack-then-work flows: agent
-  // calls send_message early, does its tool work, lets its closing
-  // statement fall through here, formatter suppresses it. No
-  // `<internal>` wrap required from the agent.
-  if (sent === 0 && opts.sendMessageToolUseCount > 0) {
-    if (scratchpad) {
-      log(
-        `[scratchpad] auto-suppressed (send_message ran ${opts.sendMessageToolUseCount}x this turn): ` +
-          `${scratchpad.slice(0, 200)}${scratchpad.length > 200 ? '…' : ''}`,
-      );
-    }
-    return;
   }
 
   // Single-destination shortcut: the agent wrote plain text — send to


### PR DESCRIPTION
## Summary

Drop the formatter's "if `send_message` ran, silently drop the trailing text" branch. Restore v1's convention of asking the agent to wrap closing chatter in `<internal>...</internal>` if it wants suppression. Keep the salvage path that catches post-compaction `<internal>`-only output.

## Why

The auto-suppress added in `67823bf` was eating substantive end-of-turn summaries from workers that used `send_message` earlier in the turn. The `models-endpoint` trace showed two consecutive 13-min and 21-min turns where the agent's closing summaries — `"PR #2829 is up. Migration 173 covers all three base models…"` — were silently dropped because the agent had also used `send_message` for an earlier "On it…" ack.

Auto-suppress can't tell "Done!" from a 600-char summary. v1 didn't have this problem because v1's `core.instructions.md` instructed the agent to wrap closing chatter in `<internal>...</internal>` — the agent decided what was "done!" vs "the answer" and the formatter just stripped what the agent marked as scratchpad.

## Trade-off

Agents that adopted the no-wrap pattern (relying on auto-suppress to drop their "Done!" lines) will now produce two messages — the `send_message` reply plus the closing line — until they read the restored CLAUDE.md guidance and start wrapping again. This matches v1 behavior, which is what the user wants.

The salvage path (unchanged in shape, only its `sendMessageToolUseCount === 0` gate is now load-bearing for correctness rather than redundant with auto-suppress) still catches the post-compaction failure mode the original commit was trying to fix — agent emits stand-alone `<internal>` block with no `send_message`, content gets unwrapped and surfaced rather than going silent.

## Tests

- Renamed the misleading `auto-suppresses` test — it was always really testing wrap-based suppression (the mock returned wrapped output); the assertion still holds because wrap → strip → empty → nothing delivered
- Added an integration test mirroring the `models-endpoint` regression: `send_message` tool_use ran AND the trailing text is a substantive summary → delivered
- Salvage test unchanged

## Test plan

- [x] 56/56 bun agent-runner tests pass (1 new, 1 renamed)
- [x] 227/227 host vitest pass
- [x] Live verified — workers re-spawned via bind-mount restart, closing summaries now reach Discord
- [ ] CI green