### PR TITLE
docs(fleet): worker lifecycle vocabulary — state what survives, what's lost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,21 @@ This is `thmtz/nanoclaw-fleet` — a fleet-manager fork on top of `qwibitai/nano
 - **Hooks.** Husky installs `.husky/` hooks automatically on `pnpm install` (via the `prepare` script). `pre-commit` formats staged files with Prettier and re-stages them; `pre-push` runs `format:check`, host + container `tsc`, and host `vitest run`. Don't skip with `--no-verify` unless you know exactly why.
 - **Restart discipline.** Don't restart the running NanoClaw service (`systemctl --user restart nanoclaw`, `launchctl kickstart`, `kill`-ing the host process) or kill running worker containers without explicit user confirmation. Workers are real long-running sessions; a restart kills active conversations and any pending turns. If a code or config change _would_ require a restart to take effect, finish the change, mention that a restart is needed, and ask before doing it.
 
+## Worker lifecycle vocabulary
+
+The words "kill", "restart", "destroy", "fresh", and "wipe" get used loosely and have caused real confusion in this session — agents proposing to "kill the workers" when they meant "stop the containers, history preserved." **Before offering or executing any worker-lifecycle action, state plainly what survives and what's lost.** Don't say "kill" without context.
+
+The four real actions:
+
+| Action             | Command                                  | Survives                                                                                                                     | Lost                                                                  |
+| ------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Stop container     | `ncf restart <n>`                        | everything (workspace, SDK session, channel, agent_group); container respawns on next message with full conversation context | nothing                                                               |
+| Reset conversation | `ncf restart <n> --fresh`                | workspace files, channel, agent_group                                                                                        | SDK session pointer — agent forgets prior turns                       |
+| Archive worker     | `ncf destroy <n>`                        | workspace + SDK session (recoverable via `ncf create <n>`)                                                                   | running container, Discord channel by default; agent_group → archived |
+| Permanent wipe     | `ncf create <n> --fresh` (after destroy) | nothing                                                                                                                      | archived workspace + history permanently gone                         |
+
+When phrasing offers, prefer the explicit action name and consequences over the verb shorthand. "Want me to stop the 4 worker containers? Conversation history and workspaces are preserved; they respawn fresh on next message." beats "Want me to kill the workers?"
+
 ## Documentation routing
 
 Read the relevant doc before working on a subsystem. Each one is short and focused.

--- a/container/agent-runner/src/mcp-tools/fleet.ts
+++ b/container/agent-runner/src/mcp-tools/fleet.ts
@@ -18,6 +18,15 @@
  * Gating: this module is only imported by the barrel when
  * NANOCLAW_FLEET_ROLE=master is set on the container. Non-master containers
  * never see these tools.
+ *
+ * Communication discipline (master agent): when offering or executing any
+ * lifecycle action below, state plainly what survives and what's lost. Don't
+ * use "kill" / "fresh" / "wipe" without context — those words have all
+ * caused user confusion. Prefer explicit phrasing:
+ *   - "stop the container; conversation history and workspace preserved"
+ *   - "reset the conversation; workspace files preserved, agent forgets prior turns"
+ *   - "archive the worker; recoverable via create_worker with the same name"
+ *   - "permanently delete workspace + history; not recoverable"
  */
 import { writeMessageOut } from '../db/messages-out.js';
 import { registerTools } from './server.js';
@@ -95,7 +104,7 @@ export const destroyWorker: McpToolDefinition = {
   tool: {
     name: 'destroy_worker',
     description:
-      'Destroy a fleet worker. Stops the container, archives the agent group (workspace and conversation preserved), and deletes its Discord channel by default. Fire-and-forget.',
+      'Archive a fleet worker (the user-facing word is "destroy" but archive is what actually happens). Stops the container, archives the agent_group, and deletes its Discord channel by default. **Workspace files and conversation history are PRESERVED on disk and recoverable** — calling create_worker with the same name later resumes the worker with full context. Use this for "stop using this worker for now" or "I might come back to it." Fire-and-forget. When offering this action, tell the user it is recoverable.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -123,7 +132,9 @@ export const destroyWorker: McpToolDefinition = {
       }),
     });
     log(`destroy_worker: ${id} → "${name}"`);
-    return ok(`Destroying worker "${name}". You will be notified when done.`);
+    return ok(
+      `Archiving worker "${name}" (workspace + history preserved; recoverable via create_worker). You will be notified when done.`,
+    );
   },
 };
 


### PR DESCRIPTION
## Summary

Two doc-only changes that codify a communication discipline rule for worker-lifecycle actions:

1. **Repo `CLAUDE.md`** — adds a "Worker lifecycle vocabulary" section with a table of the four real actions (`stop` / `reset-conversation` / `archive` / `wipe`), what each preserves, and what each loses. Includes the rule: before offering or executing any lifecycle action, state plainly what survives and what's lost. Don't say "kill" without context.

2. **`container/agent-runner/src/mcp-tools/fleet.ts`** — adds the same communication discipline note at the top of the file (master agents see it), strengthens `destroy_worker`'s description (`archive ... PRESERVED ... recoverable`) and its tool reply (so the master's first response to the user is already explicit). `switch_backend` and `create_worker` left alone — their existing wording already meets the bar.

## Why

The words "kill", "destroy", "fresh", "wipe", and "restart" have been used loosely in conversation in ways that almost cost real conversation history this session. Repeated confusion: "want me to kill the workers?" sounds permanent but actually means "stop the containers, history preserved"; "destroy" sounds permanent but is recoverable; the only truly destructive action ("fresh" after destroy) doesn't have a single command name and slips through review.

No command renames — just clearer descriptions of what the existing commands do.

## Test plan

- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- [x] `pnpm run build` clean
- [ ] CI green