### PR TITLE
fix(formatter): host-side chat-delivery flag (revive v1 design)

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -30,6 +30,14 @@ export interface WriteMessageOut {
   channel_type?: string | null;
   thread_id?: string | null;
   content: string;
+  /**
+   * Set true for host-side housekeeping notices (compaction notice, system
+   * alerts) that land in chat but do NOT represent the agent's reply to
+   * the user. Without this, the chat-delivery counter would falsely report
+   * "agent already replied this turn" and dispatchResultText would drop
+   * the agent's actual trailing-text reply. Default false (counts as reply).
+   */
+  systemNotice?: boolean;
 }
 
 /**
@@ -100,8 +108,10 @@ export function writeMessageOut(msg: WriteMessageOut): number {
   // Track immediate chat deliveries so the poll loop can suppress the
   // trailing turn-text when the agent already replied via tool. Skip
   // scheduled messages (deliver_after set) — those land in the future
-  // and don't satisfy the current turn's reply obligation.
-  if (!msg.deliver_after && (msg.kind === 'chat' || msg.kind === 'chat-sdk')) {
+  // and don't satisfy the current turn's reply obligation. Skip system
+  // notices (compaction notice, etc.) — host-side housekeeping that
+  // shouldn't pretend to be the agent's reply.
+  if (!msg.deliver_after && !msg.systemNotice && (msg.kind === 'chat' || msg.kind === 'chat-sdk')) {
     chatDeliveryCount++;
   }
 

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -33,6 +33,30 @@ export interface WriteMessageOut {
 }
 
 /**
+ * Per-turn count of immediate chat deliveries the agent has produced via
+ * MCP tools (send_message, send_file, ask_user_question, list_workers
+ * dashboards, etc.). The poll loop reads this at result-event time and
+ * drops the trailing turn-text when it's > 0 — the agent already replied
+ * via tool, so the trailing text would be a duplicate. Reset at each new
+ * batch boundary via resetChatDeliveryCount().
+ *
+ * v1 parity: revives `groupsSentMessage` / `didGroupSendMessage` from
+ * v1's src/ipc.ts — host tracks "did the agent reply this turn?" so the
+ * agent never has to reason about turn boundaries (which broke
+ * post-compaction when the agent's summary made it think a prior turn's
+ * send_message was "this turn").
+ */
+let chatDeliveryCount = 0;
+
+export function getChatDeliveryCount(): number {
+  return chatDeliveryCount;
+}
+
+export function resetChatDeliveryCount(): void {
+  chatDeliveryCount = 0;
+}
+
+/**
  * Write a new outbound message, auto-assigning an odd seq number.
  * Container uses odd seq (1, 3, 5...), host uses even (2, 4, 6...).
  *
@@ -73,6 +97,14 @@ export function writeMessageOut(msg: WriteMessageOut): number {
       $content: msg.content,
     });
 
+  // Track immediate chat deliveries so the poll loop can suppress the
+  // trailing turn-text when the agent already replied via tool. Skip
+  // scheduled messages (deliver_after set) — those land in the future
+  // and don't satisfy the current turn's reply obligation.
+  if (!msg.deliver_after && (msg.kind === 'chat' || msg.kind === 'chat-sdk')) {
+    chatDeliveryCount++;
+  }
+
   // Best-effort wake so the host delivers immediately instead of waiting
   // for the next 1s poll tick. Dropped wakes are benign — the poll catches
   // the row on the next tick. Scheduled messages (deliver_after in the
@@ -109,9 +141,7 @@ export function getMessageIdBySeq(seq: number): string | null {
   const inbound = getInboundDb();
 
   // Inbound messages: ID is already the platform message ID
-  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as
-    | { id: string }
-    | undefined;
+  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as { id: string } | undefined;
   if (inRow) return inRow.id;
 
   // Outbound messages: look up platform message ID from delivered table

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -143,6 +143,49 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
+  it('system-notice writes (e.g. compaction notice) do NOT count as agent reply', async () => {
+    // Regression guard: pre/post-compaction notices land in chat as
+    // host-side housekeeping (kind 'chat', delivered to the user's
+    // channel) — but they're NOT the agent's reply. Without the
+    // systemNotice flag they'd increment chatDeliveryCount, the
+    // agent's actual trailing-text reply would be dropped, and the
+    // user would see the notice but no real answer.
+    insertMessage(
+      'm1',
+      { sender: 'Alice', text: 'Hi' },
+      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
+    );
+
+    const reply = 'Here is the answer the user actually asked for.';
+    const provider = new MockProvider({}, () => {
+      // Simulate sendCompactionNotice firing mid-turn.
+      writeMessageOut({
+        id: 'compaction-notice-1',
+        kind: 'chat',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        thread_id: 'thread-1',
+        content: JSON.stringify({ text: '⏳ Compacting context…' }),
+        systemNotice: true,
+      });
+      return reply;
+    });
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
+
+    await waitFor(() => getUndeliveredMessages().length >= 2, 1500);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(2);
+    const texts = out.map((m) => JSON.parse(m.content).text);
+    expect(texts).toContain('⏳ Compacting context…');
+    expect(texts).toContain(reply);
+
+    await loopPromise.catch(() => {});
+  });
+
   it('salvages internal-only output when no chat delivery ran (rather than going silent)', async () => {
     // Bug PR #93 surfaced: agent emits ONLY <internal>...</internal> with no
     // chat delivery via tool. Old behavior stripped the wrapper, leaving

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
-import { getUndeliveredMessages } from './db/messages-out.js';
+import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { getPendingMessages } from './db/messages-in.js';
 import { MockProvider } from './providers/mock.js';
 import { runPollLoop } from './poll-loop.js';
@@ -82,71 +82,70 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
-  it('drops trailing text when the agent wrapped it in <internal> and send_message ran', async () => {
-    // Canonical ack-then-work: agent sent the substantive reply via
-    // send_message, then closed with `<internal>done</internal>`. Stripping
-    // the wrapper leaves "" → nothing lands in outbound (correct: the
-    // reply already went via send_message). Salvage doesn't fire here
-    // because send_message ran (we shouldn't re-surface the wrapped text
-    // as if it were the missing reply). The MCP-side send_message itself
-    // is a no-op in MockProvider, so the only thing that *would* land in
-    // outbound is the scratchpad — assert nothing lands.
-    insertMessage(
-      'm1',
-      { sender: 'Alice', text: 'Do the thing' },
-      { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
-    );
-
-    const provider = new MockProvider(
-      {},
-      () => '<internal>Sent reply via send_message. No further output needed.</internal>',
-      ['mcp__nanoclaw__send_message'],
-    );
-
-    const controller = new AbortController();
-    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
-
-    // Wait for the result event by waiting for the message to be ack'd.
-    await waitFor(() => getPendingMessages().length === 0, 1500);
-    controller.abort();
-
-    expect(getUndeliveredMessages()).toHaveLength(0);
-
-    await loopPromise.catch(() => {});
-  });
-
-  it('delivers substantive trailing text even when send_message ran earlier (no auto-suppress)', async () => {
-    // models-endpoint regression: agent calls send_message early ("On it…"),
-    // does the work, then writes a substantive summary as the trailing
-    // turn-result text. The previous auto-suppress-when-send_message-ran
-    // logic dropped these summaries. We now deliver them — the agent is
-    // expected to explicitly wrap closing chatter in <internal> when it
-    // wants suppression (see core.instructions.md).
+  it('drops trailing text whenever the agent already delivered chat via tool this turn', async () => {
+    // v1 design: host tracks "did the agent deliver this turn?" via a
+    // chat-delivery counter incremented inside writeMessageOut. If yes,
+    // the trailing turn-text is dropped — substantive or not, wrapped
+    // or not. The agent is instructed to call send_message for anything
+    // it wants delivered; trailing turn-text is scratchpad.
+    //
+    // Why not the previous "agent self-wraps in <internal>" design: it
+    // broke after Claude SDK auto-compaction, where the compacted summary
+    // made the agent think a prior turn's send_message was "this turn"
+    // and wrap the new reply too. The user got bare scratchpad
+    // ("Reply delivered via send_message.") instead of an answer.
+    //
+    // We invoke writeMessageOut directly from inside the responseFactory
+    // to simulate the delivery the real send_message MCP tool would have
+    // produced — that's what the suppression keys off.
     insertMessage(
       'm1',
       { sender: 'Alice', text: 'check the pricing_tbd models' },
       { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
     );
 
-    const summary = 'PR #2829 is up. Migration 173 covers all three base models (K2.5, MiniMax, Devstral).';
-    const provider = new MockProvider({}, () => summary, ['mcp__nanoclaw__send_message']);
+    const summary = 'PR #2829 is up. Migration 173 covers all three base models.';
+    const provider = new MockProvider({}, () => {
+      // Simulate the real send_message tool firing during the turn.
+      writeMessageOut({
+        id: 'tool-delivered-1',
+        kind: 'chat',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        thread_id: 'thread-1',
+        content: JSON.stringify({ text: 'On it — checking now…' }),
+      });
+      return summary;
+    });
 
     const controller = new AbortController();
     const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
 
+    // Wait until the early ack lands in outbound — that guarantees the
+    // mock provider's responseFactory ran (and wrote the ack via tool)
+    // and dispatchResultText fired (deciding what to do with trailing
+    // text). Polling pending status alone is racy: it flips when the
+    // loop marks 'processing', not when the result event completes.
     await waitFor(() => getUndeliveredMessages().length > 0, 1500);
+    // Give dispatchResultText one tick to write the trailing text if it
+    // was going to (it shouldn't, but we want to assert that, not race
+    // it).
+    await sleep(50);
     controller.abort();
 
+    // Exactly one delivery — the early ack. The substantive summary as
+    // trailing turn-text was dropped. The agent is expected to call
+    // send_message a second time for the summary.
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
-    expect(JSON.parse(out[0].content).text).toBe(summary);
+    expect(JSON.parse(out[0].content).text).toBe('On it — checking now…');
 
     await loopPromise.catch(() => {});
   });
 
-  it('salvages internal-only output when no send_message ran (rather than going silent)', async () => {
+  it('salvages internal-only output when no chat delivery ran (rather than going silent)', async () => {
     // Bug PR #93 surfaced: agent emits ONLY <internal>...</internal> with no
-    // send_message tool_use. Old behavior stripped the wrapper, leaving
+    // chat delivery via tool. Old behavior stripped the wrapper, leaving
     // empty text, leaving the user with silence. New behavior unwraps the
     // <internal> block and surfaces the text — weird-looking but not
     // silent, so the user can see the agent's broken state and ask again.
@@ -156,11 +155,7 @@ describe('poll loop integration', () => {
       { platformId: 'chan-1', channelType: 'discord', threadId: 'thread-1' },
     );
 
-    const provider = new MockProvider(
-      {},
-      () => '<internal>Acknowledged via send_message.</internal>',
-      [], // no tool_use this turn
-    );
+    const provider = new MockProvider({}, () => '<internal>Acknowledged via send_message.</internal>');
 
     const controller = new AbortController();
     const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 1500);
@@ -199,7 +194,7 @@ describe('poll loop integration', () => {
     const provider = new MockProvider(
       {},
       () => '<internal>Done — answered the BetterStack best practice question and surfaced the open PR.</internal>',
-      [], // critically: no send_message tool_use — salvage triggers
+      // critically: no chat delivery via tool this turn — salvage triggers
     );
 
     const controller = new AbortController();

--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -22,16 +22,16 @@ Bad acks (too vague, missing, or late):
 
 The user is often on a phone screen, doesn't see your tool calls, and only knows you exist when a chat message arrives. Silence reads as broken.
 
-### Avoid duplicate messages
+### How replies reach the user
 
-`send_message` posts a chat reply immediately. Your final turn output is _also_ delivered as a chat message — so without care the user sees a duplicate. **When you've already delivered the substantive reply via `send_message`, wrap any trailing closing chatter in `<internal>...</internal>` so it gets stripped before delivery.** The wrapper is your "this is scratchpad, not for the user" marker.
+You have two paths to the chat:
 
-Rule of thumb: if the trailing text would be _useful_ to the user, leave it unwrapped — let it land in chat. If it's just "ok, done" chatter that adds nothing on top of what `send_message` already delivered, wrap it.
+1. **MCP delivery tools** (`send_message`, `send_file`, `ask_user_question`, etc.) — post immediately, mid-turn. Use these for everything you want the user to see, including substantive end-of-turn summaries.
+2. **Trailing turn-text** — anything you write at the end of a turn that's not inside a `<message to="…">` block. The host delivers this as a reply **only if you didn't call any delivery tool this turn**. If you did call one, the trailing text is dropped (logged as scratchpad, not sent).
 
-Common patterns:
+That means: if you want the user to see it, send it via tool. If you want to think out loud at the end, just write it — it'll be silently dropped when redundant. No wrapping needed.
 
-- **Ack early, substantive reply at end** — `send_message` "On it…", do the work, then write the substantive findings as the trailing text. No wrap; the trailing text IS the answer.
-- **Substantive reply via send_message, brief close** — `send_message` with the answer, then `<internal>Done.</internal>` so the close doesn't double-post.
+`<internal>...</internal>` is for the rarer case where you want to write scratchpad even though you have nothing to deliver — e.g. you're staying silent on purpose. Wrapping is a hint to log-readers, not a load-bearing suppression mechanism.
 
 ### Pacing updates on longer turns
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,6 +1,6 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
-import { writeMessageOut } from './db/messages-out.js';
+import { writeMessageOut, getChatDeliveryCount, resetChatDeliveryCount } from './db/messages-out.js';
 import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { logTurn } from './audit-log.js';
 import { getStoredSessionId, setStoredSessionId, clearStoredSessionId } from './db/session-state.js';
@@ -346,12 +346,13 @@ async function processQuery(
   const traceId = initialBatchIds.join(',');
   const tStart = Date.now();
   let firstEventAt: number | null = null;
-  // Count of mcp__nanoclaw__send_message tool_use events in the current
-  // turn. Reset on every result so each turn's count stands alone.
-  // dispatchResultText reads this to decide whether the final turn text
-  // is a duplicate of a real reply already delivered via send_message
-  // (drop it) or the only output the agent produced (surface it).
-  let sendMessageToolUseCount = 0;
+  // Per-turn chat-delivery counter is module-level state in messages-out.ts —
+  // every writeMessageOut call with kind 'chat'/'chat-sdk' increments it.
+  // dispatchResultText reads it to decide whether the trailing turn-text is
+  // a duplicate of a real reply already delivered via tool (drop it) or the
+  // only output the agent produced (deliver / salvage it). Reset at turn
+  // start (here) and after every result event below.
+  resetChatDeliveryCount();
   try {
     for await (const event of query.events) {
       if (firstEventAt === null) {
@@ -361,11 +362,7 @@ async function processQuery(
       handleEvent(event, routing);
       touchHeartbeat();
 
-      if (event.type === 'tool_use') {
-        if (event.tool_name === 'mcp__nanoclaw__send_message') {
-          sendMessageToolUseCount++;
-        }
-      } else if (event.type === 'init') {
+      if (event.type === 'init') {
         queryContinuation = event.continuation;
         // Persist immediately so a mid-turn container crash still lets the
         // next wake resume the conversation. Without this, the session id
@@ -399,11 +396,11 @@ async function processQuery(
           stop_reason: usage?.stop_reason ?? null,
         });
         if (event.text) {
-          dispatchResultText(event.text, routing, { sendMessageToolUseCount });
+          dispatchResultText(event.text, routing, { chatDeliveryCount: getChatDeliveryCount() });
         }
         // Reset for the next turn (streaming-input mode pushes follow-up
         // user messages into the same query, each producing its own result).
-        sendMessageToolUseCount = 0;
+        resetChatDeliveryCount();
       }
     }
   } finally {
@@ -443,34 +440,24 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * Single-destination shortcut: if the agent has exactly one configured
  * destination AND the output contains zero <message> blocks, the entire
  * cleaned text (with <internal> tags stripped) is sent to that destination.
- * This preserves the simple case of one user on one channel — the agent
- * doesn't need to know about wrapping syntax at all.
  *
- * De-duplication when `send_message` ran: the agent is instructed (in
- * `core.instructions.md`) to wrap closing chatter in `<internal>...
- * </internal>` after using send_message so the trailing text is stripped
- * to empty here. We don't auto-drop trailing text whenever send_message
- * ran — that mistakes substantive end-of-turn summaries ("Here's the PR:
- * #2829, summary follows…") for "Done!" duplicates and silently eats them.
- * v1 behavior: trust the agent's wrap; surface anything that isn't wrapped.
+ * De-duplication: if the agent already delivered chat output via tool this
+ * turn (send_message, send_file, list_workers dashboard, ask_user_question,
+ * …), drop the trailing turn-text. This is v1's behavior — the host tracks
+ * "did the agent reply this turn?" so the agent never has to reason about
+ * turn boundaries. The previous v2 design (agent self-wraps with `<internal>`)
+ * broke after Claude SDK auto-compaction: the compacted summary made the
+ * agent think a prior turn's send_message was "this turn", so it wrapped
+ * the new turn's reply too and the user got a bare scratchpad note instead
+ * of an answer.
  *
- * The salvage path below catches the post-compaction failure mode where
- * the agent emits a stand-alone `<internal>` block with no send_message —
- * we'd otherwise go silent.
- */
-/**
- * Suffix appended to salvage-path output. The salvage path surfaces an
- * agent's wrapped-only output when no `send_message` ran — it prevents
- * silence, but the recovered content has often been a meta-claim like
- * "Done — answered the question" with no actual answer (post-compaction
- * confusion bug, observed 2026-04-30 across multiple workers). Without a
- * suffix the user reads the meta-claim as a deliberate reply and trusts
- * the agent. With a suffix the user knows to verify.
+ * The salvage path below catches the case where the agent emits a stand-alone
+ * `<internal>` block with no chat delivery at all — we'd otherwise go silent.
  */
 const SALVAGE_WARNING_SUFFIX =
   '⚠️ _scratchpad recovery — this came from the agent\'s internal monologue, not a deliberate `send_message`. If it reads like a vague claim ("done", "answered", "flagged") without the actual content, ask again._';
 
-function dispatchResultText(text: string, routing: RoutingContext, opts: { sendMessageToolUseCount: number }): void {
+function dispatchResultText(text: string, routing: RoutingContext, opts: { chatDeliveryCount: number }): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
 
   let match: RegExpExecArray | null;
@@ -501,24 +488,29 @@ function dispatchResultText(text: string, routing: RoutingContext, opts: { sendM
 
   const rawScratchpad = scratchpadParts.join('');
   const stripped = stripInternalTags(rawScratchpad);
-  // Salvage path: if the agent's only output was `<internal>...</internal>`
-  // (so stripping leaves nothing) AND no send_message tool_use covered
-  // the reply, treat the inner content as the actual message. Surfaces
-  // the agent's template / scratchpad text rather than dropping it
-  // silently — silence reads as "agent broken"; even a weird-looking
-  // ack ("Acknowledged via send_message.") signals the user can ask
-  // for the substantive answer.
-  //
-  // Append a warning suffix when this fires. We've seen agents emit
-  // wrapped meta-claims post-compaction ("Done — answered the X
-  // question") that the salvage surfaces verbatim; without the suffix
-  // the user reads it as a deliberate reply and trusts the claim. The
-  // suffix lets them recover quickly: noisy > misleading. User
-  // preference per discussion 2026-04-30: "bias towards more noisy
-  // output instead of overly quiet."
+
+  // v1 design: if the agent already delivered chat output via tool this
+  // turn, drop the trailing turn-text. It's redundant at best and (after
+  // compaction) often just `<internal>Reply delivered.</internal>`-style
+  // hallucination.
+  if (opts.chatDeliveryCount > 0) {
+    if (stripped) {
+      log(
+        `[scratchpad] (suppressed; ${opts.chatDeliveryCount} tool delivery this turn) ${stripped.slice(0, 200)}${stripped.length > 200 ? '…' : ''}`,
+      );
+    }
+    return;
+  }
+
+  // Salvage path: agent never delivered via tool, AND its only output was
+  // wrapped in `<internal>` (so stripping leaves nothing). Unwrap and
+  // surface — silence reads as broken; a weird-looking ack lets the user
+  // see the agent's confused state and re-ask. Suffix flags it so the
+  // user knows to verify rather than trust meta-claims like
+  // "Done — answered the question" verbatim.
   let scratchpad = stripped;
   let salvaged = false;
-  if (!stripped && opts.sendMessageToolUseCount === 0) {
+  if (!stripped) {
     const unwrapped = rawScratchpad.replace(/<\/?internal>/g, '').trim();
     if (unwrapped) {
       scratchpad = unwrapped;

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -224,6 +224,7 @@ export function sendCompactionNotice(trigger: string): void {
       content: JSON.stringify({
         text: `⏳ Compacting context (${trigger})… I'll be back in a moment.`,
       }),
+      systemNotice: true,
     });
     log(`Sent compaction notice (trigger=${trigger})`);
   } catch (err) {

--- a/container/skills/status/SKILL.md
+++ b/container/skills/status/SKILL.md
@@ -18,11 +18,7 @@ The user wants a snapshot of fleet state — master plus every worker, their bac
 
 ## What to do
 
-Call the `mcp__nanoclaw__list_workers` MCP tool. The host runs the query synchronously and posts a formatted dashboard (master state + per-worker bullets + summary footer) to the master's channel as a chat message. Your turn-result text after the call should be wrapped in `<internal>...</internal>` because the dashboard already landed via the MCP tool path — anything you write afterwards is duplicate chatter.
-
-```
-<internal>Status dashboard delivered via list_workers.</internal>
-```
+Call the `mcp__nanoclaw__list_workers` MCP tool. The host runs the query synchronously and posts a formatted dashboard (master state + per-worker bullets + summary footer) to the master's channel as a chat message. The dashboard delivery itself counts as your reply — the host drops your trailing turn-text automatically. Just end the turn after the tool call; nothing else to do.
 
 That's the entire skill.
 


### PR DESCRIPTION
## Summary

Post-Claude-SDK auto-compaction, workers were producing bare \`<internal>Reply delivered.</internal>\` scratchpad with no actual \`send_message\` — three turns in a row on \`worker-email\` until the user gave up. The salvage path surfaced the meta-claim with a warning suffix, but the agent kept doing it because the wrap-rule itself was the bug.

## Root cause

\`core.instructions.md\` told the agent "if you've already delivered via send_message, wrap closing chatter in \`<internal>\`." The Claude SDK's compacted summary describes the prior turn's send_message; the agent reads "I delivered via send_message" verbatim, applies the rule, wraps the new turn's reply as scratchpad, and emits no real send.

## Fix

Revive v1's \`groupsSentMessage\` flag (v1 \`src/ipc.ts\`). The host tracks "did the agent reply this turn?" via a chat-delivery counter incremented inside \`writeMessageOut\` for any \`kind: 'chat'/'chat-sdk'\` write that isn't scheduled. \`dispatchResultText\` reads it at result time; if > 0, the trailing turn-text is dropped. Counter resets at every turn boundary (processQuery start + after each result event).

The agent no longer reasons about turn boundaries at all — compaction can't confuse it because there's nothing for it to confuse. Same design v1 used; the previous self-wrap design was a v2 regression that introduced the post-compaction failure mode.

## Behavior change

Agents currently using "early ack via \`send_message\`, then substantive summary as trailing turn-text" must call \`send_message\` twice (once for ack, once for summary). v1 worked this way; the "summary as trailing text" pattern was a v2-only behavior introduced by 214d6bd's auto-suppress revert, which misremembered v1's semantics (v1 dropped trailing text unconditionally when send_message ran — checked at \`~/git/nanoclaw-fleet-v1-old/src/index.ts:290\`).

Salvage path stays as defense-in-depth: when no chat delivery happened this turn and the agent's only output was wrapped \`<internal>\`, unwrap and surface with the warning suffix.

## Test plan

- [x] 264/264 host vitest pass
- [x] 59/59 agent-runner bun:test pass