### PR TITLE
feat(host): port v1 resource monitor — alert master on memory/disk/container pressure

### DIFF
--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -142,6 +142,17 @@ If missing: check `ncf logs <worker>` for the worker-init `skills: linked N from
 
 (Regression seen 2026-04-30: NWCS skills missing from `better` and others because (a) the SSH→HTTPS rewrite broke the clone — fixed in PR #105 — and (b) `worker-init.sh` only checked `<repo>/.claude/skills/`, missing repos that put skills at the root. Both addressed in `fix/nwcs-skills-layout`.)
 
+### 4e. Resource monitor (host-side background polling for memory/disk/container alerts)
+
+The resource monitor runs every 5 minutes and posts to #master when memory ≥80%, disk ≥80%, or active containers ≥80% of `MAX_CONCURRENT_CONTAINERS`. Hysteresis: alert once on crossing, clear once on dropping below 70% (60% for containers).
+
+```bash
+# Verify the monitor started in host startup logs
+grep -i "Resource monitor started" logs/nanoclaw.log | tail -2
+```
+
+If you can't easily induce a real resource crunch, the threshold logic is exercised by `src/modules/resource-monitor/index.test.ts` (4 cases for crossings, hysteresis, multi-metric ticks). For a real-world spot check, watch `logs/nanoclaw.log` for `Resource alert` entries during heavy use.
+
 ### 5. Auth path (verify the source of credentials matches expectation)
 
 After the host restart, look at the host log for the LAST worker spawn:

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, st
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { startOutboundWakeServer, stopOutboundWakeServer } from './outbound-wake.js';
 import { startStatusPin, stopStatusPin } from './modules/status-pin/index.js';
+import { startResourceMonitor, stopResourceMonitor } from './modules/resource-monitor/index.js';
+import { getActiveContainerCount } from './container-runner.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
 
@@ -214,6 +216,11 @@ async function main(): Promise<void> {
   // delivery adapter so it can post/edit through Discord.
   startStatusPin();
 
+  // 5d. Resource monitor — polls memory/disk/container-count and posts
+  // hysteresis-driven alerts to #master when thresholds are crossed.
+  // Self-skips when no master is registered (alerts go to logs only).
+  startResourceMonitor({ getActiveContainers: getActiveContainerCount });
+
   // 6. Start host sweep
   startHostSweep();
   log.info('Host sweep started');
@@ -234,6 +241,7 @@ async function shutdown(signal: string): Promise<void> {
   stopDeliveryPolls();
   stopHostSweep();
   stopStatusPin();
+  stopResourceMonitor();
   await stopOutboundWakeServer();
   await teardownChannelAdapters();
   process.exit(0);

--- a/src/modules/resource-monitor/index.test.ts
+++ b/src/modules/resource-monitor/index.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Hysteresis tests for resource-monitor's threshold evaluator. Pure
+ * function — no DB, no docker, no os.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { evaluateThresholds, type MonitorState } from './index.js';
+
+function metrics(over: { mem?: number; disk?: number; containers?: number; max?: number } = {}): {
+  memoryPercent: number;
+  memoryUsedGB: number;
+  memoryTotalGB: number;
+  diskPercent: number;
+  diskUsedGB: number;
+  diskTotalGB: number;
+  containerCount: number;
+  containerMax: number;
+  containerPercent: number;
+} {
+  const containerMax = over.max ?? 5;
+  const containerCount = over.containers ?? 0;
+  return {
+    memoryPercent: over.mem ?? 0,
+    memoryUsedGB: 0,
+    memoryTotalGB: 0,
+    diskPercent: over.disk ?? 0,
+    diskUsedGB: 0,
+    diskTotalGB: 0,
+    containerCount,
+    containerMax,
+    containerPercent: Math.round((containerCount / containerMax) * 100),
+  };
+}
+
+describe('evaluateThresholds', () => {
+  it('fires memory alert when crossing 80%, then clears at <70%', () => {
+    const state: MonitorState = { active: new Set() };
+
+    // Below alert: nothing
+    let r = evaluateThresholds(state, metrics({ mem: 75 }));
+    expect(r.messages).toEqual([]);
+    state.active = r.nextActive;
+
+    // Cross alert
+    r = evaluateThresholds(state, metrics({ mem: 81 }));
+    expect(r.messages.some((m) => m.includes('Memory at 81%'))).toBe(true);
+    expect(r.nextActive.has('memoryPercent')).toBe(true);
+    state.active = r.nextActive;
+
+    // Stay above alert (still in alert band) — no repeat
+    r = evaluateThresholds(state, metrics({ mem: 85 }));
+    expect(r.messages).toEqual([]);
+    state.active = r.nextActive;
+
+    // Drop below alert but above clear (still in alert band) — no clear yet
+    r = evaluateThresholds(state, metrics({ mem: 75 }));
+    expect(r.messages).toEqual([]);
+    expect(r.nextActive.has('memoryPercent')).toBe(true);
+    state.active = r.nextActive;
+
+    // Cross clear
+    r = evaluateThresholds(state, metrics({ mem: 65 }));
+    expect(r.messages.some((m) => m.includes('Memory back'))).toBe(true);
+    expect(r.nextActive.has('memoryPercent')).toBe(false);
+  });
+
+  it('fires container alert when crossing 80% of max', () => {
+    const state: MonitorState = { active: new Set() };
+
+    // 4/5 = 80% — at threshold, alert fires
+    let r = evaluateThresholds(state, metrics({ containers: 4, max: 5 }));
+    expect(r.messages.some((m) => m.includes('Containers at 4/5'))).toBe(true);
+    state.active = r.nextActive;
+
+    // 3/5 = 60% — AT clear threshold (which is `< 60`), no clear yet
+    r = evaluateThresholds(state, metrics({ containers: 3, max: 5 }));
+    expect(r.messages).toEqual([]);
+    state.active = r.nextActive;
+
+    // 2/5 = 40% — below clear, fires
+    r = evaluateThresholds(state, metrics({ containers: 2, max: 5 }));
+    expect(r.messages.some((m) => m.includes('Containers back'))).toBe(true);
+  });
+
+  it('fires multiple alerts in one tick when multiple metrics cross', () => {
+    const state: MonitorState = { active: new Set() };
+    const r = evaluateThresholds(state, metrics({ mem: 90, disk: 85, containers: 5, max: 5 }));
+    expect(r.messages.length).toBe(3);
+    expect(r.messages.some((m) => m.includes('Memory'))).toBe(true);
+    expect(r.messages.some((m) => m.includes('Disk'))).toBe(true);
+    expect(r.messages.some((m) => m.includes('Containers'))).toBe(true);
+  });
+
+  it('does not refire after the metric stays in the alert band', () => {
+    const state: MonitorState = { active: new Set() };
+    let r = evaluateThresholds(state, metrics({ mem: 90 }));
+    expect(r.messages).toHaveLength(1);
+    state.active = r.nextActive;
+    r = evaluateThresholds(state, metrics({ mem: 92 }));
+    expect(r.messages).toEqual([]);
+    r = evaluateThresholds(state, metrics({ mem: 95 }));
+    expect(r.messages).toEqual([]);
+  });
+});

--- a/src/modules/resource-monitor/index.ts
+++ b/src/modules/resource-monitor/index.ts
@@ -1,0 +1,237 @@
+/**
+ * Resource monitor — periodically polls system metrics and posts an alert
+ * to #master when thresholds are crossed (memory / disk / container count).
+ *
+ * Ported from v1 fleet's `src/resource-monitor.ts`. Same hysteresis-driven
+ * "alert on crossing, clear when dropped below" semantics — alerts fire
+ * once per crossing, never spammed while a metric stays in the alert band.
+ *
+ * Sends the alert directly to the master agent's Discord channel by
+ * writing a `kind=chat` row to the master session's outbound DB. The
+ * delivery loop picks it up and routes through the normal channel
+ * adapter, same path as a worker reply. Going direct (vs. waking the
+ * master agent with a system message) means alerts land even when the
+ * master is dormant or offline.
+ *
+ * The monitor is started from `src/index.ts` after the master is
+ * identified. `MAX_CONCURRENT_CONTAINERS` (env, default 5) drives the
+ * "containers used" percentage.
+ */
+import { execSync } from 'child_process';
+import os from 'os';
+
+import { MAX_CONCURRENT_CONTAINERS } from '../../config.js';
+import { getActiveAgentGroups } from '../../db/agent-groups.js';
+import { getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
+import { getSessionsByAgentGroup } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { openOutboundDb } from '../../session-manager.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const STARTUP_DELAY_MS = 30_000;
+
+/**
+ * Hysteresis: alert when value >= alert, clear when value < clear.
+ * Container threshold's clear band is wider (60 vs 70 for memory/disk)
+ * because container count fluctuates more — a single demand-spawn from
+ * 4/5 → 5/5 → 4/5 within minutes is normal and shouldn't double-fire.
+ */
+const THRESHOLDS = {
+  memoryPercent: { alert: 80, clear: 70 },
+  diskPercent: { alert: 80, clear: 70 },
+  containerPercent: { alert: 80, clear: 60 },
+} as const;
+
+type ThresholdName = keyof typeof THRESHOLDS;
+
+interface SystemMetrics {
+  memoryPercent: number;
+  memoryUsedGB: number;
+  memoryTotalGB: number;
+  diskPercent: number;
+  diskUsedGB: number;
+  diskTotalGB: number;
+  containerCount: number;
+  containerMax: number;
+  containerPercent: number;
+}
+
+export function getMetrics(getActiveContainers: () => number): SystemMetrics {
+  const totalMem = os.totalmem();
+  const freeMem = os.freemem();
+  const usedMem = totalMem - freeMem;
+
+  let diskPercent = 0;
+  let diskUsedGB = 0;
+  let diskTotalGB = 0;
+  try {
+    const df = execSync('df / --output=pcent,used,size | tail -1', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const parts = df.split(/\s+/);
+    diskPercent = parseInt(parts[0], 10) || 0;
+    diskUsedGB = (parseInt(parts[1], 10) || 0) / (1024 * 1024);
+    diskTotalGB = (parseInt(parts[2], 10) || 0) / (1024 * 1024);
+  } catch {
+    /* df failure (unsupported flags on BSD/mac, etc.) — treat as 0 */
+  }
+
+  const containerCount = getActiveContainers();
+  const containerMax = MAX_CONCURRENT_CONTAINERS;
+
+  return {
+    memoryPercent: Math.round((usedMem / totalMem) * 100),
+    memoryUsedGB: +(usedMem / 1024 ** 3).toFixed(1),
+    memoryTotalGB: +(totalMem / 1024 ** 3).toFixed(1),
+    diskPercent,
+    diskUsedGB: +diskUsedGB.toFixed(1),
+    diskTotalGB: +diskTotalGB.toFixed(1),
+    containerCount,
+    containerMax,
+    containerPercent: Math.round((containerCount / Math.max(1, containerMax)) * 100),
+  };
+}
+
+/**
+ * State for `evaluateThresholds` — the set of currently-active alert
+ * names. Pure function: takes current state + metrics, returns next
+ * state + the alert/clear messages that crossed this tick. No side
+ * effects, so it's directly testable.
+ */
+export interface MonitorState {
+  active: Set<ThresholdName>;
+}
+
+export function evaluateThresholds(
+  state: MonitorState,
+  m: SystemMetrics,
+): { nextActive: Set<ThresholdName>; messages: string[] } {
+  const next = new Set(state.active);
+  const messages: string[] = [];
+
+  const cases: Array<{ name: ThresholdName; value: number; alertMsg: string; clearMsg: string }> = [
+    {
+      name: 'memoryPercent',
+      value: m.memoryPercent,
+      alertMsg: `⚠️ Memory at ${m.memoryPercent}% (${m.memoryUsedGB}/${m.memoryTotalGB} GB). Consider destroying idle workers.`,
+      clearMsg: `✅ Memory back to ${m.memoryPercent}%.`,
+    },
+    {
+      name: 'diskPercent',
+      value: m.diskPercent,
+      alertMsg: `⚠️ Disk at ${m.diskPercent}% (${m.diskUsedGB}/${m.diskTotalGB} GB).`,
+      clearMsg: `✅ Disk back to ${m.diskPercent}%.`,
+    },
+    {
+      name: 'containerPercent',
+      value: m.containerPercent,
+      alertMsg: `⚠️ Containers at ${m.containerCount}/${m.containerMax} (${m.containerPercent}%).`,
+      clearMsg: `✅ Containers back to ${m.containerCount}/${m.containerMax}.`,
+    },
+  ];
+
+  for (const c of cases) {
+    const t = THRESHOLDS[c.name];
+    if (c.value >= t.alert && !next.has(c.name)) {
+      next.add(c.name);
+      messages.push(c.alertMsg);
+    } else if (c.value < t.clear && next.has(c.name)) {
+      next.delete(c.name);
+      messages.push(c.clearMsg);
+    }
+  }
+
+  return { nextActive: next, messages };
+}
+
+/**
+ * Resolve the master's primary outbound target (channel_type + platform_id)
+ * by walking agent_groups → messaging_groups for the active master.
+ * Returns null when there's no master (or it has no messaging group),
+ * which makes the monitor a no-op — alerts go to logs only.
+ */
+function resolveMasterTarget(): {
+  agentGroupId: string;
+  sessionId: string;
+  channelType: string;
+  platformId: string;
+} | null {
+  const master = getActiveAgentGroups().find((g) => g.fleet_role === 'master');
+  if (!master) return null;
+  const sessions = getSessionsByAgentGroup(master.id);
+  if (sessions.length === 0) return null;
+  // Pick the most-recently-active session.
+  const session = [...sessions].sort((a, b) => (b.last_active ?? '').localeCompare(a.last_active ?? ''))[0];
+  const mgs = getMessagingGroupsByAgentGroup(master.id);
+  const mg = mgs[0];
+  if (!mg) return null;
+  return { agentGroupId: master.id, sessionId: session.id, channelType: mg.channel_type, platformId: mg.platform_id };
+}
+
+function writeAlertToOutbound(target: ReturnType<typeof resolveMasterTarget>, text: string): void {
+  if (!target) {
+    log.info('Resource alert (no master target — log only)', { text });
+    return;
+  }
+  try {
+    const db = openOutboundDb(target.agentGroupId, target.sessionId);
+    try {
+      // Pick next odd seq (host writes even, container writes odd; this
+      // monitor is host-side but masquerading as a container reply, so
+      // we use even — match the host-sweep's convention by picking the
+      // next available number above the current max).
+      const maxSeq = (db.prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+      const nextSeq = maxSeq + 1;
+      const id = `resmon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      db.prepare(
+        `INSERT INTO messages_out (id, seq, timestamp, kind, platform_id, channel_type, content)
+         VALUES (?, ?, datetime('now'), 'chat', ?, ?, ?)`,
+      ).run(id, nextSeq, target.platformId, target.channelType, JSON.stringify({ text }));
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    log.warn('Resource monitor failed to write alert', { err: String(err) });
+  }
+}
+
+let timer: NodeJS.Timeout | undefined;
+const state: MonitorState = { active: new Set() };
+
+/**
+ * Start the monitor loop. Idempotent — calling twice cancels the prior
+ * timer and starts fresh. Stops itself when `stopResourceMonitor` is
+ * called (used by tests / shutdown).
+ */
+export function startResourceMonitor(
+  opts: { getActiveContainers: () => number; intervalMs?: number } = { getActiveContainers: () => 0 },
+): void {
+  if (timer) clearInterval(timer);
+  const interval = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  const tick = (): void => {
+    try {
+      const target = resolveMasterTarget();
+      const metrics = getMetrics(opts.getActiveContainers);
+      const { nextActive, messages } = evaluateThresholds(state, metrics);
+      state.active = nextActive;
+      for (const m of messages) writeAlertToOutbound(target, m);
+    } catch (err) {
+      log.warn('Resource monitor tick failed', { err: String(err) });
+    }
+  };
+
+  // First check after STARTUP_DELAY_MS so the host finishes booting.
+  setTimeout(tick, STARTUP_DELAY_MS);
+  timer = setInterval(tick, interval);
+  log.info('Resource monitor started', { intervalMs: interval });
+}
+
+export function stopResourceMonitor(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+  state.active.clear();
+}


### PR DESCRIPTION
## Summary

Reintroduces the autonomous background loop from v1 fleet (FORK-SPEC.md §13.1). Polls system metrics every 5 minutes, posts a Discord alert to #master when memory ≥80%, disk ≥80%, or container count ≥80% of \`MAX_CONCURRENT_CONTAINERS\`. Hysteresis ensures alerts fire only on threshold crossings.

## Why

User asked: which v1 features are missing in v2? Resource monitoring is one of the highest-value passive features — it runs forever, catches problems automatically, and was a one-day port. Going from "user has to notice memory pressure" to "fleet self-reports" is real ops value for trivial code.

## Behavior

- Poll every 5m (first tick after 30s startup grace)
- Memory: alert ≥80%, clear <70%
- Disk: alert ≥80%, clear <70%
- Containers: alert ≥80% of \`MAX_CONCURRENT_CONTAINERS\`, clear <60%
- Each metric fires once per crossing — won't re-spam while staying in the alert band
- Alerts written directly to master's outbound DB (kind=chat, master's messaging-group routing) so they land in #master via the standard delivery loop
- Self-skips when no master is registered or master has no messaging group — alerts go to host logs only

## Tests

4 vitest cases for the pure threshold evaluator (\`evaluateThresholds\`) — extracted from the loop so it's testable without DB / docker / os: crossing fires + remembers, hysteresis blocks re-fire, partial drop without clearing, multi-metric ticks emit multiple messages.

## Doc

\`docs/fleet/guides/e2e-checklist.md\` section 4e — how to verify the monitor is live (grep startup log for \"Resource monitor started\"; threshold crossings show up as \"Resource alert\" entries).