### PR TITLE
docs: define NCF / NC naming in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ If you are a fresh install (you ran `git clone`, not `git pull`) and there are n
 
 Personal Claude assistant. See [README.md](README.md) for philosophy and setup. Architecture lives in `docs/`. Fleet-specific architecture and guides live in [`docs/fleet/`](docs/fleet/).
 
+> **Naming:** **NC** = upstream `qwibitai/nanoclaw`. **NCF** = NanoClaw-Fleet, this fork (`thmtz/nanoclaw-fleet`), which adds the fleet-manager features on top of NC. When something is "NCF-only" it lives in this fork; "NC" or "upstream" means it's in qwibitai's repo too.
+
 ## Fork workflow
 
 This is `thmtz/nanoclaw-fleet` — a fleet-manager fork on top of `qwibitai/nanoclaw` v2. The fleet additions live alongside the upstream code; both should follow the same rules.


### PR DESCRIPTION
## Summary

One-line addition to the top of `CLAUDE.md` defining **NC** (upstream `qwibitai/nanoclaw`) vs **NCF** (this fork, `thmtz/nanoclaw-fleet`).

## Why

The session conventions ("NCF v1 had this", "is this in upstream NC?") have been load-bearing for prior debugging conversations. Putting the abbreviation in the repo's CLAUDE.md so the next agent / contributor can decode them without re-deriving from context.

## Test plan

- [x] No code changes
- [ ] CI green