### PR TITLE
feat(compact): post-compaction notice in Discord

### DIFF
--- a/container/agent-runner/src/providers/claude.test.ts
+++ b/container/agent-runner/src/providers/claude.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { closeSessionDb, getInboundDb, initTestSessionDb } from '../db/connection.js';
 import { getUndeliveredMessages } from '../db/messages-out.js';
-import { sendCompactionNotice } from './claude.js';
+import { sendCompactionNotice, sendPostCompactionNotice } from './claude.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -55,6 +55,28 @@ describe('sendCompactionNotice', () => {
 
   it('silently skips when session routing is missing', () => {
     sendCompactionNotice('auto');
+    expect(getUndeliveredMessages().length).toBe(0);
+  });
+});
+
+describe('sendPostCompactionNotice', () => {
+  it('writes a "compaction complete" chat message back to the same channel', () => {
+    setSessionRouting('discord', 'channel-123', 'thread-456');
+    sendPostCompactionNotice('auto');
+
+    const out = getUndeliveredMessages();
+    expect(out.length).toBe(1);
+    expect(out[0].kind).toBe('chat');
+    expect(out[0].channel_type).toBe('discord');
+    expect(out[0].platform_id).toBe('channel-123');
+    expect(out[0].thread_id).toBe('thread-456');
+    const content = JSON.parse(out[0].content);
+    expect(content.text).toContain('Compaction complete');
+    expect(content.text).toContain('auto');
+  });
+
+  it('silently skips when session routing is missing', () => {
+    sendPostCompactionNotice('auto');
     expect(getUndeliveredMessages().length).toBe(0);
   });
 });

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 
-import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query as sdkQuery,
+  type HookCallback,
+  type PostCompactHookInput,
+  type PreCompactHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
 import { writeMessageOut } from '../db/messages-out.js';
@@ -232,6 +237,43 @@ export function sendCompactionNotice(trigger: string): void {
   }
 }
 
+/**
+ * Closes the loop opened by sendCompactionNotice — the user knows the
+ * agent went silent for compaction and is waiting to hear it's back.
+ * The SDK auto-continues the in-flight conversation after compaction
+ * (so any user message that arrived during it is processed normally),
+ * which means this notice + the agent's actual reply land back-to-back.
+ */
+export function sendPostCompactionNotice(trigger: string): void {
+  try {
+    const routing = getSessionRouting();
+    if (!routing.channel_type || !routing.platform_id) {
+      log('Skipping post-compaction notice — no session routing');
+      return;
+    }
+    writeMessageOut({
+      id: randomUUID(),
+      kind: 'chat',
+      platform_id: routing.platform_id,
+      channel_type: routing.channel_type,
+      thread_id: routing.thread_id,
+      content: JSON.stringify({
+        text: `✅ Compaction complete (${trigger}). Continuing…`,
+      }),
+      systemNotice: true,
+    });
+    log(`Sent post-compaction notice (trigger=${trigger})`);
+  } catch (err) {
+    log(`Failed to send post-compaction notice: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+const postCompactHook: HookCallback = async (input) => {
+  const postCompact = input as PostCompactHookInput;
+  sendPostCompactionNotice(postCompact.trigger || 'auto');
+  return {};
+};
+
 function createPreCompactHook(assistantName?: string): HookCallback {
   return async (input) => {
     const preCompact = input as PreCompactHookInput;
@@ -358,6 +400,7 @@ export class ClaudeProvider implements AgentProvider {
           PostToolUse: [{ hooks: [postToolUseHook] }],
           PostToolUseFailure: [{ hooks: [postToolUseHook] }],
           PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+          PostCompact: [{ hooks: [postCompactHook] }],
         },
       },
     });


### PR DESCRIPTION
## Summary

User feedback: after the "⏳ Compacting context (auto)…" notice fires, the agent goes silent for a few seconds while the SDK builds the summary, then resumes. Pre-notice with no closing notice reads as "agent crashed" from the user's side.

Adds a \`PostCompact\` SDK hook that writes a closing notice to the same channel:

> ✅ Compaction complete (auto). Continuing…

Mirrors the structure of the existing \`sendCompactionNotice\` / \`PreCompact\` hook.

## Depends on #113

This PR is stacked on #113 (chat-delivery flag) — without that PR's \`systemNotice\` carve-out, both pre and post compaction notices would falsely count as the agent's reply and the agent's actual trailing-text reply (if any) would be dropped. Merge #113 first.

## On "auto-resume"

The user also asked for the agent to auto-resume post-compaction. The SDK already auto-continues the in-flight conversation after compaction (the same query iterator stays open and processes any pending user message normally), so this notice + the agent's real reply land back-to-back. No separate auto-resume plumbing is needed.

## Test plan

- [x] 62/62 agent-runner bun:test pass (+2 for the new function)
- [x] 264/264 host vitest pass
- [x] Container typecheck clean
- [x] Stacked on #113's \`systemNotice\` flag — post-compact notice does NOT bump the chat-delivery counter
- [ ] After merge + agent-runner mount picks up the change: trigger a manual compaction in a test worker, confirm both notices land