### PR TITLE
feat(container): generic container_credentials in personal config.json

### DIFF
--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -105,6 +105,18 @@ Expected: a single `repos (cloned=N skipped=M)` line, no `WARNING: clone failed`
 
 (Regression baked in 2026-04-29 when OneCLI was activated; see `fix/git-trust-onecli-ca`. The proxy intercepts HTTPS clones but git uses its own CA bundle. `GIT_SSL_CAINFO` is now set in `worker-init.sh` when `SSL_CERT_FILE` is present.)
 
+### 4c. `container_credentials` injection (env vars from `~/.config/nanoclaw/config.json`)
+
+If the user has any `container_credentials` entries in `~/.config/nanoclaw/config.json` (file→env injection — see `docs/fleet/guides/personal-config.md`), every spawned container should have those env vars set. Easy to forget when adding new tokens — the doc says they're injected, but the only way to verify is to look inside a container.
+
+```bash
+# After any new container_credentials entry is added, restart the host
+# and spawn a worker. Then:
+docker exec <container> env | grep -E "BETTERSTACK|FIREWORKS|TOGETHER|SYNTHETIC|<your_new_var>"
+```
+
+Each entry's env var should be present. Missing = either the source file at `path` doesn't exist (silent skip — check `ls <path>`) or the host needs a restart to pick up the config change.
+
 ### 5. Auth path (verify the source of credentials matches expectation)
 
 After the host restart, look at the host log for the LAST worker spawn:

--- a/docs/fleet/guides/personal-config.md
+++ b/docs/fleet/guides/personal-config.md
@@ -72,21 +72,19 @@ The composer inlines each file as a separate fragment. Behaviour is identical to
     }
   ],
   "tools": ["uv tool install /workspace/group/your-tool --force"],
-  "mounts": [
-    { "hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true }
-  ],
+  "mounts": [{ "hostPath": "~/.ssh", "containerPath": "host-ssh", "readonly": true }],
   "ports": ["8080:8080"],
   "skills_repo": "your-skills-repo-name"
 }
 ```
 
-| Field | Purpose |
-|-|-|
-| `repos` | Cloned on first boot. SSH URLs rewritten to HTTPS using `NANOCLAW_GITHUB_TOKEN` if available. `postClone` runs from the cloned dir. |
-| `tools` | Shell commands run during init. Idempotent. |
-| `mounts` | Host paths mounted into the container. Validated against the allowlist. |
-| `ports` | Docker port mappings (`host:container`). |
-| `skills_repo` | Name of one of the cloned repos whose `.claude/skills/` is symlinked into the agent. |
+| Field         | Purpose                                                                                                                             |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `repos`       | Cloned on first boot. SSH URLs rewritten to HTTPS using `NANOCLAW_GITHUB_TOKEN` if available. `postClone` runs from the cloned dir. |
+| `tools`       | Shell commands run during init. Idempotent.                                                                                         |
+| `mounts`      | Host paths mounted into the container. Validated against the allowlist.                                                             |
+| `ports`       | Docker port mappings (`host:container`).                                                                                            |
+| `skills_repo` | Name of one of the cloned repos whose `.claude/skills/` is symlinked into the agent.                                                |
 
 Profile changes take effect on the next worker spawn. Existing workers re-apply the profile on resume.
 
@@ -99,8 +97,8 @@ For full schema and boot details, see [architecture/worker-profile.md](../archit
 ```json
 {
   "allowedRoots": [
-    {"path": "~/.ssh", "allowReadWrite": false, "description": "SSH keys (read-only)"},
-    {"path": "~/.config/gpuctl", "allowReadWrite": true, "description": "gpuctl CLI config"}
+    { "path": "~/.ssh", "allowReadWrite": false, "description": "SSH keys (read-only)" },
+    { "path": "~/.config/gpuctl", "allowReadWrite": true, "description": "gpuctl CLI config" }
   ],
   "blockedPatterns": []
 }
@@ -131,14 +129,14 @@ USER node
 
 ## Where to put what
 
-| Lives where | Why |
-|-|-|
-| Source code, container image base, default skills, MCP tools | Repo |
-| Repo-shared instructions (`instructions/`) | Repo |
-| Channel adapters (skills) | Repo (per `channels` skill branch) |
-| Personal instructions, worker profile, mount allowlist | `~/.config/nanoclaw/` |
-| Personal Docker layers | `~/.config/nanoclaw/Dockerfile` |
-| Tokens, secrets, paths | `.env` (in repo, gitignored) and OneCLI vault |
+| Lives where                                                  | Why                                           |
+| ------------------------------------------------------------ | --------------------------------------------- |
+| Source code, container image base, default skills, MCP tools | Repo                                          |
+| Repo-shared instructions (`instructions/`)                   | Repo                                          |
+| Channel adapters (skills)                                    | Repo (per `channels` skill branch)            |
+| Personal instructions, worker profile, mount allowlist       | `~/.config/nanoclaw/`                         |
+| Personal Docker layers                                       | `~/.config/nanoclaw/Dockerfile`               |
+| Tokens, secrets, paths                                       | `.env` (in repo, gitignored) and OneCLI vault |
 
 ## Getting started
 
@@ -155,6 +153,30 @@ Edit `worker-profiles/default.json` to point at your repos. Edit `instructions/g
 ./container/build.sh                # only if you changed the Dockerfile
 systemctl --user restart nanoclaw   # picks up instruction and profile changes
 ```
+
+## Container credentials (env vars from files)
+
+`~/.config/nanoclaw/config.json` accepts a `container_credentials` array that injects env vars into every spawned worker by reading values from files at spawn time. Use this for tokens the agent's tooling reads from the environment (e.g. CLIs that look at `BETTERSTACK_API_TOKEN`, `FIREWORKS_API_KEY`).
+
+```json
+{
+  "include_files": ["~/.claude/CLAUDE.md"],
+  "container_credentials": [
+    { "env": "BETTERSTACK_API_TOKEN", "path": "~/.config/betterstack/api_key" },
+    { "env": "FIREWORKS_API_KEY", "path": "~/.config/fireworks/api_key" }
+  ]
+}
+```
+
+Behaviour:
+
+- Each entry's `path` is read on every container spawn — rotated tokens take effect on next worker restart, no host restart needed.
+- Missing files skip silently (entries are opt-in).
+- Empty / whitespace-only contents skip too (avoids injecting a blank `KEY=` that consumers treat as "set").
+- `~/` expansion is supported in `path`.
+- The token value never lands on disk inside the container — only in the process env.
+
+This is the generic version of the older `NANOCLAW_GITHUB_TOKEN_PATH` env knob — that still works for backwards compatibility; new credentials go in `container_credentials`.
 
 ## See also
 

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,12 +1,37 @@
 /**
- * Unit tests for container-runner helpers. Currently only covers
- * `pickOauthToken` — the OAuth precedence that prevents the regression
- * where workers 401 hours after spawn because they were baked with a
- * since-rotated short-lived token instead of the long-lived `.env` one.
+ * Unit tests for container-runner helpers.
  */
-import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
-import { pickOauthToken } from './container-runner.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { pickOauthToken, readContainerCredentials } from './container-runner.js';
+
+// readContainerCredentials reads `~/.config/nanoclaw/config.json`. Patch
+// HOME to a temp dir so tests don't touch the real user config.
+const TEST_HOME = '/tmp/nanoclaw-container-runner-test';
+const CONFIG_DIR = path.join(TEST_HOME, '.config', 'nanoclaw');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+let originalHome: string | undefined;
+
+function setConfig(content: unknown): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(content));
+}
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  process.env.HOME = TEST_HOME;
+  if (fs.existsSync(TEST_HOME)) fs.rmSync(TEST_HOME, { recursive: true });
+  fs.mkdirSync(TEST_HOME, { recursive: true });
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  if (fs.existsSync(TEST_HOME)) fs.rmSync(TEST_HOME, { recursive: true });
+});
 
 describe('pickOauthToken', () => {
   it('prefers .env over credentials.json when both are set', () => {
@@ -35,5 +60,42 @@ describe('pickOauthToken', () => {
       token: 'short-lived-live',
       source: 'credentials.json',
     });
+  });
+});
+
+describe('readContainerCredentials', () => {
+  it('returns [] when config.json is missing', () => {
+    expect(readContainerCredentials()).toEqual([]);
+  });
+
+  it('returns [] when container_credentials field is absent', () => {
+    setConfig({ include_files: ['~/foo.md'] });
+    expect(readContainerCredentials()).toEqual([]);
+  });
+
+  it('returns the configured entries', () => {
+    setConfig({
+      container_credentials: [
+        { env: 'BETTERSTACK_API_TOKEN', path: '~/.config/betterstack/api_key' },
+        { env: 'FIREWORKS_API_KEY', path: '/abs/path/fireworks' },
+      ],
+    });
+    expect(readContainerCredentials()).toEqual([
+      { env: 'BETTERSTACK_API_TOKEN', path: '~/.config/betterstack/api_key' },
+      { env: 'FIREWORKS_API_KEY', path: '/abs/path/fireworks' },
+    ]);
+  });
+
+  it('skips entries missing env or path (does not throw)', () => {
+    setConfig({
+      container_credentials: [{ env: 'GOOD', path: '/x' }, { env: 'no_path' }, { path: '/no-env' }, null],
+    });
+    expect(readContainerCredentials()).toEqual([{ env: 'GOOD', path: '/x' }]);
+  });
+
+  it('returns [] on malformed JSON without throwing', () => {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, '{not json');
+    expect(readContainerCredentials()).toEqual([]);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -99,6 +99,41 @@ export function pickOauthToken(input: { envToken: string | undefined; liveToken:
   return { token: undefined, source: 'none' };
 }
 
+/**
+ * Read the user's `container_credentials` list from
+ * `~/.config/nanoclaw/config.json`. Each entry maps a file path to an env
+ * var name that gets injected into every spawned container.
+ *
+ * Returns `[]` when the config file is missing, malformed, or the field
+ * is absent — credential injection is opt-in. Bad entries (missing
+ * fields) are skipped with a warning rather than throwing.
+ *
+ * Exported only for tests — read at every spawn so rotations + new
+ * entries take effect without a host restart.
+ */
+export function readContainerCredentials(): Array<{ env: string; path: string }> {
+  const cfgPath = path.join(os.homedir(), '.config', 'nanoclaw', 'config.json');
+  if (!fs.existsSync(cfgPath)) return [];
+  try {
+    const raw = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as {
+      container_credentials?: Array<{ env?: string; path?: string }>;
+    };
+    const list = raw.container_credentials ?? [];
+    const out: Array<{ env: string; path: string }> = [];
+    for (const entry of list) {
+      if (!entry?.env || !entry?.path) {
+        log.warn('container_credentials entry missing env or path — skipping', { entry });
+        continue;
+      }
+      out.push({ env: entry.env, path: entry.path });
+    }
+    return out;
+  } catch (err) {
+    log.warn('container_credentials parse failed', { cfgPath, err: String(err) });
+    return [];
+  }
+}
+
 /** Active containers tracked by session ID. */
 const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
 
@@ -551,6 +586,30 @@ async function buildContainerArgs(
       }
     } catch (err) {
       log.warn('Could not read NANOCLAW_GITHUB_TOKEN_PATH', { ghPath, err: String(err) });
+    }
+  }
+
+  // Personal `container_credentials`: file→env injection for tokens the
+  // user wants every container to have. Generic version of the
+  // NANOCLAW_GITHUB_TOKEN_PATH special-case above; lets users add tokens
+  // (BETTERSTACK_API_TOKEN, FIREWORKS_API_KEY, …) by editing their
+  // `~/.config/nanoclaw/config.json` instead of adding code here.
+  //
+  // Schema:
+  //   { "container_credentials": [ { "env": "NAME", "path": "~/.config/.../api_key" }, ... ] }
+  //
+  // Each entry is read at spawn time so rotated values take effect on
+  // next container restart. Missing files skip silently. Empty file
+  // contents (whitespace-only) skip too — avoids injecting a blank
+  // env var that the consuming tool would treat as "set."
+  for (const cred of readContainerCredentials()) {
+    const resolved = cred.path.startsWith('~/') ? path.join(process.env.HOME ?? '', cred.path.slice(2)) : cred.path;
+    if (!fs.existsSync(resolved)) continue;
+    try {
+      const value = fs.readFileSync(resolved, 'utf-8').trim();
+      if (value) args.push('-e', `${cred.env}=${value}`);
+    } catch (err) {
+      log.warn('container_credentials read failed', { env: cred.env, path: resolved, err: String(err) });
     }
   }
 


### PR DESCRIPTION
## Summary

Add a `container_credentials` field to `~/.config/nanoclaw/config.json` so users can inject env-var credentials into every spawned worker without touching the repo:

\`\`\`json
{
  "container_credentials": [
    { "env": "BETTERSTACK_API_TOKEN", "path": "~/.config/betterstack/api_key" },
    { "env": "FIREWORKS_API_KEY",     "path": "~/.config/fireworks/api_key" },
    { "env": "TOGETHER_API_KEY",      "path": "~/.config/together_ai/api_key" },
    { "env": "SYNTHETIC_API_KEY",     "path": "~/.config/synthetic/api_key" }
  ]
}
\`\`\`

Generic version of the existing \`NANOCLAW_GITHUB_TOKEN_PATH\` special case. That still works for backwards compatibility; new credentials go in \`container_credentials\`.

## Why

User reported: a worker said \"No BETTERSTACK_API_TOKEN in this container, so a real dry-run isn't possible.\" Same shape applies to \`FIREWORKS_API_KEY\`, \`TOGETHER_API_KEY\`, \`SYNTHETIC_API_KEY\` — these are documented in \`personal-master.md\` as \"injected as env vars on every container spawn,\" but the implementation never landed. This PR makes the doc true and avoids needing a code edit per new token.

## Behaviour

- Read every spawn — rotated tokens take effect on next worker restart, no host restart needed
- Missing files skip silently (entries are opt-in)
- Empty / whitespace-only contents skip too (avoids injecting \`KEY=\` that consumers treat as set)
- \`~/\` path expansion supported
- Token never lands on disk inside the container, only in \`process.env\`

## Tests

5 new vitest cases for \`readContainerCredentials\`:

- Returns \`[]\` when config is missing
- Returns \`[]\` when \`container_credentials\` field is absent
- Returns valid entries
- Skips malformed entries (missing \`env\` or \`path\`, \`null\`)
- Returns \`[]\` on malformed JSON without throwing

Existing \`pickOauthToken\` tests untouched. 244/244 host suite pass.

## Doc updates

- \`docs/fleet/guides/personal-config.md\` — new \"Container credentials\" section with example + behaviour
- \`docs/fleet/guides/e2e-checklist.md\` — new section 4c verifying documented env vars actually land in spawned containers (this is the gap that let the BETTERSTACK regression slip past)