### PR TITLE
fix(container): disallow SDK SendMessage/TeamCreate/TeamDelete in workers

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -47,6 +47,14 @@ const SDK_DISALLOWED_TOOLS = [
   'ExitPlanMode',
   'EnterWorktree',
   'ExitWorktree',
+  // Claude Agent Team tools — workers communicate via NanoClaw destinations
+  // (`mcp__nanoclaw__send_message`), not the SDK's inter-agent channel.
+  // `SendMessage` was a footgun: agents confused it with our chat tool and
+  // shipped substantive replies into an SDK-internal teammate inbox that
+  // nobody reads. Disallow the trio to remove the choice.
+  'TeamCreate',
+  'TeamDelete',
+  'SendMessage',
 ];
 
 // Tool allowlist for NanoClaw agent containers
@@ -62,9 +70,6 @@ const TOOL_ALLOWLIST = [
   'Task',
   'TaskOutput',
   'TaskStop',
-  'TeamCreate',
-  'TeamDelete',
-  'SendMessage',
   'TodoWrite',
   'ToolSearch',
   'Skill',


### PR DESCRIPTION
## Summary

The Claude Agent SDK ships a top-level `SendMessage` tool for inter-agent messaging within an Agent Team. NanoClaw workers don't run as Agent Teams — they communicate via NanoClaw destinations through `mcp__nanoclaw__send_message`. The two tools have nearly identical names and intents, and at least one worker (replay) confused them: it called `SendMessage(to="worker-replay", message="<full debrief>")`, the SDK accepted the unknown teammate name without complaint, and the substantive Discord reply landed in an SDK-internal teammate inbox that nobody reads. The user only saw the agent's meta-summary ("Sent the debrief and a forward-looking brief…") with no content behind it.

This PR removes `SendMessage`, `TeamCreate`, and `TeamDelete` from the worker tool allowlist and explicitly puts them in `SDK_DISALLOWED_TOOLS` so the model never has the option. Workers needing Agent Team coordination can be opted in later via a per-group flag.

## Test plan
- [x] `cd container/agent-runner && bun run typecheck` — clean
- [x] `cd container/agent-runner && bun test` — 62 pass
- [x] `pnpm exec tsc --noEmit` (host) — clean
- [ ] After merge: rebuild image (`./container/build.sh`) and `ncf restart` workers to pick up the new tool config — workers hold their tool config from spawn time