### PR TITLE
feat(fleet): post host-restart notice to master channel on startup

### DIFF
--- a/docs/fleet/guides/e2e-checklist.md
+++ b/docs/fleet/guides/e2e-checklist.md
@@ -142,6 +142,20 @@ If missing: check `ncf logs <worker>` for the worker-init `skills: linked N from
 
 (Regression seen 2026-04-30: NWCS skills missing from `better` and others because (a) the SSH→HTTPS rewrite broke the clone — fixed in PR #105 — and (b) `worker-init.sh` only checked `<repo>/.claude/skills/`, missing repos that put skills at the root. Both addressed in `fix/nwcs-skills-layout`.)
 
+### 4d-bis. Startup notice (master sees a "host restarted" message after every host boot)
+
+The host posts a one-shot `🚀 NanoClaw host restarted.` chat to the master agent's channel after delivery polls + sweep are up. No-op when there is no master agent group yet, no session, or no messaging group.
+
+```bash
+# Restart the host (with confirmation per CLAUDE.local.md), then check the master channel
+# in Discord — there should be a single new "🚀 NanoClaw host restarted." message.
+
+# Verify in logs the host believed it was posted
+grep -i "Startup notice" logs/nanoclaw.log | tail -3
+# Expect: "Startup notice posted to master" with backend + model fields.
+# "Startup notice skipped (no master target)" only on a fresh install.
+```
+
 ### 4e. Resource monitor (host-side background polling for memory/disk/container alerts)
 
 The resource monitor runs every 5 minutes and posts to #master when memory ≥80%, disk ≥80%, or active containers ≥80% of `MAX_CONCURRENT_CONTAINERS`. Hysteresis: alert once on crossing, clear once on dropping below 70% (60% for containers).

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { startOutboundWakeServer, stopOutboundWakeServer } from './outbound-wake.js';
 import { startStatusPin, stopStatusPin } from './modules/status-pin/index.js';
 import { startResourceMonitor, stopResourceMonitor } from './modules/resource-monitor/index.js';
+import { postHostStartupNotice } from './modules/startup-notice/index.js';
 import { getActiveContainerCount } from './container-runner.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
@@ -240,6 +241,11 @@ async function main(): Promise<void> {
   // 6. Start host sweep
   startHostSweep();
   log.info('Host sweep started');
+
+  // 7. Best-effort: post a "host restarted" notice to the master agent's
+  // channel. Gives the user a sign of life and the master agent restart
+  // context for its next turn. No-op when no master is registered.
+  postHostStartupNotice();
 
   log.info('NanoClaw running');
 }

--- a/src/modules/startup-notice/index.test.ts
+++ b/src/modules/startup-notice/index.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for startup-notice. Format helper is a pure function; the
+ * "no master" path of postHostStartupNotice is covered by mocking the
+ * agent_groups db. The IO-heavy outbound write is left to manual e2e —
+ * resource-monitor follows the same convention.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { formatStartupMessage, postHostStartupNotice } from './index.js';
+
+describe('formatStartupMessage', () => {
+  const fixedNow = new Date('2026-05-04T19:42:00Z');
+
+  it('includes backend, model, and a formatted timestamp', () => {
+    const msg = formatStartupMessage({ backend: 'claude', model: 'claude-opus-4-7' }, fixedNow);
+    expect(msg).toContain('🚀 NanoClaw host restarted.');
+    expect(msg).toContain('Backend: claude (claude-opus-4-7)');
+    expect(msg).toMatch(/Time: \w+ \d+, \d{2}:\d{2}/);
+  });
+
+  it('omits the model parens when no model is set', () => {
+    const msg = formatStartupMessage({ backend: 'claude', model: null }, fixedNow);
+    expect(msg).toContain('Backend: claude\n');
+    expect(msg).not.toContain('()');
+  });
+
+  it('handles neuralwatt backend with a long model id', () => {
+    const msg = formatStartupMessage({ backend: 'neuralwatt', model: 'zai-org/GLM-5.1-FP8' }, fixedNow);
+    expect(msg).toContain('Backend: neuralwatt (zai-org/GLM-5.1-FP8)');
+  });
+});
+
+vi.mock('../../db/agent-groups.js', () => ({
+  getActiveAgentGroups: vi.fn(() => []),
+}));
+vi.mock('../../db/messaging-groups.js', () => ({
+  getMessagingGroupsByAgentGroup: vi.fn(() => []),
+}));
+vi.mock('../../db/sessions.js', () => ({
+  getSessionsByAgentGroup: vi.fn(() => []),
+}));
+vi.mock('../../session-manager.js', () => ({
+  openOutboundDb: vi.fn(),
+}));
+
+describe('postHostStartupNotice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns cleanly when there is no active master agent group', async () => {
+    const { getActiveAgentGroups } = await import('../../db/agent-groups.js');
+    const { openOutboundDb } = await import('../../session-manager.js');
+    vi.mocked(getActiveAgentGroups).mockReturnValue([]);
+
+    expect(() => postHostStartupNotice()).not.toThrow();
+    expect(openOutboundDb).not.toHaveBeenCalled();
+  });
+
+  it('skips the write when the master has no session yet', async () => {
+    const { getActiveAgentGroups } = await import('../../db/agent-groups.js');
+    const { getSessionsByAgentGroup } = await import('../../db/sessions.js');
+    const { openOutboundDb } = await import('../../session-manager.js');
+    vi.mocked(getActiveAgentGroups).mockReturnValue([
+      {
+        id: 'ag-master',
+        name: 'master',
+        folder: 'master',
+        agent_provider: 'claude',
+        created_at: '2026-01-01T00:00:00Z',
+        status: 'active',
+        fleet_role: 'master',
+        fleet_backend: 'claude',
+        fleet_model: 'claude-opus-4-7',
+      },
+    ]);
+    vi.mocked(getSessionsByAgentGroup).mockReturnValue([]);
+
+    expect(() => postHostStartupNotice()).not.toThrow();
+    expect(openOutboundDb).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/startup-notice/index.ts
+++ b/src/modules/startup-notice/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Startup notice — posts a one-shot "host restarted" chat message to the
+ * master agent's channel after the host comes up, so the user sees a
+ * sign of life and the master agent has restart context for its next
+ * turn.
+ *
+ * Ported from v1 fleet (commit 8292a9f, reverted as collateral damage in
+ * b815cf7 — never intentionally removed). Same delivery path as the
+ * resource-monitor alerts: write a `kind=chat` row to the master
+ * session's outbound DB, let the normal delivery loop pick it up. That
+ * way the message lands through whatever channel adapter the master is
+ * wired to (Discord today; Slack/Telegram later) without this module
+ * needing to know about adapters.
+ *
+ * No-op when:
+ *   - There's no active master agent group (fresh install, first run)
+ *   - The master has no session yet (never been messaged)
+ *   - The master has no messaging group (orphaned agent_group)
+ *   - The outbound DB write fails (logged warn, not thrown)
+ *
+ * In all of those cases the host still finishes booting cleanly — the
+ * notice is best-effort, not load-bearing.
+ */
+import { TIMEZONE } from '../../config.js';
+import { getActiveAgentGroups } from '../../db/agent-groups.js';
+import { getMessagingGroupsByAgentGroup } from '../../db/messaging-groups.js';
+import { getSessionsByAgentGroup } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { openOutboundDb } from '../../session-manager.js';
+
+interface MasterTarget {
+  agentGroupId: string;
+  sessionId: string;
+  channelType: string;
+  platformId: string;
+  backend: string;
+  model: string | null;
+}
+
+function resolveMasterTarget(): MasterTarget | null {
+  const master = getActiveAgentGroups().find((g) => g.fleet_role === 'master');
+  if (!master) return null;
+  const sessions = getSessionsByAgentGroup(master.id);
+  if (sessions.length === 0) return null;
+  const session = [...sessions].sort((a, b) => (b.last_active ?? '').localeCompare(a.last_active ?? ''))[0];
+  const mgs = getMessagingGroupsByAgentGroup(master.id);
+  const mg = mgs[0];
+  if (!mg) return null;
+  return {
+    agentGroupId: master.id,
+    sessionId: session.id,
+    channelType: mg.channel_type,
+    platformId: mg.platform_id,
+    // Display-only label: prefer the explicit fleet_backend, fall back to
+    // agent_provider (the v2 generic field), then 'unknown' so we don't
+    // pretend it's claude when the row is genuinely missing both.
+    backend: master.fleet_backend ?? master.agent_provider ?? 'unknown',
+    model: master.fleet_model ?? null,
+  };
+}
+
+export function formatStartupMessage(target: Pick<MasterTarget, 'backend' | 'model'>, now: Date = new Date()): string {
+  const timestamp = now.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: TIMEZONE,
+  });
+  const modelSuffix = target.model ? ` (${target.model})` : '';
+  return `🚀 NanoClaw host restarted.\nBackend: ${target.backend}${modelSuffix}\nTime: ${timestamp}`;
+}
+
+function writeNoticeToOutbound(target: MasterTarget, text: string): void {
+  try {
+    const db = openOutboundDb(target.agentGroupId, target.sessionId);
+    try {
+      const maxSeq = (db.prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+      const nextSeq = maxSeq + 1;
+      const id = `startup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      db.prepare(
+        `INSERT INTO messages_out (id, seq, timestamp, kind, platform_id, channel_type, content)
+         VALUES (?, ?, datetime('now'), 'chat', ?, ?, ?)`,
+      ).run(id, nextSeq, target.platformId, target.channelType, JSON.stringify({ text }));
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    log.warn('Startup notice write failed', { err: String(err) });
+  }
+}
+
+/**
+ * Best-effort: post a "host restarted" chat to the master's channel.
+ * Exported so src/index.ts can call it after delivery polls + sweep are
+ * up. Safe to call when there is no master — logs and returns.
+ */
+export function postHostStartupNotice(): void {
+  const target = resolveMasterTarget();
+  if (!target) {
+    log.info('Startup notice skipped (no master target)');
+    return;
+  }
+  const text = formatStartupMessage(target);
+  writeNoticeToOutbound(target, text);
+  log.info('Startup notice posted to master', {
+    channelType: target.channelType,
+    backend: target.backend,
+    model: target.model,
+  });
+}


### PR DESCRIPTION
## Summary

Ports v1's startup notification to v2 — after the host comes up, post a one-shot `🚀 NanoClaw host restarted.` chat to the master agent's channel. Gives the user a sign of life and the master agent restart context for its next turn (in-flight turns died, workers stopped on the previous host process).

v1 originally added this in commit `qwibitai/nanoclaw@8292a9f` and reverted it as collateral damage in `b815cf7` — never intentionally removed; the notification was bundled with a credential fix that was rolled back wholesale.

## Implementation

New module `src/modules/startup-notice/`:
- Mirrors the existing `src/modules/resource-monitor/` pattern (master lookup → write `kind=chat` row to the master session's outbound DB).
- Delivery loop picks it up and posts via the configured channel adapter (Discord today; works for Slack/Telegram out of the box if/when the master is wired there).
- **Doesn't wake the master container** — writes directly to outbound. The previous v1 design reverted "auto-respawn workers on restart" because synthetic input messages caused Discord spam. This avoids that trap.

No-op when:
- No active master agent group (fresh install)
- Master has no session yet (never been messaged)
- Master has no messaging group (orphaned agent_group)
- Outbound DB write fails (logged warn, host startup continues)

## Test plan

- [x] `pnpm test` — all 287 tests pass; new module has 5 tests (3 for `formatStartupMessage`, 2 for `postHostStartupNotice` no-target paths)
- [x] `pnpm run build` — typecheck clean
- [x] Pre-push hook (format:check + host tsc + container tsc + host vitest + container bun tests) — all green
- [ ] **Manual e2e** (post-merge, with restart confirmation): restart host, confirm `🚀 NanoClaw host restarted.\nBackend: claude (claude-opus-4-7)\nTime: …` appears once in the master Discord channel
- [ ] **Manual e2e**: confirm `Startup notice posted to master` appears once in `logs/host.log` (or `Startup notice skipped (no master target)` on a fresh install)