### PR TITLE
test(container): lock OAuth token precedence with a unit test

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for container-runner helpers. Currently only covers
+ * `pickOauthToken` — the OAuth precedence that prevents the regression
+ * where workers 401 hours after spawn because they were baked with a
+ * since-rotated short-lived token instead of the long-lived `.env` one.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { pickOauthToken } from './container-runner.js';
+
+describe('pickOauthToken', () => {
+  it('prefers .env over credentials.json when both are set', () => {
+    expect(pickOauthToken({ envToken: 'long-lived-env', liveToken: 'short-lived-live' })).toEqual({
+      token: 'long-lived-env',
+      source: '.env',
+    });
+  });
+
+  it('falls back to credentials.json when .env is empty', () => {
+    expect(pickOauthToken({ envToken: undefined, liveToken: 'short-lived-live' })).toEqual({
+      token: 'short-lived-live',
+      source: 'credentials.json',
+    });
+  });
+
+  it('returns none when neither is set', () => {
+    expect(pickOauthToken({ envToken: undefined, liveToken: undefined })).toEqual({
+      token: undefined,
+      source: 'none',
+    });
+  });
+
+  it('treats empty string .env token as unset (so we still try credentials.json)', () => {
+    expect(pickOauthToken({ envToken: '', liveToken: 'short-lived-live' })).toEqual({
+      token: 'short-lived-live',
+      source: 'credentials.json',
+    });
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -75,6 +75,30 @@ function readLiveClaudeOauthToken(): string | undefined {
   }
 }
 
+/**
+ * Pick which OAuth token to bake into the container env, with v1 parity:
+ * `.env.CLAUDE_CODE_OAUTH_TOKEN` (long-lived `claude setup-token`, valid for
+ * months) wins over `~/.claude/.credentials.json` (Claude Code's
+ * auto-rotating session token, ~1hr lifetime). The container env is frozen
+ * at spawn time — never refreshed — so freezing in the rotating token
+ * guarantees a 401 on the next rotation. v1 didn't hit this because v1
+ * ran a credential proxy that read `.env` per request; in v2 OneCLI is
+ * meant to fill that role, but when OneCLI isn't applied this fallback
+ * freezes the token, so we must pick the long-lived source.
+ *
+ * Exported so the precedence is locked down by a unit test
+ * (`container-runner.test.ts`). Bare-`undefined` inputs return
+ * `{ token: undefined, source: 'none' }` so callers can `if (token)` cleanly.
+ */
+export function pickOauthToken(input: { envToken: string | undefined; liveToken: string | undefined }): {
+  token: string | undefined;
+  source: '.env' | 'credentials.json' | 'none';
+} {
+  if (input.envToken) return { token: input.envToken, source: '.env' };
+  if (input.liveToken) return { token: input.liveToken, source: 'credentials.json' };
+  return { token: undefined, source: 'none' };
+}
+
 /** Active containers tracked by session ID. */
 const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
 
@@ -571,20 +595,11 @@ async function buildContainerArgs(
       'CLAUDE_CODE_OAUTH_TOKEN',
       'ANTHROPIC_BASE_URL',
     ]);
-    // Prefer the long-lived OAuth token from `.env` (`claude setup-token`,
-    // valid for months) over the short-lived one in
-    // ~/.claude/.credentials.json (Claude Code's interactive session token,
-    // rotates every ~hour). The container env is frozen at spawn time and
-    // not refreshed for the life of the container; if we baked in the
-    // rotating token, every worker would 401 within hours of the next
-    // rotation. Workers in v1 didn't hit this because v1 ran a credential
-    // proxy on the host that injected `.env` per request; in v2 OneCLI is
-    // meant to fill that role, but when OneCLI isn't applied this fallback
-    // freezes the token, so we must pick the long-lived source. Falls back
-    // to the live credentials file if `.env.CLAUDE_CODE_OAUTH_TOKEN` is
-    // unset (best-effort short-lived auth beats no auth).
     const liveOauth = readLiveClaudeOauthToken();
-    const oauth = fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN ?? liveOauth;
+    const { token: oauth, source: oauthSource } = pickOauthToken({
+      envToken: fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN,
+      liveToken: liveOauth,
+    });
     const preferOauth = !!oauth;
     for (const key of [
       'ANTHROPIC_API_KEY',
@@ -603,7 +618,7 @@ async function buildContainerArgs(
     log.info('Env credential fallback applied', {
       containerName,
       preferOauth,
-      oauthSource: fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN ? '.env' : liveOauth ? 'credentials.json' : 'none',
+      oauthSource,
     });
   }
 


### PR DESCRIPTION
## Summary

Followup to PR #97 (the OAuth precedence fix). Extract the `.env`-vs-`credentials.json` picker into a small pure helper (`pickOauthToken`) and unit test the precedence directly.

Without this, a future refactor could silently flip the precedence back and reintroduce the regression where workers 401 a few hours after spawn.

## Why this is small but worth it

- The previous fix was one line (`liveOauth ?? envToken` → `envToken ?? liveOauth`).
- That single-line shape is exactly the kind of change that gets "cleaned up" in a refactor and silently flips back.
- Locking it down with 4 tiny tests (one per branch of the picker) makes the precedence load-bearing rather than opinion-based.

## Changes

- New `pickOauthToken({ envToken, liveToken }) → { token, source }` exported from `src/container-runner.ts`. Pure function, takes the inputs, returns the chosen token and which source it came from.
- Call site in `buildContainerArgs` updated to use the helper instead of inline ternary.
- New `src/container-runner.test.ts` with 4 cases: `.env` wins when both set, fallback to `credentials.json` when `.env` empty, `none` when neither, empty string treated as unset.

## Test plan

- [x] `pnpm test` — 239/239 (4 new) pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run build` clean
- [ ] CI green