### PR TITLE
feat(fleet): port v1 gaps — enriched list_workers, profile sync at startup

### DIFF
--- a/container/skills/status/SKILL.md
+++ b/container/skills/status/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: status
+description: Report a Discord-formatted status dashboard of the fleet — master state, every worker's backend/model/uptime, and a summary footer. Trigger on the user typing "/status", "status?", "fleet status", "what's running", or anything semantically equivalent to "show me what's running right now."
+---
+
+# /status — fleet dashboard
+
+## When to use
+
+The user wants a snapshot of fleet state — master plus every worker, their backends, and uptime. Trigger on any phrasing that maps to "show me what's running":
+
+- `/status`
+- `status?`
+- `fleet status`
+- `what's running?`
+- `list workers`
+- `who's up?`
+
+## What to do
+
+Call the `mcp__nanoclaw__list_workers` MCP tool. The host runs the query synchronously and posts a formatted dashboard (master state + per-worker bullets + summary footer) to the master's channel as a chat message. Your turn-result text after the call should be wrapped in `<internal>...</internal>` because the dashboard already landed via the MCP tool path — anything you write afterwards is duplicate chatter.
+
+```
+<internal>Status dashboard delivered via list_workers.</internal>
+```
+
+That's the entire skill.
+
+## What NOT to do
+
+- Don't try to enumerate workers from `docker ps` or your own context — `list_workers` is the only source of truth. It also includes archived workers and master state which `docker ps` doesn't.
+- Don't paraphrase the dashboard. The format is intentional: the user reads it on a phone, scanning for icons + uptimes. Reformatting loses information.
+- Don't run after every message. Only on explicit "show me status" intent.
+
+## v1 parity note
+
+This is the v2 equivalent of v1 fleet's `/status` skill (FORK-SPEC §13.3), which ran `tools/nc-status.sh` and forwarded the output. The v2 form is simpler because the dashboard logic lives in `list_workers` itself rather than a separate shell script — the skill just routes the request.

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,13 @@ async function main(): Promise<void> {
   // No-op if no profile is defined. Mirrors v1 fleet's syncWorkerProfiles
   // (FORK-SPEC §7.4).
   const { syncWorkerProfiles } = await import('./modules/fleet/profile-sync.js');
-  syncWorkerProfiles();
+  const profileSyncResult = syncWorkerProfiles();
+  if (profileSyncResult.errors.length > 0) {
+    log.warn('Profile sync had errors at startup', {
+      errors: profileSyncResult.errors,
+      updated: profileSyncResult.updated.length,
+    });
+  }
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,16 @@ async function main(): Promise<void> {
   // 1b. One-time filesystem cutover — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
 
+  // 1c. Re-apply the user's worker profile to every active worker's
+  // container.json. Lets profile edits in
+  // ~/.config/nanoclaw/worker-profiles/default.json (added repos, bumped
+  // tools, tightened mounts) propagate to existing workers on the next
+  // host restart, without needing to destroy + recreate each worker.
+  // No-op if no profile is defined. Mirrors v1 fleet's syncWorkerProfiles
+  // (FORK-SPEC §7.4).
+  const { syncWorkerProfiles } = await import('./modules/fleet/profile-sync.js');
+  syncWorkerProfiles();
+
   // 2. Container runtime
   ensureContainerRuntimeRunning();
   cleanupOrphans();

--- a/src/modules/fleet/cleanup-workers.ts
+++ b/src/modules/fleet/cleanup-workers.ts
@@ -31,7 +31,7 @@ import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { deleteDiscordChannel, listDiscordChannels, loadDiscordFleetConfig } from './discord-channel.js';
 import { logWorkerEvent } from './events.js';
-import { notifyAgent } from './lib.js';
+import { CONTAINER_NAME_RE, notifyAgent } from './lib.js';
 
 interface CleanupReport {
   orphanChannels: Array<{ id: string; name: string }>;
@@ -43,16 +43,6 @@ interface CleanupReport {
 interface CleanupOptions {
   dryRun: boolean;
 }
-
-/**
- * Container-name parser: `nanoclaw-v2-<folder>-<Date.now()>`. Folder may
- * contain hyphens AND digits (e.g. `model-dev-2024`), so we anchor on a
- * 13-digit ms-epoch timestamp suffix rather than `\d+`. A loose `\d+`
- * would eat the trailing `-2024` as the timestamp and mis-identify the
- * folder as `model-dev`, potentially marking an active container as
- * orphan (or vice-versa). Matches `src/container-runner.ts:176`.
- */
-const CONTAINER_NAME_RE = /^nanoclaw-v2-(.+)-(\d{13})$/;
 
 export async function handleCleanupWorkers(content: Record<string, unknown>, session: Session): Promise<void> {
   const sourceGroup = getAgentGroup(session.agent_group_id);

--- a/src/modules/fleet/index.ts
+++ b/src/modules/fleet/index.ts
@@ -26,3 +26,8 @@ registerDeliveryAction('destroy_worker', handleDestroyWorker);
 registerDeliveryAction('switch_backend', handleSwitchBackend);
 registerDeliveryAction('list_workers_request', handleListWorkersRequest);
 registerDeliveryAction('cleanup_workers', handleCleanupWorkers);
+
+// Note: `profile-sync` is intentionally absent — it's not a delivery
+// action (no inbound MCP tool). It's a startup hook called directly from
+// `src/index.ts` after migrations, so profile edits propagate to existing
+// workers on host restart. See `profile-sync.ts`.

--- a/src/modules/fleet/lib.ts
+++ b/src/modules/fleet/lib.ts
@@ -3,6 +3,18 @@
  *
  * Used by create-worker, destroy-worker, switch-backend, list-workers.
  */
+
+/**
+ * Container-name parser: `nanoclaw-v2-<folder>-<Date.now()>`. Folder may
+ * contain hyphens AND digits, so we anchor on the trailing 13-digit
+ * ms-epoch timestamp rather than `\d+`. Loose `\d+` would eat a folder
+ * suffix like `-2024` as the timestamp and mis-identify the folder.
+ *
+ * Anchored to the actual spawn naming in `container-runner.ts:176`.
+ * Used by `cleanup_workers` (orphan detection) and `list_workers`
+ * (uptime lookup) — keep them in sync.
+ */
+export const CONTAINER_NAME_RE = /^nanoclaw-v2-(.+)-(\d{13})$/;
 import fs from 'fs';
 import path from 'path';
 

--- a/src/modules/fleet/list-workers.test.ts
+++ b/src/modules/fleet/list-workers.test.ts
@@ -1,11 +1,17 @@
 /**
- * Pure formatter tests for the fleet dashboard. The DB-backed
- * `getFleetSummary()` is exercised by `fleet.test.ts`; this file covers
- * `formatFleetSummary()` against hand-built `FleetSummary` fixtures.
+ * Pure formatter + parser tests. DB-backed `getFleetSummary()` is
+ * exercised by `fleet.test.ts`; this file covers `formatFleetSummary()`
+ * and `readRunningUptimes()` in isolation.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { formatFleetSummary, type FleetSummary } from './list-workers.js';
+const mockExecSync = vi.fn();
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+const { formatFleetSummary, readRunningUptimes } = await import('./list-workers.js');
+type FleetSummary = import('./list-workers.js').FleetSummary;
 
 describe('formatFleetSummary', () => {
   it('renders empty fleet with master line + "no workers" prompt', () => {
@@ -156,5 +162,46 @@ describe('formatFleetSummary', () => {
     const out = formatFleetSummary(s);
     expect(out).not.toContain('**Master**');
     expect(out).toContain('No fleet workers');
+  });
+});
+
+describe('readRunningUptimes', () => {
+  it('parses folder→uptime pairs from "Up X" status strings', () => {
+    mockExecSync.mockReturnValueOnce(
+      ['nanoclaw-v2-alpha-1700000000000|Up 2 hours', 'nanoclaw-v2-beta-bar-1700000001000|Up 5 minutes'].join('\n'),
+    );
+    const map = readRunningUptimes();
+    expect(map.get('alpha')).toBe('2 hours');
+    expect(map.get('beta-bar')).toBe('5 minutes');
+  });
+
+  it('preserves healthcheck suffixes after stripping "Up "', () => {
+    mockExecSync.mockReturnValueOnce('nanoclaw-v2-alpha-1700000000000|Up 2 hours (unhealthy)');
+    expect(readRunningUptimes().get('alpha')).toBe('2 hours (unhealthy)');
+  });
+
+  it('skips lines that do not match the container-name regex', () => {
+    mockExecSync.mockReturnValueOnce(
+      [
+        'unrelated-container|Up 1 hour',
+        'nanoclaw-v1-old-format|Up 1 hour',
+        'nanoclaw-v2-good-1700000000000|Up 3 minutes',
+      ].join('\n'),
+    );
+    const map = readRunningUptimes();
+    expect(map.size).toBe(1);
+    expect(map.get('good')).toBe('3 minutes');
+  });
+
+  it('returns empty map when docker fails (e.g., daemon down)', () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error('Cannot connect to the Docker daemon');
+    });
+    expect(readRunningUptimes().size).toBe(0);
+  });
+
+  it('returns empty map when no containers are running', () => {
+    mockExecSync.mockReturnValueOnce('');
+    expect(readRunningUptimes().size).toBe(0);
   });
 });

--- a/src/modules/fleet/list-workers.test.ts
+++ b/src/modules/fleet/list-workers.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure formatter tests for the fleet dashboard. The DB-backed
+ * `getFleetSummary()` is exercised by `fleet.test.ts`; this file covers
+ * `formatFleetSummary()` against hand-built `FleetSummary` fixtures.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { formatFleetSummary, type FleetSummary } from './list-workers.js';
+
+describe('formatFleetSummary', () => {
+  it('renders empty fleet with master line + "no workers" prompt', () => {
+    const s: FleetSummary = {
+      master: {
+        name: 'Master',
+        backend: 'claude',
+        model: 'claude-opus-4-7',
+        container_uptime: '2 hours',
+        container_status: 'running',
+      },
+      workers: [],
+    };
+    const out = formatFleetSummary(s);
+    expect(out).toContain('**Master**');
+    expect(out).toContain('claude-opus-4-7');
+    expect(out).toContain('up 2 hours');
+    expect(out).toContain('No fleet workers');
+    expect(out).not.toContain('## 🤖 Workers\n-'); // no bullet list
+  });
+
+  it('uses master container_status when uptime is null (e.g. master not running)', () => {
+    const s: FleetSummary = {
+      master: {
+        name: 'Master',
+        backend: 'claude',
+        model: 'claude-opus-4-7',
+        container_uptime: null,
+        container_status: 'stopped',
+      },
+      workers: [],
+    };
+    expect(formatFleetSummary(s)).toContain('· stopped');
+  });
+
+  it('renders running, idle, stopped, archived workers with the right icons', () => {
+    const s: FleetSummary = {
+      master: null,
+      workers: [
+        {
+          name: 'alpha',
+          folder: 'alpha',
+          status: 'active',
+          backend: 'claude',
+          model: 'opus-4-7',
+          channels: [],
+          container_status: 'running',
+          container_uptime: '1 hour',
+          last_active: null,
+        },
+        {
+          name: 'beta',
+          folder: 'beta',
+          status: 'active',
+          backend: 'neuralwatt',
+          model: 'glm-fast',
+          channels: [],
+          container_status: 'idle',
+          container_uptime: null,
+          last_active: null,
+        },
+        {
+          name: 'gamma',
+          folder: 'gamma',
+          status: 'active',
+          backend: 'claude',
+          model: null,
+          channels: [],
+          container_status: 'stopped',
+          container_uptime: null,
+          last_active: null,
+        },
+        {
+          name: 'delta',
+          folder: 'delta',
+          status: 'archived',
+          backend: 'claude',
+          model: null,
+          channels: [],
+          container_status: 'none',
+          container_uptime: null,
+          last_active: null,
+        },
+      ],
+    };
+    const out = formatFleetSummary(s);
+    expect(out).toMatch(/🟢 \*\*alpha\*\* · `opus-4-7` · up 1 hour/);
+    expect(out).toMatch(/⚫ \*\*beta\*\* · `glm-fast` · idle/);
+    expect(out).toMatch(/⚫ \*\*gamma\*\* · `claude` · stopped/);
+    expect(out).toMatch(/🗄️ \*\*delta\*\* · `claude` · archived/);
+  });
+
+  it('summary footer counts running vs active vs archived correctly', () => {
+    const s: FleetSummary = {
+      master: null,
+      workers: [
+        {
+          name: 'a',
+          folder: 'a',
+          status: 'active',
+          backend: 'c',
+          model: null,
+          channels: [],
+          container_status: 'running',
+          container_uptime: '1h',
+          last_active: null,
+        },
+        {
+          name: 'b',
+          folder: 'b',
+          status: 'active',
+          backend: 'c',
+          model: null,
+          channels: [],
+          container_status: 'stopped',
+          container_uptime: null,
+          last_active: null,
+        },
+        {
+          name: 'c',
+          folder: 'c',
+          status: 'archived',
+          backend: 'c',
+          model: null,
+          channels: [],
+          container_status: 'none',
+          container_uptime: null,
+          last_active: null,
+        },
+        {
+          name: 'd',
+          folder: 'd',
+          status: 'archived',
+          backend: 'c',
+          model: null,
+          channels: [],
+          container_status: 'none',
+          container_uptime: null,
+          last_active: null,
+        },
+      ],
+    };
+    expect(formatFleetSummary(s)).toMatch(/_1\/2 running · 2 archived_/);
+  });
+
+  it('omits master block when master is null', () => {
+    const s: FleetSummary = { master: null, workers: [] };
+    const out = formatFleetSummary(s);
+    expect(out).not.toContain('**Master**');
+    expect(out).toContain('No fleet workers');
+  });
+});

--- a/src/modules/fleet/list-workers.ts
+++ b/src/modules/fleet/list-workers.ts
@@ -4,7 +4,17 @@
  * Unlike create/destroy/switch, this does NOT flow through
  * registerDeliveryAction; the MCP tool invokes it synchronously and returns
  * JSON in the tool result. No messages_out emission.
+ *
+ * The Discord-formatted summary mirrors v1 fleet's `nc-status.sh` output:
+ *
+ *   **Master** · `claude-opus-4-7` · up 2h 5m
+ *
+ *   ## 🤖 Workers
+ *   - 🟢 worker-name · `model` · up 1h 23m
+ *   - ⚫ another · `model` · stopped
  */
+import { execSync } from 'child_process';
+
 import { getAllAgentGroups } from '../../db/agent-groups.js';
 import { getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
 import { getSessionsByAgentGroup } from '../../db/sessions.js';
@@ -20,53 +30,156 @@ export interface WorkerSummary {
   channels: string[];
   container_status: string;
   last_active: string | null;
+  /** Docker's `Up 2 hours`-style uptime when running, else null. */
+  container_uptime: string | null;
 }
 
-function formatWorkerSummary(workers: WorkerSummary[]): string {
-  if (workers.length === 0) return 'No fleet workers. Use create_worker to make one.';
-  const lines = ['Fleet workers:', ''];
-  for (const w of workers) {
-    const marker =
-      w.status === 'archived'
-        ? '[archived]'
-        : w.container_status === 'running'
-          ? '[running]'
-          : w.container_status === 'idle'
-            ? '[idle]'
-            : '[stopped]';
-    const backendStr = w.backend ? `${w.backend}${w.model ? ` (${w.model})` : ''}` : '—';
-    const channelStr = w.channels.length > 0 ? w.channels.join(', ') : 'no channel';
-    lines.push(`- ${marker} ${w.name} · ${backendStr} · ${channelStr}`);
+export interface MasterSummary {
+  name: string;
+  backend: string | null;
+  model: string | null;
+  container_uptime: string | null;
+  container_status: string;
+}
+
+export interface FleetSummary {
+  master: MasterSummary | null;
+  workers: WorkerSummary[];
+}
+
+/**
+ * Read all running `nanoclaw-v2-*` containers and build a folder→uptime map
+ * in one shot. Single docker call for the whole fleet — caller doesn't
+ * loop over `docker inspect`. Container name format is
+ * `nanoclaw-v2-<folder>-<13-digit-timestamp>` (matches container-runner +
+ * cleanup-workers regex). Status format is Docker's "Up 2 hours" / "Up 5
+ * minutes" — we keep it as-is and strip the "Up " prefix in the formatter.
+ */
+const NAME_RE = /^nanoclaw-v2-(.+)-(\d{13})$/;
+
+function readRunningUptimes(): Map<string, string> {
+  const map = new Map<string, string>();
+  try {
+    const out = execSync(`docker ps --filter name=nanoclaw-v2- --format '{{.Names}}|{{.Status}}'`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (!out) return map;
+    for (const line of out.split('\n')) {
+      const [name, status] = line.split('|');
+      const m = name?.match(NAME_RE);
+      if (!m) continue;
+      const folder = m[1];
+      // Status is e.g. "Up 2 hours" or "Up 5 minutes". Strip the "Up "
+      // prefix; an "(unhealthy)" suffix from container healthchecks
+      // could in principle land here, so we keep whatever's after "Up ".
+      const uptime = status?.replace(/^Up\s+/, '');
+      if (uptime) map.set(folder, uptime);
+    }
+  } catch {
+    /* docker not available — uptime stays null */
   }
+  return map;
+}
+
+export function getFleetSummary(): FleetSummary {
+  const all = getAllAgentGroups();
+  const uptimes = readRunningUptimes();
+
+  const masterAg = all.find((g) => g.fleet_role === 'master' && (g.status ?? 'active') === 'active');
+  let master: MasterSummary | null = null;
+  if (masterAg) {
+    const sessions = getSessionsByAgentGroup(masterAg.id);
+    const primary = sessions[0];
+    master = {
+      name: masterAg.name,
+      backend: masterAg.fleet_backend ?? masterAg.agent_provider ?? null,
+      model: masterAg.fleet_model ?? null,
+      container_status: primary?.container_status ?? 'none',
+      container_uptime: uptimes.get(masterAg.folder) ?? null,
+    };
+  }
+
+  const workers: WorkerSummary[] = all
+    .filter((g) => g.fleet_role === 'worker')
+    .map((g) => {
+      const sessions = getSessionsByAgentGroup(g.id);
+      // Pick the "most alive" session — running > idle > stopped — for display.
+      const byAliveness = (s: { container_status: string }): number =>
+        s.container_status === 'running' ? 2 : s.container_status === 'idle' ? 1 : 0;
+      sessions.sort((a, b) => byAliveness(b) - byAliveness(a));
+      const primary = sessions[0];
+      const mgs = getMessagingGroupsByAgentGroup(g.id);
+      return {
+        name: g.name,
+        folder: g.folder,
+        status: g.status ?? 'active',
+        backend: g.fleet_backend ?? g.agent_provider ?? null,
+        model: g.fleet_model ?? null,
+        channels: mgs.map((m) => `${m.channel_type}:${m.platform_id}`),
+        container_status: primary?.container_status ?? 'none',
+        last_active: primary?.last_active ?? null,
+        container_uptime: uptimes.get(g.folder) ?? null,
+      };
+    });
+
+  return { master, workers };
+}
+
+/**
+ * Backwards-compatible alias. New code should use `getFleetSummary()` for
+ * the master-aware result.
+ */
+export function listWorkers(): WorkerSummary[] {
+  return getFleetSummary().workers;
+}
+
+/**
+ * Discord-formatted dashboard. Master state on top, workers below as a
+ * bullet list with status emoji + uptime. Closes with a one-line summary.
+ * Mirrors v1 nc-status.sh output (FORK-SPEC §13.2).
+ */
+export function formatFleetSummary(s: FleetSummary): string {
+  const lines: string[] = [];
+
+  if (s.master) {
+    const modelStr = s.master.model ? `\`${s.master.model}\`` : `\`${s.master.backend ?? 'claude'}\``;
+    const uptimeStr = s.master.container_uptime ? `up ${s.master.container_uptime}` : s.master.container_status;
+    lines.push(`**Master** · ${modelStr} · ${uptimeStr}`);
+    lines.push('');
+  }
+
+  if (s.workers.length === 0) {
+    lines.push('## 🤖 Workers');
+    lines.push('_No fleet workers. Use `create_worker` to make one._');
+    return lines.join('\n');
+  }
+
+  lines.push('## 🤖 Workers');
+  for (const w of s.workers) {
+    const icon = w.status === 'archived' ? '🗄️' : w.container_status === 'running' ? '🟢' : '⚫';
+    const modelStr = w.model ? `\`${w.model}\`` : `\`${w.backend ?? '—'}\``;
+    const stateStr =
+      w.status === 'archived'
+        ? 'archived'
+        : w.container_uptime
+          ? `up ${w.container_uptime}`
+          : w.container_status === 'idle'
+            ? 'idle'
+            : 'stopped';
+    lines.push(`- ${icon} **${w.name}** · ${modelStr} · ${stateStr}`);
+  }
+
+  // Summary footer.
+  const active = s.workers.filter((w) => w.status !== 'archived');
+  const running = active.filter((w) => w.container_status === 'running').length;
+  const archived = s.workers.length - active.length;
+  lines.push('');
+  lines.push(`_${running}/${active.length} running${archived ? ` · ${archived} archived` : ''}_`);
+
   return lines.join('\n');
 }
 
 export async function handleListWorkersRequest(_content: Record<string, unknown>, session: Session): Promise<void> {
-  const summary = listWorkers();
-  notifyAgent(session, formatWorkerSummary(summary));
-}
-
-export function listWorkers(): WorkerSummary[] {
-  const all = getAllAgentGroups();
-  const workers = all.filter((g) => g.fleet_role === 'worker');
-
-  return workers.map((g) => {
-    const sessions = getSessionsByAgentGroup(g.id);
-    // Pick the "most alive" session — running > idle > stopped — for display.
-    const byAliveness = (s: { container_status: string }): number =>
-      s.container_status === 'running' ? 2 : s.container_status === 'idle' ? 1 : 0;
-    sessions.sort((a, b) => byAliveness(b) - byAliveness(a));
-    const primary = sessions[0];
-    const mgs = getMessagingGroupsByAgentGroup(g.id);
-    return {
-      name: g.name,
-      folder: g.folder,
-      status: g.status ?? 'active',
-      backend: g.fleet_backend ?? g.agent_provider ?? null,
-      model: g.fleet_model ?? null,
-      channels: mgs.map((m) => `${m.channel_type}:${m.platform_id}`),
-      container_status: primary?.container_status ?? 'none',
-      last_active: primary?.last_active ?? null,
-    };
-  });
+  notifyAgent(session, formatFleetSummary(getFleetSummary()));
 }

--- a/src/modules/fleet/list-workers.ts
+++ b/src/modules/fleet/list-workers.ts
@@ -19,7 +19,7 @@ import { getAllAgentGroups } from '../../db/agent-groups.js';
 import { getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
 import { getSessionsByAgentGroup } from '../../db/sessions.js';
 import type { Session } from '../../types.js';
-import { notifyAgent } from './lib.js';
+import { CONTAINER_NAME_RE, notifyAgent } from './lib.js';
 
 export interface WorkerSummary {
   name: string;
@@ -50,13 +50,10 @@ export interface FleetSummary {
 /**
  * Read all running `nanoclaw-v2-*` containers and build a folder→uptime map
  * in one shot. Single docker call for the whole fleet — caller doesn't
- * loop over `docker inspect`. Container name format is
- * `nanoclaw-v2-<folder>-<13-digit-timestamp>` (matches container-runner +
- * cleanup-workers regex). Status format is Docker's "Up 2 hours" / "Up 5
- * minutes" — we keep it as-is and strip the "Up " prefix in the formatter.
+ * loop over `docker inspect`. Status format is Docker's "Up 2 hours" /
+ * "Up 5 minutes" — kept as-is and the "Up " prefix is stripped in the
+ * formatter.
  */
-const NAME_RE = /^nanoclaw-v2-(.+)-(\d{13})$/;
-
 function readRunningUptimes(): Map<string, string> {
   const map = new Map<string, string>();
   try {
@@ -67,7 +64,7 @@ function readRunningUptimes(): Map<string, string> {
     if (!out) return map;
     for (const line of out.split('\n')) {
       const [name, status] = line.split('|');
-      const m = name?.match(NAME_RE);
+      const m = name?.match(CONTAINER_NAME_RE);
       if (!m) continue;
       const folder = m[1];
       // Status is e.g. "Up 2 hours" or "Up 5 minutes". Strip the "Up "
@@ -141,6 +138,23 @@ export function listWorkers(): WorkerSummary[] {
   return getFleetSummary().workers;
 }
 
+function workerIcon(w: WorkerSummary): string {
+  if (w.status === 'archived') return '🗄️';
+  if (w.container_status === 'running') return '🟢';
+  return '⚫';
+}
+
+function formatModel(w: { backend: string | null; model: string | null }): string {
+  return `\`${w.model ?? w.backend ?? '—'}\``;
+}
+
+function formatWorkerState(w: WorkerSummary): string {
+  if (w.status === 'archived') return 'archived';
+  if (w.container_uptime) return `up ${w.container_uptime}`;
+  if (w.container_status === 'idle') return 'idle';
+  return 'stopped';
+}
+
 /**
  * Discord-formatted dashboard. Master state on top, workers below as a
  * bullet list with status emoji + uptime. Closes with a one-line summary.
@@ -164,17 +178,7 @@ export function formatFleetSummary(s: FleetSummary): string {
 
   lines.push('## 🤖 Workers');
   for (const w of s.workers) {
-    const icon = w.status === 'archived' ? '🗄️' : w.container_status === 'running' ? '🟢' : '⚫';
-    const modelStr = w.model ? `\`${w.model}\`` : `\`${w.backend ?? '—'}\``;
-    const stateStr =
-      w.status === 'archived'
-        ? 'archived'
-        : w.container_uptime
-          ? `up ${w.container_uptime}`
-          : w.container_status === 'idle'
-            ? 'idle'
-            : 'stopped';
-    lines.push(`- ${icon} **${w.name}** · ${modelStr} · ${stateStr}`);
+    lines.push(`- ${workerIcon(w)} **${w.name}** · ${formatModel(w)} · ${formatWorkerState(w)}`);
   }
 
   // Summary footer.

--- a/src/modules/fleet/list-workers.ts
+++ b/src/modules/fleet/list-workers.ts
@@ -86,11 +86,23 @@ export function getFleetSummary(): FleetSummary {
   const all = getAllAgentGroups();
   const uptimes = readRunningUptimes();
 
+  // "Most alive" session selection — running > idle > stopped — used for
+  // both master and workers so the dashboard reports the running session
+  // when one exists rather than whichever the DB happens to return first.
+  const byAliveness = (s: { container_status: string }): number =>
+    s.container_status === 'running' ? 2 : s.container_status === 'idle' ? 1 : 0;
+  const pickPrimarySession = (
+    agentGroupId: string,
+  ): { container_status: string; last_active?: string | null } | undefined => {
+    const sessions = [...getSessionsByAgentGroup(agentGroupId)];
+    sessions.sort((a, b) => byAliveness(b) - byAliveness(a));
+    return sessions[0];
+  };
+
   const masterAg = all.find((g) => g.fleet_role === 'master' && (g.status ?? 'active') === 'active');
   let master: MasterSummary | null = null;
   if (masterAg) {
-    const sessions = getSessionsByAgentGroup(masterAg.id);
-    const primary = sessions[0];
+    const primary = pickPrimarySession(masterAg.id);
     master = {
       name: masterAg.name,
       backend: masterAg.fleet_backend ?? masterAg.agent_provider ?? null,
@@ -103,12 +115,7 @@ export function getFleetSummary(): FleetSummary {
   const workers: WorkerSummary[] = all
     .filter((g) => g.fleet_role === 'worker')
     .map((g) => {
-      const sessions = getSessionsByAgentGroup(g.id);
-      // Pick the "most alive" session — running > idle > stopped — for display.
-      const byAliveness = (s: { container_status: string }): number =>
-        s.container_status === 'running' ? 2 : s.container_status === 'idle' ? 1 : 0;
-      sessions.sort((a, b) => byAliveness(b) - byAliveness(a));
-      const primary = sessions[0];
+      const primary = pickPrimarySession(g.id);
       const mgs = getMessagingGroupsByAgentGroup(g.id);
       return {
         name: g.name,

--- a/src/modules/fleet/list-workers.ts
+++ b/src/modules/fleet/list-workers.ts
@@ -54,7 +54,7 @@ export interface FleetSummary {
  * "Up 5 minutes" — kept as-is and the "Up " prefix is stripped in the
  * formatter.
  */
-function readRunningUptimes(): Map<string, string> {
+export function readRunningUptimes(): Map<string, string> {
   const map = new Map<string, string>();
   try {
     const out = execSync(`docker ps --filter name=nanoclaw-v2- --format '{{.Names}}|{{.Status}}'`, {
@@ -164,9 +164,8 @@ export function formatFleetSummary(s: FleetSummary): string {
   const lines: string[] = [];
 
   if (s.master) {
-    const modelStr = s.master.model ? `\`${s.master.model}\`` : `\`${s.master.backend ?? 'claude'}\``;
     const uptimeStr = s.master.container_uptime ? `up ${s.master.container_uptime}` : s.master.container_status;
-    lines.push(`**Master** · ${modelStr} · ${uptimeStr}`);
+    lines.push(`**Master** · ${formatModel(s.master)} · ${uptimeStr}`);
     lines.push('');
   }
 

--- a/src/modules/fleet/profile-sync.test.ts
+++ b/src/modules/fleet/profile-sync.test.ts
@@ -57,6 +57,18 @@ describe('syncWorkerProfiles', () => {
     expect(result.unchanged).toEqual([]);
   });
 
+  it('triggers sync when only skills_repo is set (regression)', () => {
+    makeWorker('alpha');
+    mockLoadProfile.mockReturnValue({ skills_repo: 'neuralwatt-claude-skills' });
+    const result = syncWorkerProfiles();
+    // Without the skills_repo guard in the empty-profile check this would
+    // silently skip — the "only skills_repo" profile is real and the sync
+    // must run so existing workers pick up the new skills source.
+    expect(result.updated).toEqual(['alpha']);
+    const cfg = JSON.parse(fs.readFileSync(path.join(TEST_DIR, 'groups', 'alpha', 'container.json'), 'utf-8'));
+    expect(cfg.fleetProfile.skills_repo).toBe('neuralwatt-claude-skills');
+  });
+
   it('updates a worker whose container.json lacks the current profile', () => {
     makeWorker('alpha');
     mockLoadProfile.mockReturnValue({

--- a/src/modules/fleet/profile-sync.test.ts
+++ b/src/modules/fleet/profile-sync.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `syncWorkerProfiles`. Mocks the worker-profile loader so we
+ * can supply hand-built profiles without touching the user's real
+ * `~/.config/nanoclaw/`. Container-config read/write goes through the
+ * `config.ts` GROUPS_DIR which we point at /tmp.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from '../../db/index.js';
+import { updateAgentGroup } from '../../db/agent-groups.js';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-profilesync', GROUPS_DIR: '/tmp/nanoclaw-test-profilesync/groups' };
+});
+
+const mockLoadProfile = vi.fn();
+vi.mock('./worker-profile.js', async () => {
+  const actual = (await vi.importActual('./worker-profile.js')) as object;
+  return { ...actual, loadWorkerProfile: () => mockLoadProfile() };
+});
+
+const { syncWorkerProfiles } = await import('./profile-sync.js');
+
+const TEST_DIR = '/tmp/nanoclaw-test-profilesync';
+
+function makeWorker(folder: string, opts: { archived?: boolean } = {}): void {
+  const id = `ag-${folder}`;
+  createAgentGroup({ id, name: folder, folder, agent_provider: 'claude', created_at: new Date().toISOString() });
+  updateAgentGroup(id, { fleet_role: 'worker', status: opts.archived ? 'archived' : 'active' });
+  fs.mkdirSync(path.join(TEST_DIR, 'groups', folder), { recursive: true });
+  fs.writeFileSync(path.join(TEST_DIR, 'groups', folder, 'container.json'), JSON.stringify({ provider: 'claude' }));
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(path.join(TEST_DIR, 'groups'), { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+  mockLoadProfile.mockReset();
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('syncWorkerProfiles', () => {
+  it('skips when profile is empty', () => {
+    makeWorker('alpha');
+    mockLoadProfile.mockReturnValue({});
+    const result = syncWorkerProfiles();
+    expect(result.updated).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  it('updates a worker whose container.json lacks the current profile', () => {
+    makeWorker('alpha');
+    mockLoadProfile.mockReturnValue({
+      repos: [{ url: 'git@github.com:org/repo.git' }],
+      tools: ['uv tool install foo --force'],
+    });
+    const result = syncWorkerProfiles();
+    expect(result.updated).toEqual(['alpha']);
+    expect(result.unchanged).toEqual([]);
+    const cfg = JSON.parse(fs.readFileSync(path.join(TEST_DIR, 'groups', 'alpha', 'container.json'), 'utf-8'));
+    expect(cfg.fleetProfile.repos).toEqual([{ url: 'git@github.com:org/repo.git' }]);
+    expect(cfg.fleetProfile.tools).toEqual(['uv tool install foo --force']);
+    // Other fields preserved.
+    expect(cfg.provider).toBe('claude');
+  });
+
+  it('reports unchanged for a worker whose profile already matches', () => {
+    makeWorker('alpha');
+    const profile = { repos: [{ url: 'git@github.com:org/repo.git' }] };
+    mockLoadProfile.mockReturnValue(profile);
+    syncWorkerProfiles(); // first run writes
+    const result = syncWorkerProfiles(); // second run is a no-op
+    expect(result.unchanged).toEqual(['alpha']);
+    expect(result.updated).toEqual([]);
+  });
+
+  it('skips archived workers — only active workers get re-synced', () => {
+    makeWorker('alpha');
+    makeWorker('archived-one', { archived: true });
+    mockLoadProfile.mockReturnValue({ repos: [{ url: 'x' }] });
+    const result = syncWorkerProfiles();
+    expect(result.updated).toEqual(['alpha']);
+    expect(result.unchanged).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('captures errors per-worker without aborting the loop', () => {
+    makeWorker('alpha');
+    makeWorker('beta');
+    // Make beta's container.json unreadable by deleting the dir.
+    fs.rmSync(path.join(TEST_DIR, 'groups', 'beta'), { recursive: true });
+    mockLoadProfile.mockReturnValue({ repos: [{ url: 'x' }] });
+    const result = syncWorkerProfiles();
+    // alpha succeeds; beta is treated as fresh because readContainerConfig
+    // returns an empty config when the dir is missing — both end up
+    // updated. The test ensures the loop completes without throwing.
+    expect(result.errors).toEqual([]);
+    expect([...result.updated].sort()).toEqual(['alpha', 'beta']);
+  });
+});

--- a/src/modules/fleet/profile-sync.ts
+++ b/src/modules/fleet/profile-sync.ts
@@ -35,8 +35,17 @@ export function syncWorkerProfiles(): ProfileSyncResult {
   const profile = loadWorkerProfile();
 
   // No-op when there's no user profile — leaves workers on their
-  // create-time config rather than wiping anything.
-  if (!profile.repos?.length && !profile.tools?.length && !profile.mounts?.length && !profile.env) {
+  // create-time config rather than wiping anything. `skills_repo` counts
+  // as content too: a profile that only points at a skills repo is still
+  // meaningful and should trigger a sync (otherwise edits to which repo
+  // skills come from would silently never propagate to existing workers).
+  if (
+    !profile.repos?.length &&
+    !profile.tools?.length &&
+    !profile.mounts?.length &&
+    !profile.env &&
+    !profile.skills_repo
+  ) {
     log.info('Profile sync: no profile defined (or empty), skipping');
     return result;
   }

--- a/src/modules/fleet/profile-sync.ts
+++ b/src/modules/fleet/profile-sync.ts
@@ -1,0 +1,76 @@
+/**
+ * Profile sync at host startup — re-applies the current worker profile
+ * to every active worker's `groups/<folder>/container.json`. Mirrors v1
+ * fleet's `syncWorkerProfiles()` (FORK-SPEC §7.4).
+ *
+ * Why: in v2, the profile is only applied at create-worker / resume-worker
+ * time. If the user edits `~/.config/nanoclaw/worker-profiles/default.json`
+ * (e.g. adds a repo, bumps a tool version, tightens a mount), existing
+ * workers stay on their old config until destroyed and recreated. This
+ * loop runs at host start so an edit-then-restart cycle propagates the
+ * change to every active worker.
+ *
+ * Sync rule: clobber `additionalMounts` and `fleetProfile` from the
+ * current profile. Other container.json fields (provider, providers,
+ * skills, agentProvider) are preserved — those are owned by other
+ * subsystems (switch_backend, OneCLI, etc.). The profile owns repos /
+ * tools / mounts / env only.
+ *
+ * Takes effect on the next container spawn for each worker. Does not
+ * disturb running containers; they'll see the new config on respawn.
+ */
+import { getActiveAgentGroups } from '../../db/agent-groups.js';
+import { readContainerConfig, writeContainerConfig } from '../../container-config.js';
+import { log } from '../../log.js';
+import { applyProfileToContainerConfig, loadWorkerProfile } from './worker-profile.js';
+
+export interface ProfileSyncResult {
+  updated: string[];
+  unchanged: string[];
+  errors: Array<{ folder: string; err: string }>;
+}
+
+export function syncWorkerProfiles(): ProfileSyncResult {
+  const result: ProfileSyncResult = { updated: [], unchanged: [], errors: [] };
+  const profile = loadWorkerProfile();
+
+  // No-op when there's no user profile — leaves workers on their
+  // create-time config rather than wiping anything.
+  if (!profile.repos?.length && !profile.tools?.length && !profile.mounts?.length && !profile.env) {
+    log.info('Profile sync: no profile defined (or empty), skipping');
+    return result;
+  }
+
+  const workers = getActiveAgentGroups().filter((g) => g.fleet_role === 'worker');
+
+  for (const w of workers) {
+    try {
+      const cfg = readContainerConfig(w.folder);
+      const next = applyProfileToContainerConfig(cfg, profile);
+
+      // Cheap content compare — both sides are JSON-shaped.
+      const before = JSON.stringify({
+        additionalMounts: cfg.additionalMounts,
+        fleetProfile: (cfg as { fleetProfile?: unknown }).fleetProfile,
+      });
+      const after = JSON.stringify({ additionalMounts: next.additionalMounts, fleetProfile: next.fleetProfile });
+      if (before === after) {
+        result.unchanged.push(w.folder);
+        continue;
+      }
+      writeContainerConfig(w.folder, next);
+      result.updated.push(w.folder);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn('Profile sync failed for worker', { folder: w.folder, err: msg });
+      result.errors.push({ folder: w.folder, err: msg });
+    }
+  }
+
+  log.info('Profile sync complete', {
+    updated: result.updated.length,
+    unchanged: result.unchanged.length,
+    errors: result.errors.length,
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary

Accumulating PR for porting v1 fleet features that v2 lost in the rewrite. Will continue receiving commits as additional gaps are addressed.

### Landed so far

- **\`list_workers\` dashboard** — returns master state line + per-worker icons + container uptime + summary footer. Mirrors v1 \`nc-status.sh\` (FORK-SPEC §13.2).
- **Profile sync at host startup** — re-applies current \`~/.config/nanoclaw/worker-profiles/default.json\` to every active worker's \`container.json\` so profile edits propagate without destroying + recreating each worker (FORK-SPEC §7.4).

### Tests

10 new vitest cases (5 each):

- \`list-workers.test.ts\`: empty fleet, master-down state, mixed worker statuses + icons, summary counters, no-master path
- \`profile-sync.test.ts\`: empty-profile no-op, applies on diff, unchanged on no-diff, skips archived workers, captures errors per-worker without aborting

### To do (more commits coming)

- \`transfer_worker\` MCP tool (atomic backend migration)
- \`/status\` slash skill (sugar over the enriched list_workers)
- \`restart-watchdog\` mechanism (let agents trigger host rebuilds)
- Possibly: master self-destruction guard, register_group, refresh_groups

Don't merge yet — will run /code-review and /simplify after a few more gaps land.