### PR TITLE
fix(fleet): pre-create /workspace/extra mount targets so fresh purge succeeds

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { pickOauthToken, readContainerCredentials } from './container-runner.js';
+import { pickOauthToken, precreateNestedMountTargets, readContainerCredentials } from './container-runner.js';
 
 // readContainerCredentials reads `~/.config/nanoclaw/config.json`. Patch
 // HOME to a temp dir so tests don't touch the real user config.
@@ -97,5 +97,79 @@ describe('readContainerCredentials', () => {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
     fs.writeFileSync(CONFIG_PATH, '{not json');
     expect(readContainerCredentials()).toEqual([]);
+  });
+});
+
+describe('precreateNestedMountTargets', () => {
+  // Regression: create_worker --fresh failed with EACCES on rmdir of
+  // <sessdir>/extra/<name> because Docker's runc had created those mount
+  // targets as root. Pre-creating them as the host user keeps ownership
+  // correct so purgeArchivedWorker can clean up.
+  let sessDir: string;
+  let hostSrcDir: string;
+
+  beforeEach(() => {
+    sessDir = path.join(TEST_HOME, 'sessions', 'sess-test');
+    hostSrcDir = path.join(TEST_HOME, 'host-src');
+    fs.mkdirSync(sessDir, { recursive: true });
+    fs.mkdirSync(hostSrcDir, { recursive: true });
+  });
+
+  it('creates host-side mount-points for /workspace/extra/<name> mounts', () => {
+    precreateNestedMountTargets(
+      [{ hostPath: hostSrcDir, containerPath: '/workspace/extra/discord', readonly: false }],
+      sessDir,
+    );
+    expect(fs.existsSync(path.join(sessDir, 'extra', 'discord'))).toBe(true);
+  });
+
+  it('creates host-side mount-points for /workspace/agent', () => {
+    precreateNestedMountTargets(
+      [{ hostPath: hostSrcDir, containerPath: '/workspace/agent', readonly: false }],
+      sessDir,
+    );
+    expect(fs.existsSync(path.join(sessDir, 'agent'))).toBe(true);
+  });
+
+  it('skips the /workspace mount itself (it is the session dir)', () => {
+    precreateNestedMountTargets([{ hostPath: hostSrcDir, containerPath: '/workspace', readonly: false }], sessDir);
+    // The function must not create something silly like <sessDir>/<empty>.
+    expect(fs.readdirSync(sessDir)).toEqual([]);
+  });
+
+  it('skips file mounts (only dirs need a pre-created mount-point)', () => {
+    const hostFile = path.join(TEST_HOME, 'somefile.json');
+    fs.writeFileSync(hostFile, '{}');
+    precreateNestedMountTargets(
+      [{ hostPath: hostFile, containerPath: '/workspace/agent/container.json', readonly: true }],
+      sessDir,
+    );
+    expect(fs.existsSync(path.join(sessDir, 'agent'))).toBe(false);
+  });
+
+  it('skips mounts whose hostPath does not exist', () => {
+    precreateNestedMountTargets(
+      [{ hostPath: path.join(TEST_HOME, 'missing'), containerPath: '/workspace/extra/missing', readonly: false }],
+      sessDir,
+    );
+    expect(fs.existsSync(path.join(sessDir, 'extra'))).toBe(false);
+  });
+
+  it('skips mounts outside /workspace/', () => {
+    precreateNestedMountTargets(
+      [{ hostPath: hostSrcDir, containerPath: '/home/node/.claude', readonly: false }],
+      sessDir,
+    );
+    expect(fs.readdirSync(sessDir)).toEqual([]);
+  });
+
+  it('is idempotent (safe to call when target already exists)', () => {
+    fs.mkdirSync(path.join(sessDir, 'extra', 'discord'), { recursive: true });
+    expect(() =>
+      precreateNestedMountTargets(
+        [{ hostPath: hostSrcDir, containerPath: '/workspace/extra/discord', readonly: false }],
+        sessDir,
+      ),
+    ).not.toThrow();
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -434,7 +434,32 @@ function buildMounts(
     mounts.push({ hostPath: tailscaleSock, containerPath: tailscaleSock, readonly: false });
   }
 
+  // Pre-create host-side mount-point dirs for any mount nested under
+  // /workspace/. Without this, Docker's runc creates them as root when
+  // setting up the bind mounts (the daemon runs in the host namespace), and
+  // a later `purgeArchivedWorker` (`create_worker --fresh` on a recreated
+  // name) hits EACCES trying to rmdir them. Pre-creating as the host user
+  // means Docker reuses our dirs and ownership stays correct.
+  precreateNestedMountTargets(mounts, sessDir);
+
   return mounts;
+}
+
+export function precreateNestedMountTargets(mounts: VolumeMount[], sessDir: string): void {
+  const prefix = '/workspace/';
+  for (const mount of mounts) {
+    if (!mount.containerPath.startsWith(prefix) || mount.containerPath === '/workspace') continue;
+    let hostStat: fs.Stats;
+    try {
+      hostStat = fs.statSync(mount.hostPath);
+    } catch {
+      continue;
+    }
+    if (!hostStat.isDirectory()) continue;
+    const rel = mount.containerPath.slice(prefix.length);
+    const target = path.join(sessDir, rel);
+    fs.mkdirSync(target, { recursive: true });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`create_worker --fresh` failed with `EACCES, can't rmdir <sessdir>/extra/<name>` when recreating a worker with the same name. Root cause: Docker's runc creates bind-mount target directories as root (the daemon runs in the host namespace), so `<sessdir>/extra/discord/`, `<sessdir>/agent/` etc. end up root-owned. `purgeArchivedWorker`'s `fs.rmSync` then can't remove them.

Fix: pre-create each host-side mount-point dir for `/workspace/`-nested mounts in `buildMounts` before Docker spawns. Docker reuses our dirs, ownership stays with the host user, and fresh purge works.

## Test plan

- [x] `pnpm exec vitest run src/container-runner.test.ts` — 16 passed (7 new, covering dir / file / missing / outside-/workspace / idempotency / /workspace itself)
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI passes
- [ ] Manual: destroy a worker, recreate same name with `--fresh` — should succeed instead of EACCES

## How it surfaced

User's `qwen-3-6-35b` recreate hit:
```
create_worker fresh failed: EACCES, can't rmdir
/home/joey/git/nanoclaw-fleet/data/v2-sessions/ag-.../sess-.../extra/discord
```
Same root ownership pattern would also bite anyone using additional mounts (`~/.config/<x>` → `/workspace/extra/<x>`) on a worker that ever ran, then trying `--fresh` on the recreated name.