### PR TITLE
fix(formatter): warn on salvage-path output to catch hallucinated meta-claims

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -170,7 +170,53 @@ describe('poll loop integration', () => {
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
-    expect(JSON.parse(out[0].content).text).toBe('Acknowledged via send_message.');
+    const surfaced = JSON.parse(out[0].content).text;
+    expect(surfaced).toContain('Acknowledged via send_message.');
+    // The salvage path now appends a warning suffix so the user knows the
+    // content came through the safety net (post-compaction confusion has
+    // produced wrapped meta-claims that the salvage was surfacing as if
+    // they were deliberate replies). Suffix triggers on `salvaged === true`.
+    expect(surfaced).toMatch(/scratchpad recovery/i);
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('warns on post-compaction meta-claim hallucination (salvage suffix on "Done — answered X")', async () => {
+    // Reproduces the 2026-04-30 regression where two workers (nwme,
+    // better) produced wrapped meta-claims like
+    //   <internal>Done — answered the BetterStack best practice question
+    //   and surfaced the open PR.</internal>
+    // The salvage surfaced this verbatim, the user read it as a deliberate
+    // reply, and only when they pushed back did the agent produce the real
+    // answer. The suffix lets the user catch the hallucination immediately
+    // and re-ask without first being misled.
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'Is this email correct?' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
+
+    const provider = new MockProvider(
+      {},
+      () => '<internal>Done — answered the BetterStack best practice question and surfaced the open PR.</internal>',
+      [], // critically: no send_message tool_use — salvage triggers
+    );
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 1500);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    const surfaced = JSON.parse(out[0].content).text;
+    // Original meta-claim is still surfaced — we don't drop content, we
+    // bias toward noise.
+    expect(surfaced).toContain('Done — answered the BetterStack best practice question');
+    // But the warning suffix flags it as recovered scratchpad.
+    expect(surfaced).toMatch(/scratchpad recovery/i);
+    expect(surfaced).toMatch(/ask again/i);
 
     await loopPromise.catch(() => {});
   });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -458,6 +458,18 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * the agent emits a stand-alone `<internal>` block with no send_message —
  * we'd otherwise go silent.
  */
+/**
+ * Suffix appended to salvage-path output. The salvage path surfaces an
+ * agent's wrapped-only output when no `send_message` ran — it prevents
+ * silence, but the recovered content has often been a meta-claim like
+ * "Done — answered the question" with no actual answer (post-compaction
+ * confusion bug, observed 2026-04-30 across multiple workers). Without a
+ * suffix the user reads the meta-claim as a deliberate reply and trusts
+ * the agent. With a suffix the user knows to verify.
+ */
+const SALVAGE_WARNING_SUFFIX =
+  '⚠️ _scratchpad recovery — this came from the agent\'s internal monologue, not a deliberate `send_message`. If it reads like a vague claim ("done", "answered", "flagged") without the actual content, ask again._';
+
 function dispatchResultText(text: string, routing: RoutingContext, opts: { sendMessageToolUseCount: number }): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
 
@@ -496,10 +508,22 @@ function dispatchResultText(text: string, routing: RoutingContext, opts: { sendM
   // silently — silence reads as "agent broken"; even a weird-looking
   // ack ("Acknowledged via send_message.") signals the user can ask
   // for the substantive answer.
+  //
+  // Append a warning suffix when this fires. We've seen agents emit
+  // wrapped meta-claims post-compaction ("Done — answered the X
+  // question") that the salvage surfaces verbatim; without the suffix
+  // the user reads it as a deliberate reply and trusts the claim. The
+  // suffix lets them recover quickly: noisy > misleading. User
+  // preference per discussion 2026-04-30: "bias towards more noisy
+  // output instead of overly quiet."
   let scratchpad = stripped;
+  let salvaged = false;
   if (!stripped && opts.sendMessageToolUseCount === 0) {
     const unwrapped = rawScratchpad.replace(/<\/?internal>/g, '').trim();
-    if (unwrapped) scratchpad = unwrapped;
+    if (unwrapped) {
+      scratchpad = unwrapped;
+      salvaged = true;
+    }
   }
 
   // Single-destination shortcut: the agent wrote plain text — send to
@@ -511,6 +535,7 @@ function dispatchResultText(text: string, routing: RoutingContext, opts: { sendM
   // Discord replies back to the CLI transport instead of Discord, and
   // the real user got silence.
   if (sent === 0 && scratchpad) {
+    const surfaced = salvaged ? `${scratchpad}\n\n${SALVAGE_WARNING_SUFFIX}` : scratchpad;
     const sessionRouting = getSessionRouting();
     const channelType = sessionRouting.channel_type ?? routing.channelType;
     const platformId = sessionRouting.platform_id ?? routing.platformId;
@@ -523,13 +548,13 @@ function dispatchResultText(text: string, routing: RoutingContext, opts: { sendM
         platform_id: platformId,
         channel_type: channelType,
         thread_id: threadId,
-        content: JSON.stringify({ text: scratchpad }),
+        content: JSON.stringify({ text: surfaced }),
       });
       return;
     }
     const all = getAllDestinations();
     if (all.length === 1) {
-      sendToDestination(all[0], scratchpad, routing);
+      sendToDestination(all[0], surfaced, routing);
       return;
     }
   }


### PR DESCRIPTION
## Summary

Append a warning suffix to salvage-path output so users can spot hallucinated post-compaction meta-claims like \"Done — answered the BetterStack best practice question and surfaced the open PR.\"

## Why

Across two workers today (\`nwme\`, \`better\`), the same pattern: heavy autonomous tool-use turn → context fills → auto-compact mid-turn → post-compaction the agent's compacted view describes its planned reply as if already done → final emit is a wrapped meta-claim with no real content → salvage unwraps and surfaces the meta-claim verbatim → user reads it as a deliberate reply, looks for the answer, finds none, pushes back.

The salvage path was introduced (PR #99) to prevent total silence when an agent emits only \`<internal>...</internal>\`. It does that, but the recovered content has now been observed to be misleading meta-claims more often than legitimate scratchpad. Without context, the user trusts the surfaced text and gets gaslit.

## Behavior

When the salvage path triggers (wrapped-only output AND no \`send_message\` ran this turn), append:

\`\`\`
⚠️ _scratchpad recovery — this came from the agent's internal monologue, not a deliberate \`send_message\`. If it reads like a vague claim (\"done\", \"answered\", \"flagged\") without the actual content, ask again._
\`\`\`

Per user preference (\"bias towards more noisy output instead of overly quiet\"), we **don't drop** the content — we surface it AS-IS plus the suffix. The user gets the noise but knows it might be wrong.

## Tests

- Existing \`salvages internal-only output\` test now also asserts the suffix is present
- New test reproduces the meta-claim shape exactly (\"Done — answered the BetterStack best practice question\") and asserts both the content surfaces AND the suffix lands

60/60 bun tests pass; host vitest unaffected.

## Followups not in this PR

- **Root cause**: the post-compaction summary can describe planned work as if completed. Worth investigating at the prompt / SDK level — maybe a hint after compact_boundary like \"if you described what you 'did' in past tense and the action involved messaging the user, send_message the actual content now.\"
- **Detection**: an explicit log line when salvage fires would help debug from logs without exec'ing into containers.
- The \`/review-and-submit\` skill not being visible to workers — separate investigation, will post findings shortly.