### PR TITLE
fix(worker-init): prefer SSH over HTTPS clone when key is available

### DIFF
--- a/container/worker-init.sh
+++ b/container/worker-init.sh
@@ -76,6 +76,16 @@ if [ "$REPO_COUNT" -gt 0 ] 2>/dev/null; then
     GITHUB_TOKEN=$(cat "$NANOCLAW_GITHUB_TOKEN_PATH")
   fi
 
+  # Trust OneCLI's CA when its proxy is intercepting our HTTPS clones.
+  # OneCLI mounts a combined bundle (system CAs + its self-signed cert) at
+  # SSL_CERT_FILE for node/deno, but git uses its own bundle and ignores
+  # SSL_CERT_FILE — point GIT_SSL_CAINFO at the same file so HTTPS clones
+  # to github.com (and anywhere else proxied through OneCLI) verify
+  # cleanly. No-op when OneCLI isn't applied (SSL_CERT_FILE unset).
+  if [ -n "$SSL_CERT_FILE" ] && [ -f "$SSL_CERT_FILE" ]; then
+    export GIT_SSL_CAINFO="$SSL_CERT_FILE"
+  fi
+
   cloned=0
   skipped=0
   for i in $(seq 0 $((REPO_COUNT - 1))); do
@@ -92,9 +102,20 @@ if [ "$REPO_COUNT" -gt 0 ] 2>/dev/null; then
       continue
     fi
 
-    # Rewrite git@github.com:org/repo.git → https://<token>@github.com/org/repo.git
+    # Prefer SSH when an SSH key is available (set up earlier from
+    # /workspace/extra/host-ssh). Only rewrite git@github.com:org/repo.git
+    # → https://<token>@github.com/org/repo.git when SSH ISN'T usable
+    # (no key, or fallback environment).
+    #
+    # Why: under OneCLI the container has HTTPS_PROXY pointing at the
+    # OneCLI gateway, which terminates HTTPS connections (so it can
+    # inject vault credentials). But the URL-embedded basic-auth token
+    # (`https://<token>@github.com/...`) doesn't survive the proxy
+    # gracefully — git ends up prompting for a password. SSH on port 22
+    # bypasses HTTPS_PROXY entirely. Falls back to the HTTPS rewrite
+    # only when SSH is genuinely unavailable.
     CLONE_URL="$URL"
-    if [ -n "$GITHUB_TOKEN" ] && [[ "$URL" == git@github.com:* ]]; then
+    if [ ! -f ~/.ssh/id_ed25519 ] && [ -n "$GITHUB_TOKEN" ] && [[ "$URL" == git@github.com:* ]]; then
       REPO_PATH="${URL#git@github.com:}"
       REPO_PATH="${REPO_PATH%.git}"
       CLONE_URL="https://${GITHUB_TOKEN}@github.com/${REPO_PATH}.git"

--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -91,6 +91,20 @@ ncf destroy e2e-nw
 
 **Both backends matter.** The OneCLI HTTPS_PROXY breaks shim routing for neuralwatt workers if `NO_PROXY` isn't set — testing only Claude misses this entirely. (Regression baked in 2026-04-29; see commit history for `fix/neuralwatt-noproxy`.)
 
+### 4b. Worker init clones (catches OneCLI / proxy / cert breakage)
+
+The lifecycle test verifies "worker can reply" but not "worker-init.sh exited cleanly with all repos cloned." Several worker behaviors depend on cloned repos (the agent walking `/workspace/<repo>/` to answer "look at this issue"). When OneCLI's HTTPS_PROXY intercepts the HTTPS clones and git doesn't trust the proxy's CA, clones silently fail — the worker still spawns, still replies, but every "look at the inference_frontend repo" task hangs while the agent tries to clone on demand from inside the container.
+
+After creating any fresh worker (one whose workspace dir is brand new, not a resume from archive), check the init log:
+
+```bash
+ncf logs <worker> | grep -E "WARNING.*clone failed|repos \(cloned="
+```
+
+Expected: a single `repos (cloned=N skipped=M)` line, no `WARNING: clone failed` lines. If clone failed lines appear, capture the `fatal:` reason (`server certificate verification failed`, `host key verification failed`, `Permission denied`, etc.) — that's the actual blocker.
+
+(Regression baked in 2026-04-29 when OneCLI was activated; see `fix/git-trust-onecli-ca`. The proxy intercepts HTTPS clones but git uses its own CA bundle. `GIT_SSL_CAINFO` is now set in `worker-init.sh` when `SSL_CERT_FILE` is present.)
+
 ### 5. Auth path (verify the source of credentials matches expectation)
 
 After the host restart, look at the host log for the LAST worker spawn:


### PR DESCRIPTION
## Summary

Stop rewriting `git@github.com:` URLs to `https://<token>@github.com/` when an SSH key is available — SSH on port 22 bypasses `HTTPS_PROXY` entirely, avoiding the OneCLI-proxy interaction that was breaking clones.

## Why

User reported a freshly-created worker saying \"Repos aren't cloned yet on this worker\" and hanging on \"look at this issue\" tasks. \`ncf logs\` showed every repo clone failing:

\`\`\`
fatal: unable to access 'https://github.com/.../...': server certificate verification failed. CAfile: none CRLfile: none
\`\`\`

3-deep stack:

1. \`worker-init.sh\` rewrites SSH URLs → HTTPS whenever \`NANOCLAW_GITHUB_TOKEN\` is set, even when SSH was available
2. Under OneCLI, container has \`HTTPS_PROXY\` pointing at OneCLI's gateway — every HTTPS call goes through it
3. Git uses its own CA bundle and ignores \`SSL_CERT_FILE\` (which node/deno honor), so OneCLI's self-signed cert fails verification

## Fix

Only rewrite to HTTPS when SSH is genuinely unavailable (\`~/.ssh/id_ed25519\` missing). When the SSH key was set up from \`/workspace/extra/host-ssh\` (the default for installs with a host SSH key), use SSH directly. Falls back to HTTPS rewrite cleanly when no key is present (the original use case).

Also kept a \`GIT_SSL_CAINFO=$SSL_CERT_FILE\` export so that when someone DOES rely on the HTTPS+token path under OneCLI, git trusts the proxy's CA.

## Test plan

- [x] Verified inside running container: \`git ls-remote git@github.com:...\` succeeds (returns HEAD sha) — SSH path bypasses proxy
- [x] Verified the HTTPS path WITH \`GIT_SSL_CAINFO\` set passes cert verification (only the URL token issue remains, which is moot once we use SSH)
- [x] \`pnpm test\` — 239/239 host tests pass
- [x] \`pnpm exec tsc --noEmit\` clean, \`pnpm run build\` clean
- [ ] CI green
- [ ] Live verification on \`better\` after restart (next inbound message will respawn the container, which will run worker-init.sh from the bind-mount with the new logic)

## Checklist update

Section 4b added to \`docs/fleet/guides/e2e-checklist.md\` — \"worker-init clones succeed.\" \`smoke.sh\` and the existing lifecycle test verify \"worker can reply\" but not \"worker-init.sh exited cleanly with all repos cloned.\" That's what let this regression slip past — worker spawned, answered \"hi,\" we declared green; every repo task hung. Section 4b grep's \`ncf logs\` for \`WARNING: clone failed\`.