### PR TITLE
feat(fleet): cleanup_workers — master-callable orphan reconciliation

### DIFF
--- a/container/agent-runner/src/mcp-tools/fleet.ts
+++ b/container/agent-runner/src/mcp-tools/fleet.ts
@@ -186,4 +186,33 @@ export const listWorkers: McpToolDefinition = {
   },
 };
 
-registerTools([createWorker, destroyWorker, switchBackend, listWorkers]);
+export const cleanupWorkers: McpToolDefinition = {
+  tool: {
+    name: 'cleanup_workers',
+    description:
+      'Reconcile fleet state and clean up orphans: orphan Discord channels (no agent_group) and orphan containers (no active agent_group) are auto-cleaned; orphan workers (active agent_group with missing Discord channel) are reported back to you so you can decide. Pass dry_run=true to preview without changes.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        dry_run: { type: 'boolean', description: 'Report only, no changes. Defaults to false.' },
+      },
+    },
+  },
+  async handler(args) {
+    const dryRun = args.dry_run === true;
+    const id = generateId();
+    writeMessageOut({
+      id,
+      kind: 'system',
+      content: JSON.stringify({ action: 'cleanup_workers', requestId: id, dry_run: dryRun }),
+    });
+    log(`cleanup_workers: ${id} (dry_run=${dryRun})`);
+    return ok(
+      dryRun
+        ? 'Cleanup dry-run requested. The host will reply with the reconciliation report.'
+        : 'Cleanup requested. The host will reply with what was cleaned + any orphan workers needing your decision.',
+    );
+  },
+};
+
+registerTools([createWorker, destroyWorker, switchBackend, listWorkers, cleanupWorkers]);

--- a/src/modules/fleet/cleanup-workers.test.ts
+++ b/src/modules/fleet/cleanup-workers.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the cleanup_workers handler. Mirrors fleet.test.ts patterns:
+ * Discord REST + child_process are hard-mocked, central DB is in-memory.
+ */
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+} from '../../db/index.js';
+import { updateAgentGroup } from '../../db/agent-groups.js';
+import type { Session } from '../../types.js';
+
+// Stub out wakeContainer / killContainer so notifyAgent doesn't try to
+// hit a real container during the master notification path.
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  killContainer: vi.fn(),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-cleanup', GROUPS_DIR: '/tmp/nanoclaw-test-cleanup/groups' };
+});
+
+vi.mock('../../session-manager.js', async () => {
+  const actual = await vi.importActual('../../session-manager.js');
+  return { ...actual, writeSessionMessage: vi.fn() };
+});
+
+// Discord REST: configurable per test via the mocked listDiscordChannels.
+const mockListDiscordChannels = vi.fn();
+const mockDeleteDiscordChannel = vi.fn();
+vi.mock('./discord-channel.js', () => ({
+  loadDiscordFleetConfig: () => ({ botToken: 'test-token', guildId: 'test-guild' }),
+  createDiscordChannel: vi.fn(),
+  deleteDiscordChannel: mockDeleteDiscordChannel,
+  listDiscordChannels: mockListDiscordChannels,
+}));
+
+// child_process: control docker ps output and capture rm -f calls.
+const mockExecSync = vi.fn();
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+const { handleCleanupWorkers, runCleanup } = await import('./cleanup-workers.js');
+
+const TEST_DIR = '/tmp/nanoclaw-test-cleanup';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function makeMasterSession(): Session {
+  return {
+    id: 'sess-master',
+    agent_group_id: 'ag-master',
+    messaging_group_id: 'mg-master',
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  };
+}
+
+function makeWorker(id: string, folder: string, opts: { archived?: boolean } = {}): void {
+  createAgentGroup({
+    id,
+    name: folder,
+    folder,
+    agent_provider: 'claude',
+    created_at: now(),
+  });
+  updateAgentGroup(id, { fleet_role: 'worker', status: opts.archived ? 'archived' : 'active' });
+}
+
+function wireDiscordChannel(workerId: string, channelId: string): void {
+  const mgId = `mg-${workerId}`;
+  createMessagingGroup({
+    id: mgId,
+    channel_type: 'discord',
+    platform_id: `discord:${channelId}`,
+    name: 'test',
+    is_group: 0,
+    unknown_sender_policy: 'strict',
+    created_at: now(),
+  });
+  createMessagingGroupAgent({
+    id: `mga-${workerId}`,
+    messaging_group_id: mgId,
+    agent_group_id: workerId,
+    engage_mode: 'pattern',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now(),
+  });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR + '/groups', { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({
+    id: 'ag-master',
+    name: 'Master',
+    folder: 'master',
+    agent_provider: 'claude',
+    created_at: now(),
+  });
+  updateAgentGroup('ag-master', { fleet_role: 'master' });
+
+  // Default docker ps: nothing running.
+  mockExecSync.mockReturnValue('');
+  mockListDiscordChannels.mockResolvedValue([]);
+  mockDeleteDiscordChannel.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  vi.clearAllMocks();
+});
+
+describe('cleanup_workers', () => {
+  it('reports nothing when state is consistent', async () => {
+    makeWorker('ag-alpha', 'alpha');
+    wireDiscordChannel('ag-alpha', 'chan-alpha');
+    mockListDiscordChannels.mockResolvedValue([{ id: 'chan-alpha', name: 'worker-alpha', type: 0, parent_id: null }]);
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanChannels).toEqual([]);
+    expect(report.orphanWorkers).toEqual([]);
+    expect(report.orphanContainers).toEqual([]);
+    expect(report.errors).toEqual([]);
+  });
+
+  it('detects + deletes orphan Discord channels', async () => {
+    makeWorker('ag-alpha', 'alpha');
+    wireDiscordChannel('ag-alpha', 'chan-alpha');
+    mockListDiscordChannels.mockResolvedValue([
+      { id: 'chan-alpha', name: 'worker-alpha', type: 0, parent_id: null },
+      { id: 'chan-orphan', name: 'worker-ghost', type: 0, parent_id: null },
+    ]);
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanChannels).toEqual([{ id: 'chan-orphan', name: 'worker-ghost' }]);
+    expect(mockDeleteDiscordChannel).toHaveBeenCalledWith(expect.anything(), 'chan-orphan');
+  });
+
+  it('skips channels that do not match the fleet name prefix', async () => {
+    mockListDiscordChannels.mockResolvedValue([
+      { id: 'chan-user', name: 'general', type: 0, parent_id: null },
+      { id: 'chan-meta', name: 'announcements', type: 0, parent_id: null },
+    ]);
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanChannels).toEqual([]);
+    expect(mockDeleteDiscordChannel).not.toHaveBeenCalled();
+  });
+
+  it('detects orphan workers (active worker, channel missing) and does NOT auto-archive', async () => {
+    makeWorker('ag-alpha', 'alpha');
+    wireDiscordChannel('ag-alpha', 'chan-alpha');
+    mockListDiscordChannels.mockResolvedValue([]); // channel is gone from Discord
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanWorkers).toHaveLength(1);
+    expect(report.orphanWorkers[0]).toMatchObject({ name: 'alpha', folder: 'alpha' });
+    // NOT auto-archived — master decides.
+    const { getAgentGroupByFolder } = await import('../../db/agent-groups.js');
+    expect(getAgentGroupByFolder('alpha')?.status).toBe('active');
+  });
+
+  it('detects + kills orphan containers', async () => {
+    makeWorker('ag-alpha', 'alpha');
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('docker ps')) {
+        return 'nanoclaw-v2-alpha-1234567890\nnanoclaw-v2-ghost-9876543210\n';
+      }
+      return '';
+    });
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-9876543210']);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'docker rm -f nanoclaw-v2-ghost-9876543210',
+      expect.objectContaining({ stdio: expect.any(Array) }),
+    );
+  });
+
+  it('correctly parses container names with hyphens in the folder', async () => {
+    makeWorker('ag-foo', 'foo-bar-baz');
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('docker ps')) return 'nanoclaw-v2-foo-bar-baz-1234567890\n';
+      return '';
+    });
+
+    const report = await runCleanup({ dryRun: false });
+    expect(report.orphanContainers).toEqual([]); // foo-bar-baz is active, not orphan
+  });
+
+  it('dry_run does not delete or kill anything', async () => {
+    makeWorker('ag-alpha', 'alpha');
+    wireDiscordChannel('ag-alpha', 'chan-alpha');
+    mockListDiscordChannels.mockResolvedValue([{ id: 'chan-orphan', name: 'worker-ghost', type: 0, parent_id: null }]);
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('docker ps')) return 'nanoclaw-v2-ghost-9876543210\n';
+      return '';
+    });
+
+    const report = await runCleanup({ dryRun: true });
+    expect(report.orphanChannels).toHaveLength(1);
+    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-9876543210']);
+    expect(mockDeleteDiscordChannel).not.toHaveBeenCalled();
+    // Should not have called `docker rm -f`.
+    const rmCalls = mockExecSync.mock.calls.filter((c) => String(c[0]).startsWith('docker rm'));
+    expect(rmCalls).toHaveLength(0);
+  });
+
+  it('rejects non-master callers via handleCleanupWorkers', async () => {
+    updateAgentGroup('ag-master', { fleet_role: null });
+    await handleCleanupWorkers({}, makeMasterSession()); // master role is gone
+    // No throw, just no work — runCleanup wasn't called.
+    expect(mockListDiscordChannels).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/fleet/cleanup-workers.test.ts
+++ b/src/modules/fleet/cleanup-workers.test.ts
@@ -189,15 +189,15 @@ describe('cleanup_workers', () => {
     makeWorker('ag-alpha', 'alpha');
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.includes('docker ps')) {
-        return 'nanoclaw-v2-alpha-1234567890\nnanoclaw-v2-ghost-9876543210\n';
+        return 'nanoclaw-v2-alpha-1700000000000\nnanoclaw-v2-ghost-1700000000999\n';
       }
       return '';
     });
 
     const report = await runCleanup({ dryRun: false });
-    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-9876543210']);
+    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-1700000000999']);
     expect(mockExecSync).toHaveBeenCalledWith(
-      'docker rm -f nanoclaw-v2-ghost-9876543210',
+      'docker rm -f nanoclaw-v2-ghost-1700000000999',
       expect.objectContaining({ stdio: expect.any(Array) }),
     );
   });
@@ -205,7 +205,7 @@ describe('cleanup_workers', () => {
   it('correctly parses container names with hyphens in the folder', async () => {
     makeWorker('ag-foo', 'foo-bar-baz');
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.includes('docker ps')) return 'nanoclaw-v2-foo-bar-baz-1234567890\n';
+      if (cmd.includes('docker ps')) return 'nanoclaw-v2-foo-bar-baz-1700000000000\n';
       return '';
     });
 
@@ -218,13 +218,13 @@ describe('cleanup_workers', () => {
     wireDiscordChannel('ag-alpha', 'chan-alpha');
     mockListDiscordChannels.mockResolvedValue([{ id: 'chan-orphan', name: 'worker-ghost', type: 0, parent_id: null }]);
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.includes('docker ps')) return 'nanoclaw-v2-ghost-9876543210\n';
+      if (cmd.includes('docker ps')) return 'nanoclaw-v2-ghost-1700000000999\n';
       return '';
     });
 
     const report = await runCleanup({ dryRun: true });
     expect(report.orphanChannels).toHaveLength(1);
-    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-9876543210']);
+    expect(report.orphanContainers).toEqual(['nanoclaw-v2-ghost-1700000000999']);
     expect(mockDeleteDiscordChannel).not.toHaveBeenCalled();
     // Should not have called `docker rm -f`.
     const rmCalls = mockExecSync.mock.calls.filter((c) => String(c[0]).startsWith('docker rm'));

--- a/src/modules/fleet/cleanup-workers.ts
+++ b/src/modules/fleet/cleanup-workers.ts
@@ -45,11 +45,14 @@ interface CleanupOptions {
 }
 
 /**
- * Container-name parser: `nanoclaw-v2-<folder>-<timestamp>`. Folder may
- * itself contain hyphens, so we anchor on the trailing numeric timestamp.
- * Matches `src/container-runner.ts:176`.
+ * Container-name parser: `nanoclaw-v2-<folder>-<Date.now()>`. Folder may
+ * contain hyphens AND digits (e.g. `model-dev-2024`), so we anchor on a
+ * 13-digit ms-epoch timestamp suffix rather than `\d+`. A loose `\d+`
+ * would eat the trailing `-2024` as the timestamp and mis-identify the
+ * folder as `model-dev`, potentially marking an active container as
+ * orphan (or vice-versa). Matches `src/container-runner.ts:176`.
  */
-const CONTAINER_NAME_RE = /^nanoclaw-v2-(.+)-\d+$/;
+const CONTAINER_NAME_RE = /^nanoclaw-v2-(.+)-(\d{13})$/;
 
 export async function handleCleanupWorkers(content: Record<string, unknown>, session: Session): Promise<void> {
   const sourceGroup = getAgentGroup(session.agent_group_id);

--- a/src/modules/fleet/cleanup-workers.ts
+++ b/src/modules/fleet/cleanup-workers.ts
@@ -1,0 +1,223 @@
+/**
+ * `cleanup_workers` delivery-action handler.
+ *
+ * Reconciles three reality views and surfaces drift:
+ *   1. agent_groups (DB)        — what we think exists
+ *   2. messaging_groups (DB)    — channels we think we own
+ *   3. Discord guild channels   — channels that actually exist
+ *   4. Running docker containers — workers that are actually consuming RAM
+ *
+ * Three drift categories:
+ *   • Orphan channels   — Discord channel exists in our category prefix
+ *                         space but no messaging_groups row points at it.
+ *                         Auto-deleted (matches v1 cleanup_workers + v2's
+ *                         existing `ncf reap-orphans`).
+ *   • Orphan workers    — agent_groups row is active + fleet_role='worker'
+ *                         but its messaging_group's platform_id is missing
+ *                         from the live Discord channel set.
+ *                         REPORTED ONLY — the master decides whether to
+ *                         recreate the channel or archive the worker.
+ *   • Orphan containers — docker shows a `nanoclaw-v2-<folder>-<ts>` whose
+ *                         folder doesn't match any active agent_group.
+ *                         Auto-killed (matches v1).
+ *
+ * Master-only. Same fire-and-forget pattern as create/destroy/switch.
+ */
+import { execSync } from 'child_process';
+
+import { getActiveAgentGroups, getAgentGroup } from '../../db/agent-groups.js';
+import { getAllMessagingGroups, getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { deleteDiscordChannel, listDiscordChannels, loadDiscordFleetConfig } from './discord-channel.js';
+import { logWorkerEvent } from './events.js';
+import { notifyAgent } from './lib.js';
+
+interface CleanupReport {
+  orphanChannels: Array<{ id: string; name: string }>;
+  orphanWorkers: Array<{ name: string; folder: string; reason: string }>;
+  orphanContainers: string[];
+  errors: string[];
+}
+
+interface CleanupOptions {
+  dryRun: boolean;
+}
+
+/**
+ * Container-name parser: `nanoclaw-v2-<folder>-<timestamp>`. Folder may
+ * itself contain hyphens, so we anchor on the trailing numeric timestamp.
+ * Matches `src/container-runner.ts:176`.
+ */
+const CONTAINER_NAME_RE = /^nanoclaw-v2-(.+)-\d+$/;
+
+export async function handleCleanupWorkers(content: Record<string, unknown>, session: Session): Promise<void> {
+  const sourceGroup = getAgentGroup(session.agent_group_id);
+  if (!sourceGroup || sourceGroup.fleet_role !== 'master') {
+    notifyAgent(session, `cleanup_workers failed: only the master agent can run cleanup.`);
+    return;
+  }
+
+  const dryRun = content.dry_run === true;
+  const report = await runCleanup({ dryRun });
+
+  notifyAgent(session, formatReport(report, dryRun));
+  logWorkerEvent({
+    timestamp: new Date().toISOString(),
+    event: dryRun ? 'cleanup_dry_run' : 'cleanup_executed',
+    worker: 'master',
+    folder: sourceGroup.folder,
+    details: {
+      orphanChannelCount: report.orphanChannels.length,
+      orphanWorkerCount: report.orphanWorkers.length,
+      orphanContainerCount: report.orphanContainers.length,
+      errorCount: report.errors.length,
+    },
+  });
+}
+
+export async function runCleanup(opts: CleanupOptions): Promise<CleanupReport> {
+  const report: CleanupReport = {
+    orphanChannels: [],
+    orphanWorkers: [],
+    orphanContainers: [],
+    errors: [],
+  };
+
+  // 1. Reconcile Discord channels ↔ messaging_groups.
+  const discordCfg = loadDiscordFleetConfig();
+  if (discordCfg) {
+    try {
+      const liveChannels = await listDiscordChannels(discordCfg);
+      const liveChannelIds = new Set(liveChannels.filter((c) => c.type === 0).map((c) => c.id));
+
+      const ourChannelIds = new Set<string>();
+      for (const mg of getAllMessagingGroups()) {
+        if (mg.channel_type !== 'discord') continue;
+        const parts = mg.platform_id.split(':');
+        const chanId = parts[parts.length - 1];
+        if (chanId) ourChannelIds.add(chanId);
+      }
+
+      // Orphan channels: live but not ours. Restrict to fleet-prefix names so
+      // we never touch user-created channels we don't manage.
+      for (const chan of liveChannels) {
+        if (chan.type !== 0) continue;
+        if (!chan.name.startsWith('worker-') && !chan.name.startsWith('lc-')) continue;
+        if (ourChannelIds.has(chan.id)) continue;
+        report.orphanChannels.push({ id: chan.id, name: chan.name });
+      }
+
+      // Orphan workers: ours but not live. Skip workers whose messaging_group
+      // is non-Discord (those are valid; we can't verify them via this API).
+      for (const ag of getActiveAgentGroups()) {
+        if (ag.fleet_role !== 'worker') continue;
+        const mgs = getMessagingGroupsByAgentGroup(ag.id);
+        const discordMgs = mgs.filter((mg) => mg.channel_type === 'discord');
+        if (discordMgs.length === 0) {
+          // Active worker with no channel of any kind — likely stuck mid-create.
+          report.orphanWorkers.push({ name: ag.name, folder: ag.folder, reason: 'no messaging_group' });
+          continue;
+        }
+        for (const mg of discordMgs) {
+          const chanId = mg.platform_id.split(':').pop() ?? '';
+          if (!liveChannelIds.has(chanId)) {
+            report.orphanWorkers.push({
+              name: ag.name,
+              folder: ag.folder,
+              reason: `Discord channel ${chanId} missing`,
+            });
+          }
+        }
+      }
+
+      // Auto-delete orphan channels (skip on dry run).
+      if (!opts.dryRun) {
+        for (const o of report.orphanChannels) {
+          try {
+            await deleteDiscordChannel(discordCfg, o.id);
+            await new Promise((r) => setTimeout(r, 700)); // courtesy rate-limit
+          } catch (err) {
+            const msg = `delete channel ${o.id} (${o.name}) failed: ${err instanceof Error ? err.message : String(err)}`;
+            report.errors.push(msg);
+            log.warn('cleanup_workers: ' + msg);
+          }
+        }
+      }
+    } catch (err) {
+      const msg = `Discord reconciliation failed: ${err instanceof Error ? err.message : String(err)}`;
+      report.errors.push(msg);
+      log.warn('cleanup_workers: ' + msg);
+    }
+  } else {
+    report.errors.push('Discord not configured (DISCORD_BOT_TOKEN/GUILD_ID missing); skipped channel reconciliation.');
+  }
+
+  // 2. Reconcile running containers ↔ active agent_groups.
+  const activeFolders = new Set(getActiveAgentGroups().map((g) => g.folder));
+  try {
+    const out = execSync(`docker ps --filter name=nanoclaw-v2- --format '{{.Names}}'`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const runningNames = out ? out.split('\n') : [];
+    for (const name of runningNames) {
+      const m = name.match(CONTAINER_NAME_RE);
+      if (!m) continue;
+      const folder = m[1];
+      if (activeFolders.has(folder)) continue;
+      report.orphanContainers.push(name);
+    }
+
+    if (!opts.dryRun) {
+      for (const name of report.orphanContainers) {
+        try {
+          execSync(`docker rm -f ${name}`, { stdio: ['pipe', 'pipe', 'pipe'] });
+        } catch (err) {
+          const msg = `kill container ${name} failed: ${err instanceof Error ? err.message : String(err)}`;
+          report.errors.push(msg);
+          log.warn('cleanup_workers: ' + msg);
+        }
+      }
+    }
+  } catch (err) {
+    report.errors.push(`docker ps failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return report;
+}
+
+function formatReport(report: CleanupReport, dryRun: boolean): string {
+  const lines: string[] = [];
+  lines.push(dryRun ? '🔍 cleanup_workers (dry-run)' : '🧹 cleanup_workers');
+
+  if (report.orphanChannels.length === 0) {
+    lines.push('• Orphan channels: none');
+  } else {
+    lines.push(`• Orphan channels (${report.orphanChannels.length})${dryRun ? ' — would delete:' : ' — deleted:'}`);
+    for (const o of report.orphanChannels) lines.push(`    ${o.id} ${o.name}`);
+  }
+
+  if (report.orphanContainers.length === 0) {
+    lines.push('• Orphan containers: none');
+  } else {
+    lines.push(`• Orphan containers (${report.orphanContainers.length})${dryRun ? ' — would kill:' : ' — killed:'}`);
+    for (const n of report.orphanContainers) lines.push(`    ${n}`);
+  }
+
+  if (report.orphanWorkers.length === 0) {
+    lines.push('• Orphan workers: none');
+  } else {
+    lines.push(
+      `• Orphan workers (${report.orphanWorkers.length}) — needs your decision (recreate channel, or destroy_worker to archive):`,
+    );
+    for (const w of report.orphanWorkers) lines.push(`    ${w.name} (${w.folder}) — ${w.reason}`);
+  }
+
+  if (report.errors.length > 0) {
+    lines.push(`• Errors (${report.errors.length}):`);
+    for (const e of report.errors) lines.push(`    ${e}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/modules/fleet/discord-channel.ts
+++ b/src/modules/fleet/discord-channel.ts
@@ -79,6 +79,22 @@ export async function createDiscordChannel(
 }
 
 /**
+ * List all text channels in the configured guild. Returns id + name + parent
+ * so the caller can filter (e.g. by category) and reconcile against
+ * `messaging_groups.platform_id`.
+ */
+export async function listDiscordChannels(
+  cfg: DiscordChannelConfig,
+): Promise<Array<{ id: string; name: string; type: number; parent_id: string | null }>> {
+  const res = await discordFetch(cfg, `/guilds/${cfg.guildId}/channels`);
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`Discord list channels failed: ${res.status} ${txt}`);
+  }
+  return (await res.json()) as Array<{ id: string; name: string; type: number; parent_id: string | null }>;
+}
+
+/**
  * Delete a Discord channel by ID. Idempotent in the sense that we log and
  * swallow 404 (channel already gone) so destroy can retry safely.
  */

--- a/src/modules/fleet/events.ts
+++ b/src/modules/fleet/events.ts
@@ -14,7 +14,13 @@ import path from 'path';
 
 const EVENTS_FILE = path.resolve(process.cwd(), 'logs', 'worker-events.jsonl');
 
-export type WorkerEventKind = 'created' | 'destroyed' | 'backend_switched' | 'resumed';
+export type WorkerEventKind =
+  | 'created'
+  | 'destroyed'
+  | 'backend_switched'
+  | 'resumed'
+  | 'cleanup_dry_run'
+  | 'cleanup_executed';
 
 export interface WorkerEvent {
   timestamp: string;

--- a/src/modules/fleet/index.ts
+++ b/src/modules/fleet/index.ts
@@ -15,6 +15,7 @@
  * NANOCLAW_FLEET_ROLE=master).
  */
 import { registerDeliveryAction } from '../../delivery.js';
+import { handleCleanupWorkers } from './cleanup-workers.js';
 import { handleCreateWorker } from './create-worker.js';
 import { handleDestroyWorker } from './destroy-worker.js';
 import { handleListWorkersRequest } from './list-workers.js';
@@ -24,3 +25,4 @@ registerDeliveryAction('create_worker', handleCreateWorker);
 registerDeliveryAction('destroy_worker', handleDestroyWorker);
 registerDeliveryAction('switch_backend', handleSwitchBackend);
 registerDeliveryAction('list_workers_request', handleListWorkersRequest);
+registerDeliveryAction('cleanup_workers', handleCleanupWorkers);


### PR DESCRIPTION
## Summary

Adds a master-callable `cleanup_workers` MCP tool + host handler that reconciles fleet state and surfaces drift across four reality views: `agent_groups` (DB), `messaging_groups` (DB), live Discord channels, and running docker containers.

## Why

v1 had an agent-callable `cleanup_workers` IPC command (src/ipc.ts:1000-1077 in the old tree) that reaped orphan containers. v2's only equivalent — `ncf reap-orphans` CLI — only reaps orphan Discord channels and isn't callable by the master agent. Neither caught the third drift case (active `agent_group` whose Discord channel was deleted out-of-band).

## Behavior

Three drift categories:

| Category | Detection | Action |
|-|-|-|
| Orphan channels | Live Discord channel matches our fleet name prefix (`worker-*` / `lc-*`) but no `messaging_groups` row points at it | Auto-delete (matches v1) |
| Orphan containers | Running `nanoclaw-v2-<folder>-<ts>` whose folder doesn't match any active `agent_group` | Auto-kill (matches v1) |
| Orphan workers | Active `agent_group` worker, but its messaging_group's Discord channel is missing from the live channel set | **REPORT ONLY** — master decides whether to recreate the channel or `destroy_worker` to archive |

Orphan workers aren't auto-archived because the master should choose between recreating the channel and explicit destroy — silent archive-on-drift would lose session resumability on a transient channel deletion.

Same fire-and-forget pattern as `create_worker` / `destroy_worker` / `switch_backend`. Master-only on both ends. Optional `dry_run` flag for preview.

`ncf reap-orphans` CLI left alone for now (channel-only, synchronous) — unifying it with the new shared logic is a follow-up.

## Self-review fix

Tightened the container-name regex from `(.+)-\d+$` to `(.+)-(\d{13})$` — the loose form mis-parses folders that end in digits (e.g. `model-dev-2024` would have its trailing `2024` eaten as the timestamp). Date.now() is always 13 digits.

## Test plan

- [x] 8 vitest cases in `cleanup-workers.test.ts` — empty state, orphan channel detect+delete, name prefix filter, orphan worker detect (no auto-archive), orphan container detect+kill, hyphenated folder parsing, dry_run no-op, non-master rejection
- [x] All existing tests still pass (235 host)
- [x] `pnpm exec tsc --noEmit` clean, `pnpm run build` clean
- [ ] CI green