### PR TITLE
fix(worker-init): support two skills_repo layouts + skip broken symlinks

### DIFF
--- a/container/worker-init.sh
+++ b/container/worker-init.sh
@@ -135,12 +135,27 @@ if [ "$REPO_COUNT" -gt 0 ] 2>/dev/null; then
 fi
 
 # ── Install skills from skills_repo ─────────────────────────────────────
+# Two layouts are supported:
+#   1. <repo>/.claude/skills/<name>/SKILL.md  — the "Claude Code conventional"
+#      layout where a repo packages skills under a `.claude/skills/` subtree
+#   2. <repo>/<name>/SKILL.md                 — repo where each top-level
+#      directory IS a skill (e.g. neuralwatt-claude-skills). Detection: a
+#      subdir contains a SKILL.md file.
+# Broken symlinks (a symlink whose target isn't visible inside the
+# container — happens when the host has `~/.claude/skills/<x>` symlinked
+# at a path the container can't see) are skipped silently.
 SKILLS_REPO=$(bun -e "const p=$PROFILE_JSON; process.stdout.write(p.skills_repo ?? '');" 2>/dev/null)
-if [ -n "$SKILLS_REPO" ] && [ -d "$WORKSPACE/$SKILLS_REPO/.claude/skills" ]; then
+if [ -n "$SKILLS_REPO" ] && [ -d "$WORKSPACE/$SKILLS_REPO" ]; then
   mkdir -p "$SKILLS_DIR"
+  if [ -d "$WORKSPACE/$SKILLS_REPO/.claude/skills" ]; then
+    SKILLS_SRC="$WORKSPACE/$SKILLS_REPO/.claude/skills"
+  else
+    SKILLS_SRC="$WORKSPACE/$SKILLS_REPO"
+  fi
   count=0
-  for sd in "$WORKSPACE/$SKILLS_REPO/.claude/skills"/*/; do
-    [ -d "$sd" ] || continue
+  for sd in "$SKILLS_SRC"/*/; do
+    [ -d "$sd" ] || continue                       # skip broken symlinks
+    [ -f "$sd/SKILL.md" ] || continue              # skill-shaped only
     sname=$(basename "$sd")
     [[ "$sname" == .* ]] && continue
     if [ ! -e "$SKILLS_DIR/$sname" ]; then
@@ -152,11 +167,17 @@ if [ -n "$SKILLS_REPO" ] && [ -d "$WORKSPACE/$SKILLS_REPO/.claude/skills" ]; the
 fi
 
 # ── Host-skills mount (optional) ────────────────────────────────────────
+# Same broken-symlink guard as above — host-skills mounts `~/.claude/skills/`
+# from the host, but if any of those entries are themselves symlinks
+# pointing OUTSIDE the mount (a common pattern: `~/.claude/skills/foo`
+# is a symlink into `~/git/team-skills/foo/`), they appear as broken
+# symlinks inside the container. The `[ -d "$sd" ]` test fails for
+# broken symlinks, so they're skipped.
 if [ -d "/workspace/extra/host-skills" ]; then
   mkdir -p "$SKILLS_DIR"
   count=0
   for sd in /workspace/extra/host-skills/*/; do
-    [ -d "$sd" ] || continue
+    [ -d "$sd" ] || continue                       # skip broken symlinks
     sname=$(basename "$sd")
     [[ "$sname" == .* ]] && continue
     if [ ! -e "$SKILLS_DIR/$sname" ]; then

--- a/docs/fleet/architecture/worker-profile.md
+++ b/docs/fleet/architecture/worker-profile.md
@@ -20,19 +20,19 @@ interface WorkerProfile {
   mounts?: Array<{ hostPath: string; containerPath: string; readonly?: boolean }>;
   ports?: string[];
   skills_repo?: string;
-  init_script?: string;        // alternative init script name
-  claude_md?: string;          // alternative CLAUDE.md template
+  init_script?: string; // alternative init script name
+  claude_md?: string; // alternative CLAUDE.md template
 }
 ```
 
-| Field | Purpose |
-|-|-|
-| `repos` | Cloned on first boot. SSH URLs are rewritten to HTTPS using `NANOCLAW_GITHUB_TOKEN` if available. `postClone` runs after each clone. |
-| `tools` | Shell commands run during init (e.g. `uv tool install /workspace/group/your-tool --force`). Idempotent. |
-| `mounts` | Host paths bind-mounted into the container. Validated against `~/.config/nanoclaw/mount-allowlist.json`. |
-| `ports` | Port mappings (`8080:8080`) passed to docker run. |
-| `skills_repo` | Name of one of the cloned repos whose `.claude/skills/` should be symlinked into the agent's skill path. |
-| `env` | Extra env vars merged into the container spawn (per-worker, on top of provider env). |
+| Field         | Purpose                                                                                                                                                                                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repos`       | Cloned on first boot. SSH URLs are rewritten to HTTPS using `NANOCLAW_GITHUB_TOKEN` if available. `postClone` runs after each clone.                                                                                                                                                     |
+| `tools`       | Shell commands run during init (e.g. `uv tool install /workspace/group/your-tool --force`). Idempotent.                                                                                                                                                                                  |
+| `mounts`      | Host paths bind-mounted into the container. Validated against `~/.config/nanoclaw/mount-allowlist.json`.                                                                                                                                                                                 |
+| `ports`       | Port mappings (`8080:8080`) passed to docker run.                                                                                                                                                                                                                                        |
+| `skills_repo` | Name of one of the cloned repos whose skills should be symlinked into the agent's skill path. Two layouts auto-detected: `<repo>/.claude/skills/<name>/SKILL.md` (Claude Code convention) or `<repo>/<name>/SKILL.md` (each top-level dir IS a skill — e.g. `neuralwatt-claude-skills`). |
+| `env`         | Extra env vars merged into the container spawn (per-worker, on top of provider env).                                                                                                                                                                                                     |
 
 ## Loading
 
@@ -74,8 +74,8 @@ Profile mounts go through `validateAdditionalMounts()` (`src/modules/mount-secur
 ```json
 {
   "allowedRoots": [
-    {"path": "~/.ssh", "allowReadWrite": false, "description": "SSH keys (read-only)"},
-    {"path": "~/.config/gpuctl", "allowReadWrite": true, "description": "gpuctl CLI config"}
+    { "path": "~/.ssh", "allowReadWrite": false, "description": "SSH keys (read-only)" },
+    { "path": "~/.config/gpuctl", "allowReadWrite": true, "description": "gpuctl CLI config" }
   ],
   "blockedPatterns": []
 }
@@ -91,10 +91,10 @@ The allowlist is read once at host startup. New entries require a restart.
 
 ## Files
 
-| File | Role |
-|-|-|
-| `src/modules/fleet/worker-profile.ts` | `loadWorkerProfile`, `applyProfileToContainerConfig`, schema |
-| `container/worker-init.sh` | Boot script (clones, tools, skills) |
-| `src/modules/mount-security/index.ts` | Allowlist validation |
-| `examples/worker-profiles/example.json` | Reference template |
+| File                                       | Role                                                           |
+| ------------------------------------------ | -------------------------------------------------------------- |
+| `src/modules/fleet/worker-profile.ts`      | `loadWorkerProfile`, `applyProfileToContainerConfig`, schema   |
+| `container/worker-init.sh`                 | Boot script (clones, tools, skills)                            |
+| `src/modules/mount-security/index.ts`      | Allowlist validation                                           |
+| `examples/worker-profiles/example.json`    | Reference template                                             |
 | `examples/worker-profiles/init.sh.example` | Reference init script (for forks that need a fully custom one) |

--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -117,6 +117,31 @@ docker exec <container> env | grep -E "BETTERSTACK|FIREWORKS|TOGETHER|SYNTHETIC|
 
 Each entry's env var should be present. Missing = either the source file at `path` doesn't exist (silent skip — check `ls <path>`) or the host needs a restart to pick up the config change.
 
+### 4d. Team skills available to the agent (`skills_repo` + host-skills)
+
+Worker profile lists a `skills_repo` (typically `neuralwatt-claude-skills`) whose contents should be auto-discoverable by the agent. The chain is fragile — the repo must be cloned successfully, and `worker-init.sh` must find the skill layout. Manifestation when this breaks: agent says `"I don't have /review-and-submit"` even though it's in the team repo.
+
+```bash
+# After spawning a fresh worker, count expected vs visible skills
+docker exec <container> ls /home/node/.claude/skills | wc -l
+docker exec <container> ls /workspace/extra/host-skills | wc -l
+docker exec <container> ls /workspace/<skills_repo>/ 2>/dev/null
+```
+
+Spot-check a known team skill:
+
+```bash
+docker exec <container> ls /home/node/.claude/skills/review-and-submit
+```
+
+If missing: check `ncf logs <worker>` for the worker-init `skills: linked N from <repo>` line. Common causes:
+
+- The `skills_repo` clone failed (check the clone log lines — see section 4b)
+- The repo doesn't follow either layout (`.claude/skills/<name>/SKILL.md` or `<name>/SKILL.md`)
+- A `~/.claude/skills/<name>` entry on the host is a symlink pointing OUTSIDE the mount (the mount carries the symlink but not its target — broken symlink in container, gets skipped silently)
+
+(Regression seen 2026-04-30: NWCS skills missing from `better` and others because (a) the SSH→HTTPS rewrite broke the clone — fixed in PR #105 — and (b) `worker-init.sh` only checked `<repo>/.claude/skills/`, missing repos that put skills at the root. Both addressed in `fix/nwcs-skills-layout`.)
+
 ### 5. Auth path (verify the source of credentials matches expectation)
 
 After the host restart, look at the host log for the LAST worker spawn:


### PR DESCRIPTION
## Summary

Two related fixes for the \"agent says it doesn't have /review-and-submit\" failure mode:

1. **`skills_repo` layout** — `worker-init.sh` only checked `<repo>/.claude/skills/<name>/`, but `neuralwatt-claude-skills` (NWCS) keeps skills directly at the repo root (`<repo>/<name>/SKILL.md`). Now: when `<repo>/.claude/skills/` doesn't exist, fall back to scanning `<repo>/` for top-level subdirs containing `SKILL.md`. Layout is auto-detected.

2. **Broken-symlink defense** — host has `~/.claude/skills/review-and-submit` as a symlink into `~/git/neuralwatt-claude-skills/review-and-submit`. When `~/.claude/skills/` is mounted into the container, the symlink itself appears but its target isn't visible inside the container — broken symlink, was being silently skipped (correctly) but with no log explaining why. Both loops (skills_repo and host-skills) now explicitly defend against this, with clarifying comments.

## Why now

User reported `better` worker saying \"I don't have /review-and-submit\" even though it exists in NWCS. Root cause was the layout mismatch + broken-symlink shadowing. Same root cause affects ~19 other team skills today.

## Test plan

- [x] Verified inside `better` container: linking `review-and-submit` manually with the new logic succeeds; `[ -d \"$sd\" ]` correctly skips broken symlinks
- [x] `pnpm test` — 244/244 host pass
- [x] `pnpm exec tsc --noEmit` clean, `pnpm run build` clean
- [ ] CI green
- [ ] After merge: spawn a fresh worker, verify `ls /home/node/.claude/skills/review-and-submit` succeeds

## Doc updates

- `worker-profile.md` — describes both supported `skills_repo` layouts
- `e2e-checklist.md` — new section 4d with grep + spot-check commands for verifying team skills are visible to the agent