### PR TITLE
fix(fleet): tolerate EACCES on legacy sessions in mount precreate

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -172,4 +172,25 @@ describe('precreateNestedMountTargets', () => {
       ),
     ).not.toThrow();
   });
+
+  it('tolerates EACCES on a root-owned parent dir (legacy sessions)', () => {
+    // Simulate a legacy session: <sessDir>/agent exists but is unwritable.
+    // The new precreate must not throw — it should log and continue so the
+    // host doesn't crash on every wake of an old session.
+    const legacyParent = path.join(sessDir, 'agent');
+    fs.mkdirSync(legacyParent, { recursive: true });
+    fs.chmodSync(legacyParent, 0o555); // read+exec, no write
+    try {
+      expect(() =>
+        precreateNestedMountTargets(
+          [{ hostPath: hostSrcDir, containerPath: '/workspace/agent/.claude-fragments', readonly: false }],
+          sessDir,
+        ),
+      ).not.toThrow();
+      // The intermediate dir didn't get the new sub-target — Docker will create it.
+      expect(fs.existsSync(path.join(legacyParent, '.claude-fragments'))).toBe(false);
+    } finally {
+      fs.chmodSync(legacyParent, 0o755); // restore for cleanup
+    }
+  });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -458,7 +458,24 @@ export function precreateNestedMountTargets(mounts: VolumeMount[], sessDir: stri
     if (!hostStat.isDirectory()) continue;
     const rel = mount.containerPath.slice(prefix.length);
     const target = path.join(sessDir, rel);
-    fs.mkdirSync(target, { recursive: true });
+    if (fs.existsSync(target)) continue;
+    // Tolerate EACCES: legacy sessions created before this fix have root-owned
+    // intermediate dirs (e.g. <sessDir>/agent owned by root because Docker
+    // created it). We can't mkdir under them. Log and let Docker handle it
+    // the old way for those sessions — new sessions get the clean path.
+    try {
+      fs.mkdirSync(target, { recursive: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        log.warn('Pre-create mount target denied (legacy root-owned parent?) — Docker will create as root', {
+          target,
+          containerPath: mount.containerPath,
+        });
+        continue;
+      }
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

PR #119's `precreateNestedMountTargets` crashed the host sweep on every wake of a legacy session. Sessions created before #119 have root-owned intermediate dirs (e.g. `<sessDir>/agent/`) because Docker's runc created them in the host namespace. New sub-targets like `agent/.claude-fragments` couldn't be created under those legacy parents, and the unhandled EACCES bubbled up through `sweepSession`.

Caught live: every host sweep tick threw `EACCES: permission denied, mkdir <sessDir>/agent/.claude-fragments`, and the affected workers couldn't be woken at all.

## Fix

- Catch EACCES/EPERM in `precreateNestedMountTargets`, log a warning, and continue. New sessions still get clean ownership; legacy sessions degrade to pre-#119 behavior (Docker creates as root) — same as if the fix wasn't there for them.
- Short-circuit when the target already exists (cheap idempotency).

## Test plan

- [x] `pnpm exec vitest run src/container-runner.test.ts` — 17 passed (1 new test simulating root-owned parent via chmod 0o555).
- [x] `pnpm exec tsc --noEmit` clean.
- [x] Live verification: rebuilt + restarted host with the patch, errors stopped, `worker-misc` woke successfully on next sweep tick.

## Why this didn't catch in CI

The unit test for #119 created fresh temp dirs (always writable). It never simulated an existing root-owned parent because the test runner doesn't have root. The new `tolerates EACCES on a root-owned parent dir` test uses `chmod 0o555` to simulate the unwritable-parent case as joey.