### PR TITLE
feat(compact): model-aware auto-compact window

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -355,9 +355,14 @@ export class ClaudeProvider implements AgentProvider {
     this.assistantName = options.assistantName;
     this.mcpServers = options.mcpServers ?? {};
     this.additionalDirectories = options.additionalDirectories;
+    // Default first, host-supplied env wins. Lets the host override
+    // CLAUDE_CODE_AUTO_COMPACT_WINDOW per-worker (resolved from the
+    // worker's model in src/compact-window.ts) without touching this
+    // constant. Pre-fix the spread order was inverted, so the hardcoded
+    // 165k always won regardless of what the host passed.
     this.env = {
-      ...(options.env ?? {}),
       CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+      ...(options.env ?? {}),
     };
   }
 

--- a/src/compact-window.test.ts
+++ b/src/compact-window.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { resolveCompactWindow } from './compact-window.js';
+
+let tmpDir: string;
+let limitsPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compact-window-'));
+  limitsPath = path.join(tmpDir, 'model-limits.json');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('resolveCompactWindow', () => {
+  it('uses the explicit override when provided', () => {
+    const result = resolveCompactWindow('claude-opus-4-7', { override: 500_000 });
+    expect(result).toBe(500_000);
+  });
+
+  it('returns 85% of context for known Claude models (1M-context Opus/Sonnet)', () => {
+    expect(resolveCompactWindow('claude-opus-4-7')).toBe(850_000);
+    expect(resolveCompactWindow('claude-sonnet-4-6')).toBe(850_000);
+  });
+
+  it('returns 85% of context for Claude Haiku (200k)', () => {
+    expect(resolveCompactWindow('claude-haiku-4-5')).toBe(170_000);
+  });
+
+  it('reads Neuralwatt limits from the cache file', () => {
+    fs.writeFileSync(limitsPath, JSON.stringify({ 'Qwen/Qwen3.6-35B-A3B': 131072, 'moonshotai/Kimi-K2.6': 262144 }));
+    expect(resolveCompactWindow('Qwen/Qwen3.6-35B-A3B', { limitsPath })).toBe(Math.floor(131072 * 0.85));
+    expect(resolveCompactWindow('moonshotai/Kimi-K2.6', { limitsPath })).toBe(Math.floor(262144 * 0.85));
+  });
+
+  it('falls back when model is unknown to both maps', () => {
+    fs.writeFileSync(limitsPath, JSON.stringify({ 'known-model': 100_000 }));
+    expect(resolveCompactWindow('unknown-model', { limitsPath })).toBe(165_000);
+  });
+
+  it('falls back when model is undefined', () => {
+    expect(resolveCompactWindow(undefined)).toBe(165_000);
+  });
+
+  it('honors custom fallback', () => {
+    expect(resolveCompactWindow('unknown', { limitsPath, fallback: 99_999 })).toBe(99_999);
+  });
+
+  it('survives missing limits cache file', () => {
+    expect(resolveCompactWindow('unknown', { limitsPath: '/nonexistent/path.json' })).toBe(165_000);
+  });
+
+  it('survives malformed limits cache file', () => {
+    fs.writeFileSync(limitsPath, 'not json');
+    expect(resolveCompactWindow('unknown', { limitsPath })).toBe(165_000);
+  });
+});

--- a/src/compact-window.ts
+++ b/src/compact-window.ts
@@ -1,0 +1,105 @@
+/**
+ * Resolve the per-worker auto-compact window — how many input tokens can
+ * accumulate before the Claude Agent SDK auto-summarizes the conversation.
+ *
+ * Why per-worker: a single hardcoded value (the previous 165k) compacts
+ * Opus/Sonnet workers at 16% of their 1M context, which both wastes context
+ * and creates more chances to trip the post-compaction failure modes. For
+ * shorter-context Neuralwatt models (128–256k) the same value either fires
+ * sensibly or never fires at all (model errors first).
+ *
+ * Resolution order:
+ *   1. Explicit per-worker override (caller passes a number)
+ *   2. Hardcoded Claude model → context map (we know these values)
+ *   3. Neuralwatt model-limits cache file (written by tools/anthropic-shim.ts)
+ *   4. Fallback (DEFAULT_FALLBACK_WINDOW)
+ *
+ * The returned value is ~85% of the model's context — leaves headroom for
+ * the response itself plus a buffer before the SDK starts summarizing.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+
+const COMPACT_RATIO = 0.85;
+const DEFAULT_FALLBACK_WINDOW = 165_000;
+
+/**
+ * Hardcoded Claude model context limits. Values come from Anthropic's
+ * published model docs and are stable for the lifetime of each model
+ * version — when adding a new model, look up its window once and add it
+ * here. Anthropic's `/v1/models` endpoint doesn't expose context length
+ * the way Neuralwatt's does, so we maintain this map by hand.
+ */
+const CLAUDE_MODEL_CONTEXT: Record<string, number> = {
+  // Claude 4.x — Opus and Sonnet support 1M context (extended)
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-sonnet-4-5-20250929': 1_000_000,
+  'claude-sonnet-4-20250514': 1_000_000,
+  'claude-haiku-4-5-20251001': 200_000,
+  'claude-haiku-4-5': 200_000,
+};
+
+/**
+ * Where the Neuralwatt limits cache lives. Resolution order:
+ *   1. NW_SHIM_MODEL_LIMITS_PATH env var (matches the shim's MODEL_LIMITS_PATH)
+ *   2. Same in .env file
+ *   3. Fallback to <cwd>/data/model-limits.json (the shim's default)
+ */
+function defaultLimitsPath(): string {
+  const fromProcess = process.env.NW_SHIM_MODEL_LIMITS_PATH;
+  if (fromProcess) return fromProcess;
+  try {
+    const fromEnvFile = readEnvFile(['NW_SHIM_MODEL_LIMITS_PATH']).NW_SHIM_MODEL_LIMITS_PATH;
+    if (fromEnvFile) return fromEnvFile;
+  } catch {
+    /* fallthrough */
+  }
+  return path.join(process.cwd(), 'data', 'model-limits.json');
+}
+
+let nwLimitsCache: { mtime: number; data: Record<string, number> } | null = null;
+
+function loadNeuralwattLimits(limitsPath: string = defaultLimitsPath()): Record<string, number> {
+  try {
+    if (!fs.existsSync(limitsPath)) return {};
+    const stat = fs.statSync(limitsPath);
+    if (nwLimitsCache && nwLimitsCache.mtime === stat.mtimeMs) return nwLimitsCache.data;
+    const data = JSON.parse(fs.readFileSync(limitsPath, 'utf-8')) as Record<string, number>;
+    nwLimitsCache = { mtime: stat.mtimeMs, data };
+    return data;
+  } catch {
+    return {};
+  }
+}
+
+export interface ResolveCompactWindowOptions {
+  /** Explicit per-worker override — wins over all auto-resolution. */
+  override?: number;
+  /** Path to the Neuralwatt limits cache. Defaults to `data/model-limits.json`. */
+  limitsPath?: string;
+  /** Fallback window when nothing matches. Defaults to 165k. */
+  fallback?: number;
+}
+
+/**
+ * Resolve the auto-compact window for a given model name. Pure function —
+ * tests can pass a custom limitsPath / fallback. Returns floor(ratio * context).
+ */
+export function resolveCompactWindow(model: string | undefined, opts: ResolveCompactWindowOptions = {}): number {
+  const fallback = opts.fallback ?? DEFAULT_FALLBACK_WINDOW;
+  if (typeof opts.override === 'number' && opts.override > 0) return opts.override;
+  if (!model) return fallback;
+
+  const claude = CLAUDE_MODEL_CONTEXT[model];
+  if (claude) return Math.floor(claude * COMPACT_RATIO);
+
+  const nwLimits = loadNeuralwattLimits(opts.limitsPath);
+  const nw = nwLimits[model];
+  if (nw) return Math.floor(nw * COMPACT_RATIO);
+
+  return fallback;
+}

--- a/src/compact-window.ts
+++ b/src/compact-window.ts
@@ -71,7 +71,13 @@ function loadNeuralwattLimits(limitsPath: string = defaultLimitsPath()): Record<
     const data = JSON.parse(fs.readFileSync(limitsPath, 'utf-8')) as Record<string, number>;
     nwLimitsCache = { mtime: stat.mtimeMs, data };
     return data;
-  } catch {
+  } catch (err) {
+    // Cache regenerates on the shim's next /v1/models refresh, so this
+    // is recoverable — but corruption shouldn't be invisible. Workers
+    // fall through to DEFAULT_FALLBACK_WINDOW until the cache repairs.
+    console.warn(
+      `[compact-window] Failed to read NW limits cache at ${limitsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return {};
   }
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -20,6 +20,7 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
+import { resolveCompactWindow } from './compact-window.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
 import { readEnvFile } from './env.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
@@ -607,6 +608,14 @@ async function buildContainerArgs(
       args.push('-e', `${key}=${value}`);
     }
   }
+
+  // Auto-compact window — resolve from the worker's model so 1M-context
+  // Claude / shorter-context Neuralwatt models compact at sensible
+  // thresholds instead of a one-size-fits-all 165k. See compact-window.ts.
+  const modelForCompact = providerContribution.env?.ANTHROPIC_MODEL;
+  const compactWindow = resolveCompactWindow(modelForCompact);
+  args.push('-e', `CLAUDE_CODE_AUTO_COMPACT_WINDOW=${compactWindow}`);
+  log.info('Resolved auto-compact window', { containerName, model: modelForCompact, window: compactWindow });
 
   // OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
   // are routed through the agent vault for credential injection.

--- a/tools/anthropic-shim.ts
+++ b/tools/anthropic-shim.ts
@@ -71,6 +71,11 @@ interface WorkerUsage {
 }
 
 const USAGE_PATH = process.env.USAGE_PATH || 'data/worker-usage.json';
+// Cache of upstream model context limits — host reads this to pick the
+// auto-compact window per worker. Refreshed on the same 5-min cadence as
+// modelsCache below; written atomically so the host always sees a complete
+// JSON object.
+const MODEL_LIMITS_PATH = process.env.MODEL_LIMITS_PATH || 'data/model-limits.json';
 
 let workerUsage: Record<string, WorkerUsage> = {};
 
@@ -163,6 +168,25 @@ loadUsage();
 let modelsCache: string[] | null = null;
 let modelsCacheTime = 0;
 
+function writeModelLimits(
+  entries: Array<{ id: string; max_model_len?: number; metadata?: { limits?: { max_context_length?: number } } }>,
+): void {
+  const limits: Record<string, number> = {};
+  for (const m of entries) {
+    const lim = m.metadata?.limits?.max_context_length ?? m.max_model_len;
+    if (typeof lim === 'number' && lim > 0) limits[m.id] = lim;
+  }
+  if (Object.keys(limits).length === 0) return;
+  try {
+    fs.mkdirSync(path.dirname(MODEL_LIMITS_PATH), { recursive: true });
+    const tmp = `${MODEL_LIMITS_PATH}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(limits, null, 2));
+    fs.renameSync(tmp, MODEL_LIMITS_PATH);
+  } catch (err) {
+    console.error(`[shim] Failed to write model-limits cache: ${err}`);
+  }
+}
+
 async function refreshModelsCache(): Promise<void> {
   const now = Date.now();
   if (modelsCache && now - modelsCacheTime < 5 * 60 * 1000) return;
@@ -172,8 +196,10 @@ async function refreshModelsCache(): Promise<void> {
     });
     if (resp.ok) {
       const data = await resp.json();
-      modelsCache = (data as any).data?.map((m: any) => m.id) || [];
+      const entries = (data as any).data || [];
+      modelsCache = entries.map((m: any) => m.id) || [];
       modelsCacheTime = now;
+      writeModelLimits(entries);
     }
   } catch {
     /* ignore */


### PR DESCRIPTION
## Summary

Replace the hardcoded 165k auto-compact threshold with per-model resolution. Pre-fix, every worker — Opus (1M context), Sonnet (1M), Kimi K2.6 (256k), Qwen 35B (128k) — compacted at the same value. That meant Opus workers compacted at 16% of capacity (wasted context, more chances to trip post-compaction failure modes), and short-context Neuralwatt workers risked never compacting at all (model errors before threshold fires).

## Pieces

- **\`src/compact-window.ts\`** — pure resolver. Hardcoded Claude model → context map (Anthropic doesn't expose context length on \`/v1/models\` the way Neuralwatt does, and there are <5 active Claude models, so a tiny by-hand map is fine). Neuralwatt models read from a cache file the shim writes. Returns \`floor(0.85 * context)\`.
- **\`tools/anthropic-shim.ts\`** — \`refreshModelsCache\` now also writes \`data/model-limits.json\` (atomic via tmp + rename) extracting \`metadata.limits.max_context_length\` / \`max_model_len\` from the upstream \`/v1/models\` response. Same 5-min cache cycle as the existing model id list.
- **\`src/container-runner.ts\`** — \`buildContainerArgs\` reads the worker's model from \`providerContribution.env.ANTHROPIC_MODEL\`, calls \`resolveCompactWindow\`, sets \`CLAUDE_CODE_AUTO_COMPACT_WINDOW\` via \`-e\`.
- **\`container/agent-runner/src/providers/claude.ts\`** — \`ClaudeProvider\` constructor's env merge order was inverted; the hardcoded 165k always won regardless of what the host passed. Default goes first now, options.env wins.

## Resolution order

1. Hardcoded Claude map (\`claude-opus-4-7\` → 1M, \`claude-haiku-4-5\` → 200k, …)
2. Neuralwatt \`/v1/models\` cache (\`data/model-limits.json\`)
3. Fallback to 165k (current behavior)

Per-worker explicit override is supported in the resolver but not yet wired into \`container.json\` — easy follow-up if anyone needs to tune a specific worker.

## Effect on existing workers (after host restart + new image)

| Model | Before | After |
|-|-|-|
| claude-opus-4-7 | 165k | 850k |
| claude-haiku-4-5 | 165k | 170k |
| Qwen/Qwen3.6-35B-A3B | 165k | 111k (was overflow risk) |
| moonshotai/Kimi-K2.6 | 165k | 222k |

## Test plan

- [x] 273/273 host vitest (+9 for compact-window resolver)
- [x] 62/62 agent-runner bun:test
- [x] Both typechecks clean
- [ ] After merge + host restart: spawn an Opus worker, confirm CLAUDE_CODE_AUTO_COMPACT_WINDOW=850000 in the container env (\`docker inspect\`)
- [ ] Confirm shim writes data/model-limits.json on next /models request