### PR TITLE
fix(fleet): validate model against backend before persisting

### DIFF
--- a/docs/fleet/architecture/inference-routing.md
+++ b/docs/fleet/architecture/inference-routing.md
@@ -80,6 +80,16 @@ The Neuralwatt shim is a separate process from NanoClaw. It reads `data/worker-b
 
 `syncShimBackendConfig()` in `src/modules/fleet/lib.ts` is called from `setFleetBackend` whenever the active backend is Neuralwatt. It reads `NW_SHIM_CONFIG_PATH` from the environment, opens the shim's `worker-backends.json`, and writes/updates the entry for this folder. Best effort — if the file is missing or unwritable, the host logs a warning and continues. Workers run fine without Neuralwatt; the sync only matters when you flip a worker onto the shim.
 
+## Pre-flight model validation
+
+`switch_backend`, `create_worker`, and the resume path all run the requested model through `resolveModelForBackend(backend, model)` (`src/modules/fleet/model-resolver.ts`) before any DB or `container.json` write. For `neuralwatt` this is a `GET <NW_SHIM_HOST_URL>/models/resolve/<query>` against the shim — the shim already does the fuzzy matching and knows the live model catalogue. The canonical id from the shim (e.g. `zai-org/GLM-5.1-FP8` for input `GLM-5.1`) is what gets persisted.
+
+If the shim returns 404 (no match) or 503 (catalogue empty) or the connect fails, the helper throws `ModelResolutionError` and the handler `notifyAgent`s the master with the resolver's message — nothing is persisted. This avoids the failure mode where a bad model id silently lands in `container.json` + `worker-backends.json` and surfaces only later as an SDK "model not available" error inside the worker container, far from where the bad input came in.
+
+`claude` is pass-through. The SDK validates Claude model ids downstream and there's no shim hop where a bad value can poison routing for a container's whole lifetime.
+
+`NW_SHIM_HOST_URL` defaults to `http://127.0.0.1:3003` (the host's view of the shim, distinct from the container's `host.docker.internal:3003`).
+
 ## Runtime model switching
 
 Within Neuralwatt:
@@ -121,17 +131,18 @@ The streaming logic lives in the v1 shim (`tools/anthropic-shim.ts`) and is reus
 
 ## Files
 
-| File | Role |
-|-|-|
-| `src/modules/fleet/lib.ts` | `setFleetBackend`, `syncShimBackendConfig` |
-| `src/providers/claude.ts` | Host-side provider config: emits `ANTHROPIC_MODEL` from container.json |
-| `src/providers/neuralwatt.ts` | Host-side provider config: emits `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL` |
-| `src/providers/provider-container-registry.ts` | Registration plumbing |
-| `container/agent-runner/src/providers/claude.ts` | Container-side default provider |
-| `container/agent-runner/src/providers/neuralwatt.ts` | Container-side alias to ClaudeProvider |
-| `tools/anthropic-shim.ts` | The shim itself (v1 fleet, reused) |
-| `data/worker-backends.json` | Shim's per-folder backend/model state |
-| `groups/<folder>/container.json` | Per-agent-group provider config |
+| File                                                 | Role                                                                        |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| `src/modules/fleet/lib.ts`                           | `setFleetBackend`, `syncShimBackendConfig`                                  |
+| `src/modules/fleet/model-resolver.ts`                | `resolveModelForBackend` (pre-flight model validation against the shim)     |
+| `src/providers/claude.ts`                            | Host-side provider config: emits `ANTHROPIC_MODEL` from container.json      |
+| `src/providers/neuralwatt.ts`                        | Host-side provider config: emits `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL` |
+| `src/providers/provider-container-registry.ts`       | Registration plumbing                                                       |
+| `container/agent-runner/src/providers/claude.ts`     | Container-side default provider                                             |
+| `container/agent-runner/src/providers/neuralwatt.ts` | Container-side alias to ClaudeProvider                                      |
+| `tools/anthropic-shim.ts`                            | The shim itself (v1 fleet, reused)                                          |
+| `data/worker-backends.json`                          | Shim's per-folder backend/model state                                       |
+| `groups/<folder>/container.json`                     | Per-agent-group provider config                                             |
 
 ## Limitations
 

--- a/src/modules/fleet/create-worker.ts
+++ b/src/modules/fleet/create-worker.ts
@@ -42,6 +42,7 @@ import { writeDestinations } from '../agent-to-agent/write-destinations.js';
 import { readContainerConfig, writeContainerConfig } from '../../container-config.js';
 import { logWorkerEvent } from './events.js';
 import { generateId, normalizeName, notifyAgent, setFleetBackend } from './lib.js';
+import { ModelResolutionError, resolveModelForBackend } from './model-resolver.js';
 import { provisionDiscordChannel } from './provision.js';
 import { applyProfileToContainerConfig, loadWorkerProfile } from './worker-profile.js';
 import { createDestination as _ensureCreateDestImported } from '../agent-to-agent/db/agent-destinations.js';
@@ -234,6 +235,18 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
     return;
   }
 
+  let resolvedModel: string | undefined;
+  try {
+    resolvedModel = await resolveModelForBackend(backend, model);
+  } catch (err) {
+    if (err instanceof ModelResolutionError) {
+      notifyAgent(session, `create_worker rejected: ${err.message} (no worker created.)`);
+      log.warn('create_worker model resolution failed', { localName, backend, model, err: err.message });
+      return;
+    }
+    throw err;
+  }
+
   const agentGroupId = generateId('ag');
   const now = new Date().toISOString();
 
@@ -245,12 +258,12 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
     created_at: now,
     status: 'active',
     fleet_backend: backend,
-    fleet_model: model ?? null,
+    fleet_model: resolvedModel ?? null,
     fleet_role: 'worker',
   };
   createAgentGroup(newGroup);
   initGroupFilesystem(newGroup, { instructions: instructions ?? undefined });
-  setFleetBackend(localName, backend, model);
+  setFleetBackend(localName, backend, resolvedModel);
 
   // Apply the user's worker profile (repos / tools / mounts / skills) to
   // the new worker's container.json so the next container boot runs
@@ -282,13 +295,13 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
 
   notifyAgent(
     session,
-    `Worker "${localName}" created on ${backend}${model ? ` (${model})` : ''}. ${provision.statusText}. Message it with <message to="${localName}">...</message>.`,
+    `Worker "${localName}" created on ${backend}${resolvedModel ? ` (${resolvedModel})` : ''}. ${provision.statusText}. Message it with <message to="${localName}">...</message>.`,
   );
   log.info('Worker created', {
     agentGroupId,
     localName,
     backend,
-    model,
+    model: resolvedModel,
     messagingGroupId: provision.messagingGroupId,
     parent: sourceGroup.id,
   });
@@ -297,7 +310,7 @@ export async function handleCreateWorker(content: Record<string, unknown>, sessi
     event: 'created',
     worker: localName,
     folder: localName,
-    details: { agentGroupId, backend, model: model ?? null, parent: sourceGroup.folder },
+    details: { agentGroupId, backend, model: resolvedModel ?? null, parent: sourceGroup.folder },
   });
 }
 
@@ -310,14 +323,31 @@ async function resumeWorker(
   const { backend, model } = opts;
   const now = new Date().toISOString();
 
+  let resolvedModel: string | undefined;
+  try {
+    resolvedModel = await resolveModelForBackend(backend, model);
+  } catch (err) {
+    if (err instanceof ModelResolutionError) {
+      notifyAgent(session, `create_worker (resume) rejected: ${err.message} ("${existing.folder}" stays archived.)`);
+      log.warn('resumeWorker model resolution failed', {
+        folder: existing.folder,
+        backend,
+        model,
+        err: err.message,
+      });
+      return;
+    }
+    throw err;
+  }
+
   updateAgentGroup(existing.id, {
     status: 'active',
     agent_provider: backend,
     fleet_backend: backend,
-    fleet_model: model ?? null,
+    fleet_model: resolvedModel ?? null,
     fleet_role: 'worker',
   });
-  setFleetBackend(existing.folder, backend, model);
+  setFleetBackend(existing.folder, backend, resolvedModel);
 
   // Re-apply the current worker profile on resume. The archived worker's
   // container.json was captured before the user may have edited their
@@ -376,14 +406,14 @@ async function resumeWorker(
 
   notifyAgent(
     session,
-    `Worker "${localName}" resumed from archive on ${backend}${model ? ` (${model})` : ''}. ${channelStatus}. Prior sessions and workspace preserved.`,
+    `Worker "${localName}" resumed from archive on ${backend}${resolvedModel ? ` (${resolvedModel})` : ''}. ${channelStatus}. Prior sessions and workspace preserved.`,
   );
-  log.info('Worker resumed', { agentGroupId: existing.id, localName, backend, model });
+  log.info('Worker resumed', { agentGroupId: existing.id, localName, backend, model: resolvedModel });
   logWorkerEvent({
     timestamp: new Date().toISOString(),
     event: 'resumed',
     worker: localName,
     folder: existing.folder,
-    details: { agentGroupId: existing.id, backend, model: model ?? null },
+    details: { agentGroupId: existing.id, backend, model: resolvedModel ?? null },
   });
 }

--- a/src/modules/fleet/fleet.test.ts
+++ b/src/modules/fleet/fleet.test.ts
@@ -50,6 +50,18 @@ vi.mock('./discord-channel.js', () => ({
   createDiscordChannel: vi.fn(),
   deleteDiscordChannel: vi.fn(),
 }));
+// Stub the model resolver — these tests don't have a real shim to talk to.
+// Identity-resolve mirrors a healthy shim returning an exact match. Tests
+// that need a 404/connect-error path can override this per-case.
+vi.mock('./model-resolver.js', () => ({
+  ModelResolutionError: class ModelResolutionError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'ModelResolutionError';
+    }
+  },
+  resolveModelForBackend: vi.fn(async (_backend: string, model: string | undefined) => model),
+}));
 vi.mock('../agent-to-agent/write-destinations.js', () => ({
   writeDestinations: vi.fn(),
 }));
@@ -264,6 +276,36 @@ describe('switch_backend', () => {
     expect(w?.fleet_model).toBe('kimi-k2.5');
     const cfg = JSON.parse(fs.readFileSync(TEST_DIR + '/groups/epsilon/container.json', 'utf-8'));
     expect(cfg.provider).toBe('neuralwatt');
+  });
+
+  it('persists the canonical model id returned by the resolver, not the user input', async () => {
+    const resolver = await import('./model-resolver.js');
+    await handleCreateWorker({ name: 'epsilon-canon', backend: 'claude' }, makeMasterSession());
+    vi.mocked(resolver.resolveModelForBackend).mockResolvedValueOnce('zai-org/GLM-5.1-FP8');
+    await handleSwitchBackend({ name: 'epsilon-canon', backend: 'neuralwatt', model: 'GLM-5.1' }, makeMasterSession());
+    const w = getAgentGroupByFolder('epsilon-canon');
+    expect(w?.fleet_model).toBe('zai-org/GLM-5.1-FP8');
+    const cfg = JSON.parse(fs.readFileSync(TEST_DIR + '/groups/epsilon-canon/container.json', 'utf-8'));
+    expect(cfg.providers.neuralwatt.model).toBe('zai-org/GLM-5.1-FP8');
+  });
+
+  it('rejects unresolvable models without touching DB or container.json', async () => {
+    const resolver = await import('./model-resolver.js');
+    await handleCreateWorker({ name: 'epsilon-reject', backend: 'claude', model: 'opus-4.7' }, makeMasterSession());
+    const beforeDb = getAgentGroupByFolder('epsilon-reject');
+    const beforeCfg = JSON.parse(fs.readFileSync(TEST_DIR + '/groups/epsilon-reject/container.json', 'utf-8'));
+
+    vi.mocked(resolver.resolveModelForBackend).mockRejectedValueOnce(
+      new resolver.ModelResolutionError('Neuralwatt model "bogus" not found.'),
+    );
+    await handleSwitchBackend({ name: 'epsilon-reject', backend: 'neuralwatt', model: 'bogus' }, makeMasterSession());
+
+    const afterDb = getAgentGroupByFolder('epsilon-reject');
+    const afterCfg = JSON.parse(fs.readFileSync(TEST_DIR + '/groups/epsilon-reject/container.json', 'utf-8'));
+    expect(afterDb?.agent_provider).toBe(beforeDb?.agent_provider);
+    expect(afterDb?.fleet_backend).toBe(beforeDb?.fleet_backend);
+    expect(afterDb?.fleet_model).toBe(beforeDb?.fleet_model);
+    expect(afterCfg).toEqual(beforeCfg);
   });
 });
 

--- a/src/modules/fleet/model-resolver.test.ts
+++ b/src/modules/fleet/model-resolver.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the neuralwatt model resolver. Mocks global fetch so we
+ * can exercise the success / 404 / 503 / connect-error paths without a
+ * live shim.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModelResolutionError, resolveModelForBackend } from './model-resolver.js';
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(impl: (url: string) => Promise<Response> | Response): void {
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    const url = typeof input === 'string' ? input : (input as URL).toString();
+    return await impl(url);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.NW_SHIM_HOST_URL = 'http://shim.test';
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.NW_SHIM_HOST_URL;
+  vi.restoreAllMocks();
+});
+
+describe('resolveModelForBackend', () => {
+  it('returns undefined when no model is supplied', async () => {
+    expect(await resolveModelForBackend('neuralwatt', undefined)).toBeUndefined();
+    expect(await resolveModelForBackend('neuralwatt', '')).toBeUndefined();
+    expect(await resolveModelForBackend('neuralwatt', '   ')).toBeUndefined();
+  });
+
+  it('passes claude models through without hitting the shim', async () => {
+    mockFetch(() => {
+      throw new Error('shim should not be called for claude');
+    });
+    expect(await resolveModelForBackend('claude', 'opus-4.7')).toBe('opus-4.7');
+  });
+
+  it('returns canonical id from the shim on a fuzzy match', async () => {
+    mockFetch((url) => {
+      expect(url).toBe('http://shim.test/models/resolve/GLM-5.1');
+      return new Response(
+        JSON.stringify({ model: 'zai-org/GLM-5.1-FP8', match: 'fuzzy', candidates: ['zai-org/GLM-5.1-FP8'] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    expect(await resolveModelForBackend('neuralwatt', 'GLM-5.1')).toBe('zai-org/GLM-5.1-FP8');
+  });
+
+  it('throws ModelResolutionError with candidates on 404', async () => {
+    mockFetch(
+      () =>
+        new Response(JSON.stringify({ error: 'no match for "bogus"', available: ['glm-5-fast', 'kimi-k2.6-fast'] }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    await expect(resolveModelForBackend('neuralwatt', 'bogus')).rejects.toBeInstanceOf(ModelResolutionError);
+  });
+
+  it('throws ModelResolutionError on 503 (shim catalogue empty)', async () => {
+    mockFetch(
+      () =>
+        new Response(JSON.stringify({ error: 'no models available' }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    await expect(resolveModelForBackend('neuralwatt', 'kimi')).rejects.toThrow(ModelResolutionError);
+  });
+
+  it('throws ModelResolutionError when the shim is unreachable', async () => {
+    mockFetch(() => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:3003');
+    });
+    await expect(resolveModelForBackend('neuralwatt', 'kimi')).rejects.toMatchObject({
+      name: 'ModelResolutionError',
+    });
+  });
+});

--- a/src/modules/fleet/model-resolver.test.ts
+++ b/src/modules/fleet/model-resolver.test.ts
@@ -81,4 +81,23 @@ describe('resolveModelForBackend', () => {
       name: 'ModelResolutionError',
     });
   });
+
+  // Regression: a hung shim (accepting connections but not responding) used
+  // to block the fleet handler indefinitely. The resolver now applies an
+  // AbortSignal.timeout, and on abort throws ModelResolutionError with a
+  // timeout-flavored message instead of propagating the raw TimeoutError
+  // (which the handler can't categorize).
+  it('throws ModelResolutionError with a timeout message when fetch aborts', async () => {
+    mockFetch(() => {
+      // Simulate what the platform throws when AbortSignal.timeout fires —
+      // skip the real wall-clock wait so the test stays fast.
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'TimeoutError';
+      throw err;
+    });
+    await expect(resolveModelForBackend('neuralwatt', 'kimi')).rejects.toMatchObject({
+      name: 'ModelResolutionError',
+      message: expect.stringContaining('did not respond within'),
+    });
+  });
 });

--- a/src/modules/fleet/model-resolver.ts
+++ b/src/modules/fleet/model-resolver.ts
@@ -24,6 +24,7 @@ import { readEnvFile } from '../../env.js';
 import { log } from '../../log.js';
 
 const DEFAULT_SHIM_HOST_URL = 'http://127.0.0.1:3003';
+const RESOLVE_TIMEOUT_MS = 5000;
 
 export class ModelResolutionError extends Error {
   constructor(message: string) {
@@ -52,11 +53,20 @@ async function resolveNeuralwattModel(model: string): Promise<string> {
   const url = `${baseUrl.replace(/\/$/, '')}/models/resolve/${encodeURIComponent(model)}`;
   let resp: Response;
   try {
-    resp = await fetch(url);
+    // Bounded timeout: model resolution is a local HTTP hop. Without a
+    // timeout, a hung shim (accepting connections but not responding —
+    // distinct from a dead shim, which fails fast with ECONNREFUSED) would
+    // block the calling fleet handler indefinitely, freezing the master
+    // agent's turn with no error to surface.
+    resp = await fetch(url, { signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS) });
   } catch (err) {
+    const reason =
+      err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')
+        ? `did not respond within ${RESOLVE_TIMEOUT_MS}ms`
+        : `was unreachable (${String(err)})`;
     throw new ModelResolutionError(
-      `Could not reach the Neuralwatt shim at ${baseUrl} to validate model "${model}" (${String(err)}). ` +
-        `Start the shim (systemctl --user start nanoclaw-shim) and retry, or check NW_SHIM_HOST_URL.`,
+      `Neuralwatt shim at ${baseUrl} ${reason} when validating model "${model}". ` +
+        `Check the shim (systemctl --user status nanoclaw-shim) and retry, or check NW_SHIM_HOST_URL.`,
     );
   }
   let body: { model?: string; match?: string; error?: string; candidates?: string[] } = {};

--- a/src/modules/fleet/model-resolver.ts
+++ b/src/modules/fleet/model-resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * Pre-flight model validation for fleet backend changes.
+ *
+ * Background: switch_backend / create_worker / resumeWorker all accept a
+ * `model` string from the master agent and used to write it straight into
+ * agent_groups + container.json + the shim's worker-backends.json. If the
+ * master passed a friendly name like "GLM-5.1" or fat-fingered an id, the
+ * write succeeded silently and the failure surfaced minutes later as an
+ * SDK "model not available" error from inside the worker container —
+ * with no link back to the master that requested the bad value.
+ *
+ * Fix: the host validates the model against the target backend before
+ * persisting. For neuralwatt that means hitting the shim's
+ * /models/resolve/<query> endpoint (which already does fuzzy matching and
+ * knows the live model catalogue). On success the canonical id replaces
+ * the user-provided string. On failure the helper throws so the caller
+ * skips persisting and notifies the master with the resolver's message.
+ *
+ * Claude is pass-through for now — the SDK validates Claude model ids
+ * downstream and there's no shim hop where a bad id can poison routing
+ * for an entire container's lifetime.
+ */
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+
+const DEFAULT_SHIM_HOST_URL = 'http://127.0.0.1:3003';
+
+export class ModelResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModelResolutionError';
+  }
+}
+
+/**
+ * Validate (and canonicalize) a model id for a backend before persistence.
+ *
+ * Returns the resolved model id (which may differ from the input, e.g.
+ * "GLM-5.1" → "zai-org/GLM-5.1-FP8"), or undefined if no model was
+ * supplied. Throws ModelResolutionError if the input is non-empty and the
+ * backend can't accept it. Callers must not persist on throw.
+ */
+export async function resolveModelForBackend(backend: string, model: string | undefined): Promise<string | undefined> {
+  if (!model || model.trim() === '') return undefined;
+  const trimmed = model.trim();
+  if (backend !== 'neuralwatt') return trimmed;
+  return await resolveNeuralwattModel(trimmed);
+}
+
+async function resolveNeuralwattModel(model: string): Promise<string> {
+  const baseUrl = shimHostUrl();
+  const url = `${baseUrl.replace(/\/$/, '')}/models/resolve/${encodeURIComponent(model)}`;
+  let resp: Response;
+  try {
+    resp = await fetch(url);
+  } catch (err) {
+    throw new ModelResolutionError(
+      `Could not reach the Neuralwatt shim at ${baseUrl} to validate model "${model}" (${String(err)}). ` +
+        `Start the shim (systemctl --user start nanoclaw-shim) and retry, or check NW_SHIM_HOST_URL.`,
+    );
+  }
+  let body: { model?: string; match?: string; error?: string; candidates?: string[] } = {};
+  try {
+    body = (await resp.json()) as typeof body;
+  } catch {
+    // Fall through with empty body; error message will reflect status only.
+  }
+  if (resp.ok && body.model) {
+    if (body.model !== model) {
+      log.info('Neuralwatt model resolved', { requested: model, resolved: body.model, match: body.match });
+    }
+    return body.model;
+  }
+  if (resp.status === 404) {
+    const cands = body.candidates && body.candidates.length > 0 ? ` Candidates: ${body.candidates.join(', ')}` : '';
+    throw new ModelResolutionError(
+      `Neuralwatt model "${model}" not found.${cands} Use a name from /models or pick one of the candidates above.`,
+    );
+  }
+  if (resp.status === 503) {
+    throw new ModelResolutionError(
+      `Neuralwatt shim has no model catalogue available right now (503${body.error ? `: ${body.error}` : ''}). ` +
+        `The shim may have just started or upstream is unreachable. Retry in a few seconds.`,
+    );
+  }
+  throw new ModelResolutionError(
+    `Neuralwatt shim refused to resolve "${model}" (HTTP ${resp.status}${body.error ? `: ${body.error}` : ''}).`,
+  );
+}
+
+function shimHostUrl(): string {
+  const fromProcess = process.env.NW_SHIM_HOST_URL;
+  if (fromProcess) return fromProcess;
+  const fromEnvFile = readEnvFile(['NW_SHIM_HOST_URL']).NW_SHIM_HOST_URL;
+  return fromEnvFile ?? DEFAULT_SHIM_HOST_URL;
+}

--- a/src/modules/fleet/switch-backend.ts
+++ b/src/modules/fleet/switch-backend.ts
@@ -17,6 +17,7 @@ import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { logWorkerEvent } from './events.js';
 import { normalizeName, notifyAgent, setFleetBackend } from './lib.js';
+import { ModelResolutionError, resolveModelForBackend } from './model-resolver.js';
 
 export async function handleSwitchBackend(content: Record<string, unknown>, session: Session): Promise<void> {
   const name = content.name as string;
@@ -48,8 +49,24 @@ export async function handleSwitchBackend(content: Record<string, unknown>, sess
     return;
   }
 
-  updateAgentGroup(target.id, { agent_provider: backend, fleet_backend: backend, fleet_model: model ?? null });
-  setFleetBackend(target.folder, backend, model);
+  let resolvedModel: string | undefined;
+  try {
+    resolvedModel = await resolveModelForBackend(backend, model);
+  } catch (err) {
+    if (err instanceof ModelResolutionError) {
+      notifyAgent(session, `switch_backend rejected: ${err.message} (no changes made to "${localName}".)`);
+      log.warn('switch_backend model resolution failed', { localName, backend, model, err: err.message });
+      return;
+    }
+    throw err;
+  }
+
+  updateAgentGroup(target.id, {
+    agent_provider: backend,
+    fleet_backend: backend,
+    fleet_model: resolvedModel ?? null,
+  });
+  setFleetBackend(target.folder, backend, resolvedModel);
 
   // Kill running container so next wake uses new provider env/mounts.
   for (const s of getSessionsByAgentGroup(target.id)) {
@@ -58,14 +75,14 @@ export async function handleSwitchBackend(content: Record<string, unknown>, sess
 
   notifyAgent(
     session,
-    `Worker "${localName}" switched to ${backend}${model ? ` (${model})` : ''}. Container will use the new provider on next message.`,
+    `Worker "${localName}" switched to ${backend}${resolvedModel ? ` (${resolvedModel})` : ''}. Container will use the new provider on next message.`,
   );
-  log.info('Worker backend switched', { agentGroupId: target.id, localName, backend, model });
+  log.info('Worker backend switched', { agentGroupId: target.id, localName, backend, model: resolvedModel });
   logWorkerEvent({
     timestamp: new Date().toISOString(),
     event: 'backend_switched',
     worker: localName,
     folder: target.folder,
-    details: { agentGroupId: target.id, backend, model: model ?? null, fleet_role: target.fleet_role },
+    details: { agentGroupId: target.id, backend, model: resolvedModel ?? null, fleet_role: target.fleet_role },
   });
 }


### PR DESCRIPTION
## Summary

`switch_backend`, `create_worker`, and the resume path used to write any model string straight into `agent_groups` + `container.json` + the shim's `worker-backends.json`. Bad ids (typos, friendly names like `GLM-5.1`) only surfaced minutes later as an SDK "model not available" error inside the worker container — far from the master that requested them, and indistinguishable from a real shim outage. This produced confusing UX where the master would hallucinate plausible-but-wrong reasons for the failure ("the shim's down so I couldn't fuzzy-resolve…") even though no resolution was ever attempted.

The fix routes all three handlers through a new `resolveModelForBackend(backend, model)` helper that validates against the target backend before any DB or filesystem write.

- For `neuralwatt`: `GET <NW_SHIM_HOST_URL>/models/resolve/<query>` — the shim already does fuzzy matching and knows the live model catalogue. The canonical id replaces the user input on success (`GLM-5.1` → `zai-org/GLM-5.1-FP8`).
- On 404 (no match), 503 (catalogue empty), or connect-error: throws `ModelResolutionError`. The handler catches it, `notifyAgent`s the master with the resolver's message (including candidate models on 404), and persists nothing.
- For `claude`: pass-through. SDK validates downstream and there's no shim hop where a bad value can poison routing for a container's whole lifetime.

`NW_SHIM_HOST_URL` defaults to `http://127.0.0.1:3003` (host's view; distinct from the container's `host.docker.internal:3003`).

## Verification

Smoke-tested directly against the live shim:
- `GLM-5.1` → `zai-org/GLM-5.1-FP8` ✓
- `kimi` → `moonshotai/Kimi-K2.6` ✓
- `claude` + `opus-4.7` → pass-through ✓
- `undefined` → `undefined` ✓
- `totally-fake-model-xyz` → rejected with candidate list ✓

## Test plan

- [x] Unit tests for `resolveModelForBackend`: success / claude pass-through / undefined / 404 / 503 / connect-error
- [x] `switch_backend` test: persists canonical id (not user input) on success
- [x] `switch_backend` test: rejects unresolvable model without touching DB or `container.json`
- [x] Existing `fleet.test.ts` switch_backend / create_worker tests pass with default identity-mock resolver
- [x] Full host suite: 281/281 pass
- [x] `pnpm run build` clean
- [x] Pre-push hooks (format:check + host tsc + container tsc + vitest) green
- [ ] E2E via Discord debug bot: switch a worker to a fuzzy name, verify it lands on canonical id; switch to a bogus name, verify rejection message comes back to master and worker is untouched