### PR TITLE
fix(neuralwatt): bypass OneCLI proxy for shim + add e2e checklist gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ Read the relevant doc before working on a subsystem. Each one is short and focus
 
 For the upstream v2 baseline (entity model, two-DB session split, channel adapters, providers, isolation), see [`docs/`](docs/).
 
+## Before declaring NCF "ready" / "go try it"
+
+**Mandatory gate** before telling the user the fleet is ready, deployment is live, or "go try it" — any time after host code, container code, credentials, OneCLI, proxy, or `.env` changes (or after a host restart):
+
+1. **Run the e2e checklist:** [`docs/fleet/guides/e2e-checklist.md`](docs/fleet/guides/e2e-checklist.md). Every section in order. The checklist starts with `./scripts/smoke.sh` which exercises both Claude and neuralwatt backends end-to-end via Discord — that one script catches most regressions.
+2. **If you find a behavior that's broken and not on the checklist:** add it to the checklist BEFORE fixing the bug. The PR that fixes the bug includes the new checklist item that would have caught it. The checklist must accumulate every behavior that has ever been found broken — that's the entire point.
+3. **If you skip the checklist** and the user finds something broken when they "go try it," that's a process failure, not a coding bug. The checklist exists so you don't have to remember which paths to exercise.
+
+If you can't run a check (e.g. the user is using Discord interactively and you can't drive it from the CLI), say so explicitly — don't claim ready on the strength of unit tests alone.
+
 ## After making changes
 
 After implementing a feature or fix, do all three before declaring done.

--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -1,0 +1,152 @@
+# NCF e2e checklist
+
+The mandatory gate before saying "NCF is ready / go try it" to the user.
+
+If you skip this checklist and the user finds NCF broken, that's a process failure. The checklist exists so you don't have to remember which paths to exercise — it remembers for you.
+
+---
+
+## When you MUST run this
+
+Before declaring NCF ready / "go try it" / "deployment is live" after **any** of:
+
+- Host code change in `src/` (built into `dist/`)
+- Container code change in `container/agent-runner/src/` (bind-mounted on next spawn)
+- `Dockerfile`, `worker-init.sh`, or `container/build.sh` change
+- Credential / OAuth / OneCLI / proxy / `.env` changes (any auth touch)
+- Host service restart
+- `pnpm install` / dependency upgrade
+- Migration to a new agent runtime (provider switch, SDK bump)
+
+If you're unsure whether your change qualifies — run it anyway. The cost is ~3 minutes. The cost of a false "ready" is your trust + the user's time.
+
+---
+
+## When you MUST update this
+
+Anytime the user reports "NCF said it was ready but X is broken" and X isn't already a checklist item, **add the test for X to this file BEFORE fixing the underlying bug.** The checklist must accumulate every behavior anyone has ever found broken; that's the entire point.
+
+Same rule applies if you find a regression yourself during exploratory work.
+
+The PR that fixes the bug should include the checklist update. No PR with a "behavior regression fix" should land without a corresponding checklist test that would have caught it.
+
+---
+
+## The checklist
+
+Run in order. Each section is a hard gate; later sections only matter if earlier ones pass.
+
+### 1. Host & infrastructure health
+
+```bash
+systemctl --user is-active nanoclaw                                # → active
+curl -sf http://127.0.0.1:10254/api/secrets -o /dev/null -w "%{http_code}\n"  # → 200 (OneCLI admin)
+curl -sf http://127.0.0.1:3003/v1/models -o /dev/null -w "%{http_code}\n"     # → 200 (shim, only if any neuralwatt worker exists)
+docker ps --filter name=nanoclaw-v2-                               # current worker containers
+ncf debug                                                           # one-shot health
+pnpm test                                                           # → all green (host)
+cd container/agent-runner && bun test && cd -                      # → all green (container)
+```
+
+If any check fails, stop and fix before proceeding.
+
+### 2. Build freshness
+
+```bash
+# dist/ must be newer than src/ — host runs from dist/index.js
+ls -lt dist/index.js src/index.ts | head -2
+# If src/ is newer: pnpm run build, then restart the host (with user permission)
+```
+
+### 3. Smoke test (canonical script)
+
+```bash
+./scripts/smoke.sh
+```
+
+This is the first-line e2e. It already covers:
+
+- `ncf inject --wait` to master, verify reply
+- Status-pin landed in `#master`
+- Worker create → message → switch backend (Claude → neuralwatt) → message via new backend → destroy → recreate (resume)
+- Reaps orphan channels on exit
+
+**If smoke is green, you've covered most of the surface.** If smoke is red, every red item gets investigated before claiming ready.
+
+### 4. Backend coverage spot-checks (when smoke can't be trusted)
+
+If smoke.sh is unavailable or you've changed something it doesn't exercise, hit each backend path manually:
+
+```bash
+# Claude path
+ncf create e2e-claude --backend claude
+# Then send a Discord message to the new channel; expect a real reply
+ncf destroy e2e-claude
+
+# Neuralwatt path (catches the OneCLI / HTTPS_PROXY interaction with the shim)
+ncf create e2e-nw --backend neuralwatt --model zai-org/GLM-5.1-FP8
+# Then send a Discord message; expect a real reply (no API retry loop, no empty replies from shim)
+ncf destroy e2e-nw
+```
+
+**Both backends matter.** The OneCLI HTTPS_PROXY breaks shim routing for neuralwatt workers if `NO_PROXY` isn't set — testing only Claude misses this entirely. (Regression baked in 2026-04-29; see commit history for `fix/neuralwatt-noproxy`.)
+
+### 5. Auth path (verify the source of credentials matches expectation)
+
+After the host restart, look at the host log for the LAST worker spawn:
+
+```bash
+tail -100 logs/nanoclaw.log | grep -iE "OneCLI gateway applied|Env credential fallback applied|oauthSource"
+```
+
+Expected with OneCLI: `OneCLI gateway applied`. With env fallback: `oauthSource=".env"` (long-lived) — never `oauthSource="credentials.json"` (short-lived) unless `.env.CLAUDE_CODE_OAUTH_TOKEN` is intentionally absent.
+
+Inside a running container:
+
+```bash
+docker exec <container> env | grep -iE "ANTHROPIC|HTTPS_PROXY|NO_PROXY"
+```
+
+For a Claude worker under OneCLI: `HTTPS_PROXY` set, `ANTHROPIC_BASE_URL` unset (or api.anthropic.com).
+For a neuralwatt worker under OneCLI: `HTTPS_PROXY` set, `ANTHROPIC_BASE_URL=http://host.docker.internal:3003/...`, `NO_PROXY` includes `host.docker.internal`.
+
+### 6. Compaction path
+
+The hard one to trigger on demand. Two options:
+
+- Wait for a real long-context turn (auto-compact, takes hours of usage)
+- Send the slash command from an admin user: `/compact` in a worker channel
+
+Expected behavior:
+
+1. User sees `⏳ Compacting context (auto)…` (PreCompact hook fires)
+2. Compaction completes silently (no fake `Context compacted (X tokens)` terminating reply)
+3. Agent's actual response continues and lands
+
+If you only see `Context compacted (X tokens)` and no real reply, the `compact_boundary` regression has reappeared.
+
+### 7. send_message + trailing text
+
+Ask a worker to do a multi-step task: "ack first, do work, then summarize when done."
+
+Expected:
+
+- Early `send_message` ack lands in chat
+- Substantive end-of-turn summary lands in chat (auto-suppress regression check)
+- Internal scratchpad wrapped in `<internal>...</internal>` does NOT land
+
+### 8. Master MCP tool surface
+
+In a master Discord conversation:
+
+- "list workers" → reply lists fleet
+- "create a worker named test-mcp" → worker spawned
+- "switch test-mcp to neuralwatt with kimi-k2.6-fast" → backend swapped, container restarted, replies via new backend
+- "cleanup workers, dry run" → reports orphan channels / containers / workers without acting
+- "destroy test-mcp" → archived, channel deleted
+
+---
+
+## "What changed → what to test" routing
+
+This stays in [`testing.md`](testing.md). The checklist above is the COMPREHENSIVE pass; testing.md tells you what's most likely affected by a specific code change. Run the targeted subset during dev, then the full checklist before declaring ready.

--- a/src/providers/neuralwatt.ts
+++ b/src/providers/neuralwatt.ts
@@ -46,7 +46,19 @@ registerProviderContainerConfig('neuralwatt', (ctx) => {
   const explicitBase = block.base_url ?? ctx.hostEnv.NW_SHIM_URL ?? ctx.hostEnv.ANTHROPIC_BASE_URL;
   const baseUrl = explicitBase ?? `${DEFAULT_BASE_URL}/w/${ctx.agentGroupFolder}`;
 
-  const env: Record<string, string> = { ANTHROPIC_BASE_URL: baseUrl };
+  // NO_PROXY for the host shim. When OneCLI is active the container has
+  // HTTPS_PROXY pointing at the OneCLI gateway, which intercepts ALL
+  // outbound HTTPS — including the shim call to host.docker.internal:3003.
+  // OneCLI returns "empty reply" for the un-allowlisted destination and
+  // the SDK retries forever. Bypassing the proxy for host.docker.internal
+  // (and loopback) lets the SDK reach the shim directly. Public API calls
+  // (api.anthropic.com etc.) still go through OneCLI for credential
+  // injection. Without OneCLI active these vars are no-ops.
+  const env: Record<string, string> = {
+    ANTHROPIC_BASE_URL: baseUrl,
+    NO_PROXY: 'host.docker.internal,localhost,127.0.0.1',
+    no_proxy: 'host.docker.internal,localhost,127.0.0.1',
+  };
   if (block.model) env.ANTHROPIC_MODEL = block.model;
   return { env };
 });


### PR DESCRIPTION
## Summary

Two changes that ship together because the checklist is the gate that should have caught the bug.

### 1. fix: NO_PROXY for neuralwatt workers

`src/providers/neuralwatt.ts` now contributes `NO_PROXY=host.docker.internal,localhost,127.0.0.1` to the container env. Without this, the container's `HTTPS_PROXY` (set by OneCLI) intercepts the call to the local shim at `host.docker.internal:3003`, OneCLI rejects with "empty reply", and the SDK retries forever (\`API retry retryable: true\` in poll-loop logs). Public-API calls (api.anthropic.com, github.com) still route through OneCLI for credential injection.

Discovered when \`qwen-lmcache\` wouldn't respond after activating OneCLI today.

### 2. docs: e2e checklist as a mandatory gate

\`docs/fleet/guides/e2e-checklist.md\` codifies what to run before declaring NCF "ready" / "go try it":

- **When you MUST run it:** host/container/credential changes, restarts
- **When you MUST update it:** every behavior anyone has found broken accumulates here, BEFORE the bug is fixed
- **The checklist itself:** \`smoke.sh\` as the canonical first step (already exercises both backends end-to-end via Discord), then explicit Claude AND neuralwatt spot-checks, auth path verification, compaction, send_message + trailing text, master MCP tools

Wired into \`CLAUDE.md\` as the rule: if you skip the checklist and the user finds something broken when they "go try it," that's a process failure.

The neuralwatt path is now an explicit checklist item — testing only Claude (what I did this morning) misses the OneCLI/proxy interaction that this PR fixes.

## Test plan

- [x] \`pnpm test\` — 239/239 host tests pass
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`./scripts/smoke.sh\` — all green, including the post-switch neuralwatt reply (the previously-broken path)
- [ ] CI green